### PR TITLE
[Improvement]Dynamically refresh the BE node from cache

### DIFF
--- a/flink-doris-connector/pom.xml
+++ b/flink-doris-connector/pom.xml
@@ -246,11 +246,11 @@ under the License.
             <artifactId>jackson-databind</artifactId>
             <version>2.13.3</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+        <!-- https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>30.1.1-jre</version>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.1</version>
         </dependency>
         <!--Test-->
         <dependency>

--- a/flink-doris-connector/pom.xml
+++ b/flink-doris-connector/pom.xml
@@ -250,7 +250,7 @@ under the License.
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>3.1.1</version>
+            <version>2.9.3</version>
         </dependency>
         <!--Test-->
         <dependency>

--- a/flink-doris-connector/pom.xml
+++ b/flink-doris-connector/pom.xml
@@ -246,6 +246,12 @@ under the License.
             <artifactId>jackson-databind</artifactId>
             <version>2.13.3</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>30.1.1-jre</version>
+        </dependency>
         <!--Test-->
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -256,7 +262,13 @@ under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.27.0</version>
+            <version>4.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -20,9 +20,9 @@ package org.apache.doris.flink.rest;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.flink.cfg.ConfigurationOptions;
@@ -98,7 +98,7 @@ public class RestService implements Serializable {
     private static LoadingCache<String, List<BackendRowV2>> cache;
 
     public static  void initCache(DorisOptions dorisOptions, DorisReadOptions dorisReadOptions, Logger log) {
-        cache = CacheBuilder.newBuilder()
+        cache = Caffeine.newBuilder()
                 .expireAfterWrite(cacheExpireTimeout, TimeUnit.MINUTES)
                 .build(new CacheLoader<String, List<BackendRowV2>>() {
                     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -93,6 +93,7 @@ public class RestService implements Serializable {
     private static final String BACKENDS = "/rest/v1/system?path=//backends";
     private static final String BACKENDS_V2 = "/api/backends?is_alive=true";
     private static final String FE_LOGIN = "/rest/v1/login";
+    private static final String cacheBackends = "backends";
     private static final long cacheExpireTimeout = 4 * 60;
     private static LoadingCache<String, List<BackendRowV2>> cache;
 
@@ -282,6 +283,17 @@ public class RestService implements Serializable {
     }
 
     /**
+     * get backend in new cache
+     *
+     * @param LOG slf4j logger
+     * @return The BE node in the new cache
+     */
+    public static String getBackendInNewCache(Logger LOG) {
+        cache.invalidate(cacheBackends);
+        return getBackend(LOG);
+    }
+
+    /**
      * choice a Doris BE node from cache.
      *
      * @param LOG slf4j logger
@@ -290,7 +302,7 @@ public class RestService implements Serializable {
     public static String getBackend(Logger LOG) {
         try {
             //get backends from cache
-            List<BackendV2.BackendRowV2> backends = cache.get("backends");
+            List<BackendV2.BackendRowV2> backends = cache.get(cacheBackends);
             LOG.trace("Parse beNodes '{}'.", backends);
             if (backends == null || backends.isEmpty()) {
                 LOG.error(ILLEGAL_ARGUMENT_MESSAGE, "beNodes", backends);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -282,7 +282,7 @@ public class RestService implements Serializable {
     }
 
     /**
-     * choice a Doris BE node to cache.
+     * choice a Doris BE node from cache.
      *
      * @param LOG slf4j logger
      * @return the chosen one Doris BE node

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -299,7 +299,7 @@ public class RestService implements Serializable {
             Collections.shuffle(backends);
             BackendV2.BackendRowV2 backend = backends.get(0);
             String beNode = backend.getIp() + ":" + backend.getHttpPort();
-            LOG.info("get be node from cache. node={}", beNode);
+            LOG.debug("get be node from cache. node={}", beNode);
             return beNode;
         } catch (Exception e) {
             throw new RuntimeException("get backends info fail", e);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
@@ -91,14 +91,14 @@ public class DorisCommitter implements Committer<DorisCommittable> {
                 response = httpClient.execute(putBuilder.build());
             } catch (IOException e) {
                 LOG.error("commit transaction failed: ", e);
-                hostPort = RestService.getBackend(dorisOptions, dorisReadOptions, LOG);
+                hostPort = RestService.getBackend(LOG);
                 continue;
             }
             statusCode = response.getStatusLine().getStatusCode();
             reasonPhrase = response.getStatusLine().getReasonPhrase();
             if (statusCode != 200) {
                 LOG.warn("commit failed with {}, reason {}", hostPort, reasonPhrase);
-                hostPort = RestService.getBackend(dorisOptions, dorisReadOptions, LOG);
+                hostPort = RestService.getBackend(LOG);
             } else {
                 break;
             }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
@@ -91,14 +91,14 @@ public class DorisCommitter implements Committer<DorisCommittable> {
                 response = httpClient.execute(putBuilder.build());
             } catch (IOException e) {
                 LOG.error("commit transaction failed: ", e);
-                hostPort = RestService.getBackend(LOG);
+                hostPort = RestService.getBackendInNewCache(LOG);
                 continue;
             }
             statusCode = response.getStatusLine().getStatusCode();
             reasonPhrase = response.getStatusLine().getReasonPhrase();
             if (statusCode != 200) {
                 LOG.warn("commit failed with {}, reason {}", hostPort, reasonPhrase);
-                hostPort = RestService.getBackend(LOG);
+                hostPort = RestService.getBackendInNewCache(LOG);
             } else {
                 break;
             }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -222,7 +222,7 @@ public class DorisStreamLoad implements Serializable {
 
     /**
      * refresh BE node from cache.
-     * note: requesting a fixed Coordinator BE for a long time, will cause the Coordinator BE to suffer
+     * Note: requesting a fixed Coordinator BE for a long time, will cause the Coordinator BE to suffer
      * a lot of network traffic and scheduling management, which will cause the Coordinator BE in a high load state.
      */
     public void refreshBeNode() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -97,12 +97,12 @@ public class DorisWriter<IN> implements SinkWriter<IN, DorisCommittable, DorisWr
         this.executionOptions = executionOptions;
         this.intervalTime = executionOptions.checkInterval();
         this.loading = false;
+        RestService.initCache(dorisOptions, dorisReadOptions, LOG);
     }
 
     public void initializeLoad(List<DorisWriterState> state) throws IOException {
         try {
             this.dorisStreamLoad = new DorisStreamLoad(
-                    RestService.getBackend(dorisOptions, dorisReadOptions, LOG),
                     dorisOptions,
                     executionOptions,
                     labelGenerator, new HttpUtil().getHttpClient());

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriter.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriter.java
@@ -62,7 +62,8 @@ public class TestDorisWriter {
         CloseableHttpResponse preCommitResponse = HttpTestUtil.getResponse(HttpTestUtil.PRE_COMMIT_RESPONSE, true);
         when(httpClient.execute(any())).thenReturn(preCommitResponse);
 
-        DorisStreamLoad dorisStreamLoad = new DorisStreamLoad("local:8040", dorisOptions, executionOptions, new LabelGenerator("", true), httpClient);
+        DorisStreamLoad dorisStreamLoad = new DorisStreamLoad(dorisOptions, executionOptions, new LabelGenerator("", true), httpClient);
+        dorisStreamLoad.setHostPort("local:8040");
         dorisStreamLoad.startLoad("");
         Sink.InitContext initContext = mock(Sink.InitContext.class);
         when(initContext.getRestoredCheckpointId()).thenReturn(OptionalLong.of(1));
@@ -83,7 +84,8 @@ public class TestDorisWriter {
         CloseableHttpResponse preCommitResponse = HttpTestUtil.getResponse(HttpTestUtil.PRE_COMMIT_RESPONSE, true);
         when(httpClient.execute(any())).thenReturn(preCommitResponse);
 
-        DorisStreamLoad dorisStreamLoad = new DorisStreamLoad("local:8040", dorisOptions, executionOptions, new LabelGenerator("", true), httpClient);
+        DorisStreamLoad dorisStreamLoad = new DorisStreamLoad(dorisOptions, executionOptions, new LabelGenerator("", true), httpClient);
+        dorisStreamLoad.setHostPort("local:8040");
         Sink.InitContext initContext = mock(Sink.InitContext.class);
         when(initContext.getRestoredCheckpointId()).thenReturn(OptionalLong.of(1));
         DorisWriter<String> dorisWriter = new DorisWriter<String>(initContext, Collections.emptyList(), new SimpleStringSerializer(), dorisOptions, readOptions, executionOptions);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
requesting a fixed Coordinator BE for a long time, will cause the Coordinator BE to suffer a lot of network traffic and scheduling management, which will cause the Coordinator BE in a high load state. 

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
