### PR TITLE
FIX: fix wrap null

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/deserialization/converter/DorisRowConverter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/deserialization/converter/DorisRowConverter.java
@@ -115,7 +115,7 @@ public class DorisRowConverter implements Serializable {
 
     protected SerializationConverter wrapIntoNullableExternalConverter(SerializationConverter serializationConverter) {
         return (index, val) -> {
-            if (val == null) {
+            if (val == null || val.isNullAt(index)) {
                 return null;
             } else {
                 return serializationConverter.serialize(index, val);


### PR DESCRIPTION
# Proposed changes

## Problem Summary:
when use wrap, such as Integer, BigInteger appears null, it will be npe.