### PR TITLE
[Improvement]dynamic refresh BE node

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -296,11 +296,6 @@ public class RestService implements Serializable {
         }
     }
 
-    /**
-     * dynamic refresh BE node.
-     * Note: requesting a fixed Coordinator BE for a long time, will cause the Coordinator BE to suffer
-     * a lot of network traffic and scheduling management, which will cause the Coordinator BE in a high load state.
-     */
     public static String getAvailableHost() {
         long tmp = pos + backendRows.size();
         while (pos < tmp) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -28,6 +28,7 @@ import org.apache.doris.flink.rest.models.RespContent;
 import org.apache.doris.flink.sink.HttpPutBuilder;
 import org.apache.doris.flink.sink.ResponseUtil;
 
+import org.apache.commons.lang3.StringUtils;
 import static org.apache.doris.flink.sink.LoadStatus.SUCCESS;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.Preconditions;
@@ -119,6 +120,9 @@ public class DorisStreamLoad implements Serializable {
     }
 
     public void setHostPort(String hostPort) {
+        if (StringUtils.isEmpty(hostPort)) {
+            throw new IllegalArgumentException("cannot get host port.");
+        }
         this.hostPort = hostPort;
         this.loadUrlStr = String.format(LOAD_URL_PATTERN, hostPort, this.db, this.table);
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -152,6 +152,7 @@ public class DorisWriter<IN> implements SinkWriter<IN, DorisCommittable, DorisWr
     @Override
     public List<DorisWriterState> snapshotState(long checkpointId) throws IOException {
         Preconditions.checkState(dorisStreamLoad != null);
+        dorisStreamLoad.setHostPort(RestService.getAvailableHost());
         this.dorisStreamLoad.startLoad(labelGenerator.generateLabel(checkpointId + 1));
         this.loading = true;
         return Collections.singletonList(dorisWriterState);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -152,6 +152,7 @@ public class DorisWriter<IN> implements SinkWriter<IN, DorisCommittable, DorisWr
     @Override
     public List<DorisWriterState> snapshotState(long checkpointId) throws IOException {
         Preconditions.checkState(dorisStreamLoad != null);
+        // dynamic refresh BE node
         dorisStreamLoad.setHostPort(RestService.getAvailableHost());
         this.dorisStreamLoad.startLoad(labelGenerator.generateLabel(checkpointId + 1));
         this.loading = true;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
requesting a fixed Coordinator BE for a long time, will cause the Coordinator BE to suffer a lot of network traffic and scheduling management, which will cause the Coordinator BE in a high load state.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
