### PR TITLE
[Improvement] dynamic refresh backend on each once checkpoint

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -252,11 +252,11 @@ public class RestService implements Serializable {
      * @throws IllegalArgumentException fe nodes is illegal
      */
     @VisibleForTesting
-    static List<String> allEndpoints(String feNodes, Logger logger) throws IllegalArgumentException {
+    static List<String> allEndpoints(String feNodes, Logger logger) {
         logger.trace("Parse fenodes '{}'.", feNodes);
         if (StringUtils.isEmpty(feNodes)) {
             logger.error(ILLEGAL_ARGUMENT_MESSAGE, "fenodes", feNodes);
-            throw new IllegalArgumentException("fenodes", feNodes);
+            throw new DorisRuntimeException("fenodes is empty");
         }
         List<String> nodes = Arrays.stream(feNodes.split(",")).map(String::trim).collect(Collectors.toList());
         Collections.shuffle(nodes);
@@ -353,8 +353,7 @@ public class RestService implements Serializable {
      * @return the chosen one Doris BE node
      * @throws IllegalArgumentException BE nodes is illegal
      */
-    @VisibleForTesting
-    static List<BackendV2.BackendRowV2> getBackendsV2(DorisOptions options, DorisReadOptions readOptions, Logger logger) throws DorisException, IOException {
+    public static List<BackendV2.BackendRowV2> getBackendsV2(DorisOptions options, DorisReadOptions readOptions, Logger logger) {
         String feNodes = options.getFenodes();
         List<String> feNodeList = allEndpoints(feNodes, logger);
         for (String feNode: feNodeList) {
@@ -371,10 +370,10 @@ public class RestService implements Serializable {
         }
         String errMsg = "No Doris FE is available, please check configuration";
         logger.error(errMsg);
-        throw new DorisException(errMsg);
+        throw new DorisRuntimeException(errMsg);
     }
 
-    static List<BackendV2.BackendRowV2> parseBackendV2(String response, Logger logger) throws DorisException, IOException {
+    static List<BackendV2.BackendRowV2> parseBackendV2(String response, Logger logger) {
         ObjectMapper mapper = new ObjectMapper();
         BackendV2 backend;
         try {
@@ -382,15 +381,15 @@ public class RestService implements Serializable {
         } catch (JsonParseException e) {
             String errMsg = "Doris BE's response is not a json. res: " + response;
             logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
+            throw new DorisRuntimeException(errMsg, e);
         } catch (JsonMappingException e) {
             String errMsg = "Doris BE's response cannot map to schema. res: " + response;
             logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
+            throw new DorisRuntimeException(errMsg, e);
         } catch (IOException e) {
             String errMsg = "Parse Doris BE's response to json failed. res: " + response;
             logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
+            throw new DorisRuntimeException(errMsg, e);
         }
 
         if (backend == null) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/BackendV2.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/BackendV2.java
@@ -70,5 +70,10 @@ public class BackendV2 {
         public void setAlive(boolean alive) {
             isAlive = alive;
         }
+
+        public String toBackendString(){
+            return ip + ":" + httpPort;
+        }
+
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -27,8 +27,6 @@ import org.apache.doris.flink.exception.StreamLoadException;
 import org.apache.doris.flink.rest.models.RespContent;
 import org.apache.doris.flink.sink.HttpPutBuilder;
 import org.apache.doris.flink.sink.ResponseUtil;
-
-import static org.apache.doris.flink.sink.LoadStatus.SUCCESS;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
@@ -52,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 import static org.apache.doris.flink.sink.LoadStatus.LABEL_ALREADY_EXIST;
+import static org.apache.doris.flink.sink.LoadStatus.SUCCESS;
 import static org.apache.doris.flink.sink.ResponseUtil.LABEL_EXIST_PATTERN;
 import static org.apache.doris.flink.sink.writer.LoadConstants.LINE_DELIMITER_DEFAULT;
 import static org.apache.doris.flink.sink.writer.LoadConstants.LINE_DELIMITER_KEY;
@@ -230,7 +229,7 @@ public class DorisStreamLoad implements Serializable {
         loadBatchFirstRecord = true;
         HttpPutBuilder putBuilder = new HttpPutBuilder();
         recordStream.startInput();
-        LOG.info("stream load started for {}", label);
+        LOG.info("stream load started for {} on host {}", label, hostPort);
         try {
             InputStreamEntity entity = new InputStreamEntity(recordStream);
             putBuilder.setUrl(loadUrlStr)

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriter.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriter.java
@@ -17,14 +17,14 @@
 
 package org.apache.doris.flink.sink.writer;
 
-import org.apache.flink.api.connector.sink.Sink;
-
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.rest.models.BackendV2;
 import org.apache.doris.flink.sink.DorisCommittable;
 import org.apache.doris.flink.sink.HttpTestUtil;
 import org.apache.doris.flink.sink.OptionUtils;
+import org.apache.flink.api.connector.sink.Sink;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Assert;
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.OptionalLong;
@@ -94,4 +95,36 @@ public class TestDorisWriter {
         Assert.assertEquals("doris", writerStates.get(0).getLabelPrefix());
         Assert.assertTrue(dorisWriter.isLoading());
     }
+
+    @Test
+    public void testGetAvailableBackend() throws Exception{
+        Sink.InitContext initContext = mock(Sink.InitContext.class);
+        DorisWriter<String> dorisWriter = new DorisWriter<String>(initContext, Collections.emptyList(), new SimpleStringSerializer(), dorisOptions, readOptions, executionOptions);
+        List<BackendV2.BackendRowV2> backends = Arrays.asList(
+                newBackend("127.0.0.1", 8040),
+                newBackend("127.0.0.2", 8040),
+                newBackend("127.0.0.3", 8040));
+        dorisWriter.setBackends(backends);
+        Assert.assertEquals(backends.get(0).toBackendString(), dorisWriter.getAvailableBackend());
+        Assert.assertEquals(backends.get(1).toBackendString(), dorisWriter.getAvailableBackend());
+        Assert.assertEquals(backends.get(2).toBackendString(), dorisWriter.getAvailableBackend());
+        Assert.assertEquals(backends.get(0).toBackendString(), dorisWriter.getAvailableBackend());
+    }
+
+    @Test
+    public void testTryHttpConnection(){
+        Sink.InitContext initContext = mock(Sink.InitContext.class);
+        DorisWriter<String> dorisWriter = new DorisWriter<String>(initContext, Collections.emptyList(), new SimpleStringSerializer(), dorisOptions, readOptions, executionOptions);
+        boolean flag = dorisWriter.tryHttpConnection("43.142.11.232:8040");
+        System.out.println(flag);
+    }
+
+    private BackendV2.BackendRowV2 newBackend(String host, int port){
+        BackendV2.BackendRowV2 backend = new BackendV2.BackendRowV2();
+        backend.setIp(host);
+        backend.setHttpPort(port);
+        return backend;
+    }
+
+
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriter.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriter.java
@@ -115,8 +115,8 @@ public class TestDorisWriter {
     public void testTryHttpConnection(){
         Sink.InitContext initContext = mock(Sink.InitContext.class);
         DorisWriter<String> dorisWriter = new DorisWriter<String>(initContext, Collections.emptyList(), new SimpleStringSerializer(), dorisOptions, readOptions, executionOptions);
-        boolean flag = dorisWriter.tryHttpConnection("43.142.11.232:8040");
-        System.out.println(flag);
+        boolean flag = dorisWriter.tryHttpConnection("127.0.0.1:8040");
+        Assert.assertFalse(flag);
     }
 
     private BackendV2.BackendRowV2 newBackend(String host, int port){


### PR DESCRIPTION
## Problem Summary:

The current implementation is to always send a StreamLoad request to a coordinator BE, which may cause a certain BE to be overloaded.
Improvement: re-rotate every time Checkpoint selects the available be to initiate a streamload request

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
