### PR TITLE
[docs] Fix broken link for doris connector docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Flink Doris Connector now support flink version from 1.11 to 1.14.
 
 If you wish to contribute or use a connector from flink 1.13 (and earlier), please use the [branch-for-flink-before-1.13](https://github.com/apache/doris-flink-connector/tree/branch-for-flink-before-1.13)
 
-More information about compilation and usage, please visit [Flink Doris Connector](https://doris.apache.org/docs/ecosystem/flink-doris-connector.html)
+More information about compilation and usage, please visit [Flink Doris Connector](https://doris.apache.org/docs/ecosystem/flink-doris-connector/)
 
 ## License
 


### PR DESCRIPTION
# Proposed changes

The link to the website is broken. This PR fixes it.

## Problem Summary:

The link to the website is broken. This PR fixes it.
## Checklist(Required)

1. Does it affect the original behavior: ni
2. Has unit tests been added: ni
3. Has document been added or modified: no
4. Does it need to update dependencies: no
5. Are there any changes that cannot be rolled back: no

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
