### PR TITLE
[lookup](cache)fix lookup join when cache open

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisRowDataAsyncLookupFunction.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisRowDataAsyncLookupFunction.java
@@ -87,8 +87,8 @@ public class DorisRowDataAsyncLookupFunction extends AsyncTableFunction<RowData>
             List<RowData> cachedRows = cache.getIfPresent(keyRow);
             if (cachedRows != null) {
                 future.complete(cachedRows);
+                return;
             }
-            return;
         }
         CompletableFuture<List<RowData>> resultFuture = lookupReader.asyncGet(keyRow);
         resultFuture.handleAsync(


### PR DESCRIPTION
## Problem Summary:

when cache open and lookup join is failed

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
