### PR TITLE
[Fix]add tips for Mac OS users in case meeting getopt error

### DIFF
--- a/flink-doris-connector/build.sh
+++ b/flink-doris-connector/build.sh
@@ -42,6 +42,16 @@ usage() {
   exit 1
 }
 
+# we use GNU enhanced version getopt command here for long option names, rather than the original version.
+# check the version of the getopt command before using.
+getopt -T > /dev/null && echo "
+  The GNU version of getopt command is required.
+  On Mac OS, you can use Homebrew to install gnu-getopt:
+    1. brew install gnu-getopt                  # install gnu-getopt
+    2. GETOPT_PATH=\`brew --prefix gnu-getopt\`   # get the gnu-getopt execute path
+    3. export PATH=\"\${GETOPT_PATH}/bin:\$PATH\"         # set gnu-getopt as default getopt
+" && exit 1
+
 OPTS=$(getopt \
   -n $0 \
   -o '' \


### PR DESCRIPTION
## Problem Summary:

1.add tips for Mac OS users in case meeting getopt error

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
