### PR TITLE
support flink catalog create table

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalogFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalogFactory.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.doris.flink.catalog;
 
+import org.apache.doris.flink.cfg.DorisConnectionOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.catalog.Catalog;
@@ -26,7 +27,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.doris.flink.catalog.DorisCatalogOptions.DEFAULT_DATABASE;
-import static org.apache.doris.flink.catalog.DorisCatalogOptions.JDBCURL;
+import static org.apache.doris.flink.table.DorisConfigOptions.JDBC_URL;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_BATCH_SIZE;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_ARROW_ASYNC;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_QUEUE_SIZE;
@@ -67,7 +68,7 @@ public class DorisCatalogFactory implements CatalogFactory {
     @Override
     public Set<ConfigOption<?>> requiredOptions() {
         final Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(JDBCURL);
+        options.add(JDBC_URL);
         options.add(USERNAME);
         options.add(PASSWORD);
         return options;
@@ -76,7 +77,7 @@ public class DorisCatalogFactory implements CatalogFactory {
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
         final Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(JDBCURL);
+        options.add(JDBC_URL);
         options.add(DEFAULT_DATABASE);
 
         options.add(FENODES);
@@ -115,12 +116,17 @@ public class DorisCatalogFactory implements CatalogFactory {
                 FactoryUtil.createCatalogFactoryHelper(this, context);
         helper.validateExcept(STREAM_LOAD_PROP_PREFIX);
 
+        DorisConnectionOptions connectionOptions =
+                new DorisConnectionOptions.DorisConnectionOptionsBuilder()
+                        .withFenodes(helper.getOptions().get(FENODES))
+                        .withJdbcUrl(helper.getOptions().get(JDBC_URL))
+                        .withUsername(helper.getOptions().get(USERNAME))
+                        .withPassword(helper.getOptions().get(PASSWORD))
+                        .build();
         return new DorisCatalog(
                 context.getName(),
-                helper.getOptions().get(JDBCURL),
+                connectionOptions,
                 helper.getOptions().get(DEFAULT_DATABASE),
-                helper.getOptions().get(USERNAME),
-                helper.getOptions().get(PASSWORD),
                 ((Configuration) helper.getOptions()).toMap());
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalogOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalogOptions.java
@@ -20,7 +20,23 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.table.catalog.CommonCatalogOptions;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class DorisCatalogOptions {
-    public static final ConfigOption<String> JDBCURL = ConfigOptions.key("jdbc-url").stringType().noDefaultValue().withDescription("doris jdbc url.");
     public static final ConfigOption<String> DEFAULT_DATABASE = ConfigOptions.key(CommonCatalogOptions.DEFAULT_DATABASE_KEY).stringType().noDefaultValue();
+
+    public static final String TABLE_PROPERTIES_PREFIX = "table.properties.";
+
+    public static Map<String, String> getCreateTableProps(Map<String, String> tableOptions) {
+        final Map<String, String> tableProps = new HashMap<>();
+
+        for (Map.Entry<String, String> entry : tableOptions.entrySet()) {
+            if (entry.getKey().startsWith(TABLE_PROPERTIES_PREFIX)) {
+                String subKey = entry.getKey().substring(TABLE_PROPERTIES_PREFIX.length());
+                tableProps.put(subKey, entry.getValue());
+            }
+        }
+        return tableProps;
+    }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisTypeMapper.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisTypeMapper.java
@@ -16,83 +16,87 @@
 // under the License.
 package org.apache.doris.flink.catalog;
 
+import org.apache.doris.flink.catalog.doris.DorisType;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
+
+import static org.apache.doris.flink.catalog.doris.DorisType.BIGINT;
+import static org.apache.doris.flink.catalog.doris.DorisType.BOOLEAN;
+import static org.apache.doris.flink.catalog.doris.DorisType.CHAR;
+import static org.apache.doris.flink.catalog.doris.DorisType.DATE;
+import static org.apache.doris.flink.catalog.doris.DorisType.DATETIME;
+import static org.apache.doris.flink.catalog.doris.DorisType.DATETIME_V2;
+import static org.apache.doris.flink.catalog.doris.DorisType.DATE_V2;
+import static org.apache.doris.flink.catalog.doris.DorisType.DECIMAL;
+import static org.apache.doris.flink.catalog.doris.DorisType.DECIMAL_V3;
+import static org.apache.doris.flink.catalog.doris.DorisType.DOUBLE;
+import static org.apache.doris.flink.catalog.doris.DorisType.FLOAT;
+import static org.apache.doris.flink.catalog.doris.DorisType.INT;
+import static org.apache.doris.flink.catalog.doris.DorisType.JSONB;
+import static org.apache.doris.flink.catalog.doris.DorisType.LARGEINT;
+import static org.apache.doris.flink.catalog.doris.DorisType.SMALLINT;
+import static org.apache.doris.flink.catalog.doris.DorisType.STRING;
+import static org.apache.doris.flink.catalog.doris.DorisType.TINYINT;
+import static org.apache.doris.flink.catalog.doris.DorisType.VARCHAR;
 
 public class DorisTypeMapper {
-
-    // -------------------------number----------------------------
-    private static final String DORIS_TINYINT = "TINYINT";
-    private static final String DORIS_SMALLINT = "SMALLINT";
-    private static final String DORIS_INT = "INT";
-    private static final String DORIS_BIGINT = "BIGINT";
-    private static final String DORIS_LARGEINT = "BIGINT UNSIGNED";
-    private static final String DORIS_DECIMAL = "DECIMAL";
-    private static final String DORIS_DECIMALV2 = "DECIMALV2";
-    private static final String DORIS_DECIMAL32 = "DECIMAL32";
-    private static final String DORIS_DECIMAL64 = "DECIMAL64";
-    private static final String DORIS_DECIMAL128I = "DECIMAL128I";
-    private static final String DORIS_FLOAT = "FLOAT";
-    private static final String DORIS_DOUBLE = "DOUBLE";
-
-    // -------------------------string----------------------------
-    private static final String DORIS_CHAR = "CHAR";
-    private static final String DORIS_VARCHAR = "VARCHAR";
-    private static final String DORIS_STRING = "STRING";
-    private static final String DORIS_TEXT = "TEXT";
-    private static final String DORIS_JSONB = "JSONB";
-
-    // ------------------------------time-------------------------
-    private static final String DORIS_DATE = "DATE";
-    private static final String DORIS_DATEV2 = "DATEV2";
-    private static final String DORIS_DATETIME = "DATETIME";
-    private static final String DORIS_DATETIMEV2 = "DATETIMEV2";
-
-    //------------------------------bool------------------------
-    private static final String DORIS_BOOLEAN = "BOOLEAN";
-
 
     public static DataType toFlinkType(String columnName, String columnType, int precision, int scale) {
         columnType = columnType.toUpperCase();
         switch (columnType) {
-            case DORIS_BOOLEAN:
+            case BOOLEAN:
                 return DataTypes.BOOLEAN();
-            case DORIS_TINYINT:
+            case TINYINT:
                 if (precision == 0) {
                     //The boolean type will become tinyint when queried in information_schema, and precision=0
                     return DataTypes.BOOLEAN();
                 } else {
                     return DataTypes.TINYINT();
                 }
-            case DORIS_SMALLINT:
+            case SMALLINT:
                 return DataTypes.SMALLINT();
-            case DORIS_INT:
+            case INT:
                 return DataTypes.INT();
-            case DORIS_BIGINT:
+            case BIGINT:
                 return DataTypes.BIGINT();
-            case DORIS_DECIMAL:
-            case DORIS_DECIMALV2:
-            case DORIS_DECIMAL32:
-            case DORIS_DECIMAL64:
-            case DORIS_DECIMAL128I:
+            case DECIMAL:
+            case DECIMAL_V3:
                 return DataTypes.DECIMAL(precision, scale);
-            case DORIS_FLOAT:
+            case FLOAT:
                 return DataTypes.FLOAT();
-            case DORIS_DOUBLE:
+            case DOUBLE:
                 return DataTypes.DOUBLE();
-            case DORIS_CHAR:
+            case CHAR:
                 return DataTypes.CHAR(precision);
-            case DORIS_LARGEINT:
-            case DORIS_VARCHAR:
-            case DORIS_STRING:
-            case DORIS_TEXT:
-            case DORIS_JSONB:
+            case VARCHAR:
+                return DataTypes.VARCHAR(precision);
+            case LARGEINT:
+            case STRING:
+            case JSONB:
                 return DataTypes.STRING();
-            case DORIS_DATE:
-            case DORIS_DATEV2:
+            case DATE:
+            case DATE_V2:
                 return DataTypes.DATE();
-            case DORIS_DATETIME:
-            case DORIS_DATETIMEV2:
+            case DATETIME:
+            case DATETIME_V2:
                 return DataTypes.TIMESTAMP(0);
             default:
                 throw new UnsupportedOperationException(
@@ -100,4 +104,112 @@ public class DorisTypeMapper {
                                 "Doesn't support Doris type '%s' on column '%s'", columnType, columnName));
         }
     }
+
+    public static String toDorisType(DataType flinkType){
+        LogicalType logicalType = flinkType.getLogicalType();
+        return logicalType.accept(new LogicalTypeVisitor(logicalType));
+    }
+
+    private static class LogicalTypeVisitor extends LogicalTypeDefaultVisitor<String> {
+        private final LogicalType type;
+
+        LogicalTypeVisitor(LogicalType type) {
+            this.type = type;
+        }
+
+        @Override
+        public String visit(CharType charType) {
+            return String.format("%s(%s)", DorisType.CHAR, charType.getLength());
+        }
+
+        @Override
+        public String visit(VarCharType varCharType) {
+            int length = varCharType.getLength();
+            return length > 65533 ? STRING : String.format("%s(%s)", VARCHAR, length);
+        }
+
+        @Override
+        public String visit(BooleanType booleanType) {
+            return BOOLEAN;
+        }
+
+        @Override
+        public String visit(VarBinaryType varBinaryType) {
+            return STRING;
+        }
+
+        @Override
+        public String  visit(DecimalType decimalType) {
+            int precision = decimalType.getPrecision();
+            int scale = decimalType.getScale();
+            return precision <= 38
+                    ? String.format("%s(%s,%s)", DorisType.DECIMAL_V3, precision, scale >= 0 ? scale : 0)
+                    : DorisType.STRING;
+        }
+
+        @Override
+        public String visit(TinyIntType tinyIntType) {
+            return TINYINT;
+        }
+
+        @Override
+        public String visit(SmallIntType smallIntType) {
+            return SMALLINT;
+        }
+
+        @Override
+        public String visit(IntType intType) {
+            return INT;
+        }
+
+        @Override
+        public String visit(BigIntType bigIntType) {
+            return BIGINT;
+        }
+
+        @Override
+        public String visit(FloatType floatType) {
+            return FLOAT;
+        }
+
+        @Override
+        public String visit(DoubleType doubleType) {
+            return DOUBLE;
+        }
+
+        @Override
+        public String visit(DateType dateType) {
+            return DATE_V2;
+        }
+
+        @Override
+        public String visit(TimestampType timestampType) {
+            int precision = timestampType.getPrecision();
+            return String.format("%s(%s)", DorisType.DATETIME_V2, Math.min(Math.max(precision, 0), 6));
+        }
+
+        @Override
+        public String visit(ArrayType arrayType) {
+            return STRING;
+        }
+
+        @Override
+        public String visit(MapType mapType) {
+            return STRING;
+        }
+
+        @Override
+        public String visit(RowType rowType) {
+            return STRING;
+        }
+
+        @Override
+        protected String defaultMethod(LogicalType logicalType) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Flink doesn't support converting type %s to Doris type yet.",
+                            type.toString()));
+        }
+    }
+
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/DorisSystemException.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/DorisSystemException.java
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.exception;
+
+/**
+ * Doris System run exception.
+ */
+public class DorisSystemException extends RuntimeException {
+    public DorisSystemException() {
+        super();
+    }
+
+    public DorisSystemException(String message) {
+        super(message);
+    }
+
+    public DorisSystemException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DorisSystemException(Throwable cause) {
+        super(cause);
+    }
+
+    protected DorisSystemException(String message, Throwable cause,
+                                   boolean enableSuppression,
+                                   boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}


### PR DESCRIPTION
## Problem Summary:
In FlinkCatalog, methods such as create table and create database are supported.
The current table defaults to the UNIQ model, the primary key is the key of the doris table and the bucket key, and the bucket is auto

```
CREATE CATALOG doris_catalog WITH(
> 'type' = 'doris',
> 'default-database' = 'db5',
> 'username' = 'root',
> 'password' = '',
> 'fenodes' = 'xxxx:8234',
> 'jdbc-url' = 'jdbc:mysql://xxx:9234',
> 'sink.label-prefix' = 'labelxxx'
> )
[INFO] Execute statement succeed.

Flink SQL> use catalog doris_catalog;
[INFO] Execute statement succeed.

Flink SQL> CREATE TABLE `doris_catalog`.`db5`.`t_all_types` (
>   `id` VARCHAR(16),
>   `c_boolean` BOOLEAN,
>   `c_char` CHAR(1),
>   `c_date` DATE,
>   `c_datetime` TIMESTAMP(0),
>   `c_decimal` DECIMAL(10, 2),
>   `c_double` DOUBLE,
>   `c_float` FLOAT,
>   `c_int` INT,
>   `c_bigint` BIGINT,
>   `c_largeint` STRING,
>   `c_smallint` SMALLINT,
>   `c_string` STRING,
>   `c_tinyint` TINYINT,
>   primary key(id) NOT ENFORCED
> ) WITH (
>   'password' = '',
>   'connector' = 'doris',
>   'fenodes' = 'xxx:8234',
>   'table.identifier' = 'db5.t_all_types',
>   'sink.label-prefix' = 'label_test_t_all_types',
>   'username' = 'root',
>   'table.properties.replication_num' = '1'
> );
[INFO] Execute statement succeed.


Flink SQL> create database dbtest;
[INFO] Execute statement succeed.

```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
