### PR TITLE
[improve] Schema change does not require db consistency

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/JsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/JsonDebeziumSchemaSerializer.java
@@ -217,10 +217,11 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
             return null;
         }
         String ddl = extractJsonNode(objectMapper.readTree(historyRecord), "ddl");
-        LOG.info("parse ddl:{}", ddl);
+        LOG.debug("received debezium ddl :{}", ddl);
         if (!Objects.isNull(ddl)) {
             //filter add/drop operation
             if (addDropDDLPattern.matcher(ddl).matches()) {
+                LOG.info("parse ddl:{}", ddl);
                 return ddl;
             }
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

At present, in JsonDebeziumSchemaSerializer, the db is obtained from the source data, and the upstream database name must be consistent with the doris database name.
It should be obtained from the doris configuration, so that the database name has nothing to do with upstream database name

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
