### PR TITLE
[Improvement] Update the build.sh with latest version

### DIFF
--- a/flink-doris-connector/build.sh
+++ b/flink-doris-connector/build.sh
@@ -33,10 +33,10 @@ export DORIS_HOME=${ROOT}/../
 usage() {
   echo "
   Usage:
-    $0 --flink version --scala version # specify flink and scala version
-    $0 --tag                           # this is a build from tag
+    $0 --flink version # specify flink version (after flink-doris-connector v1.2 and flink-1.15, there is no need to provide scala version)
+    $0 --tag           # this is a build from tag
   e.g.:
-    $0 --flink 1.15.2 --scala 2.12
+    $0 --flink 1.16.0
     $0 --tag
   "
   exit 1
@@ -57,7 +57,6 @@ OPTS=$(getopt \
   -o '' \
   -o 'h' \
   -l 'flink:' \
-  -l 'scala:' \
   -l 'tag' \
   -- "$@")
 
@@ -76,11 +75,9 @@ fi
 
 BUILD_FROM_TAG=0
 FLINK_VERSION=0
-SCALA_VERSION=0
 while true; do
     case "$1" in
         --flink) FLINK_VERSION=$2 ; shift 2 ;;
-        --scala) SCALA_VERSION=$2 ; shift 2 ;;
         --tag) BUILD_FROM_TAG=1 ; shift ;;
         --) shift ;  break ;;
         *) echo "Internal error" ; exit 1 ;;
@@ -100,7 +97,7 @@ if [[ ${BUILD_FROM_TAG} -eq 1 ]]; then
     ${MVN_BIN} clean package
 else
     rm -rf output/
-    ${MVN_BIN} clean package -Dscala.version=${SCALA_VERSION} -Dflink.version=${FLINK_VERSION} -Dflink.minor.version=${FLINK_MINOR_VERSION}
+    ${MVN_BIN} clean package -Dflink.version=${FLINK_VERSION} -Dflink.minor.version=${FLINK_MINOR_VERSION}
 fi
 
 echo "*****************************************"

--- a/flink-doris-connector/pom.xml
+++ b/flink-doris-connector/pom.xml
@@ -27,7 +27,7 @@ under the License.
     </parent>
     <groupId>org.apache.doris</groupId>
     <artifactId>flink-doris-connector-${flink.minor.version}</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <name>Flink Doris Connector</name>
     <url>https://doris.apache.org/</url>
     <licenses>


### PR DESCRIPTION
# Proposed changes

Issue Number: no issues yet.

## Problem Summary:

Describe the overview of changes.
Since the master branch focus on the latest code, the `pom.xml` file should change the version to `1.3.0-SNAPSHOT` and the related content of `build.sh` should also update to drop the scala version support.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (Yes)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments
