### PR TITLE
[Improve](mysqlSync)Add the configuration of whether to synchronize the default value

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/deserialization/DorisJsonDebeziumDeserializationSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/deserialization/DorisJsonDebeziumDeserializationSchema.java
@@ -34,6 +34,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.util.Collector;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -77,8 +78,10 @@ public class DorisJsonDebeziumDeserializationSchema implements DebeziumDeseriali
             final Schema.Type schemaType;
             if (schema == null) {
                 schemaType = ConnectSchema.schemaType(value.getClass());
-                if (schemaType == null)
-                    throw new DorisException("Java class " + value.getClass() + " does not have corresponding schema type.");
+                if (schemaType == null) {
+                    throw new DorisException(
+                            "Java class " + value.getClass() + " does not have corresponding schema type.");
+                }
             } else {
                 schemaType = schema.type();
             }
@@ -105,6 +108,8 @@ public class DorisJsonDebeziumDeserializationSchema implements DebeziumDeseriali
                         return JSON_NODE_FACTORY.binaryNode((byte[]) value);
                     } else if (value instanceof ByteBuffer) {
                         return JSON_NODE_FACTORY.binaryNode(((ByteBuffer) value).array());
+                    } else if (value instanceof BigDecimal) {
+                        return JSON_NODE_FACTORY.numberNode((BigDecimal) value);
                     } else {
                         throw new DorisException("Invalid type for bytes type: " + value.getClass());
                     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/deserialization/DorisJsonDebeziumDeserializationSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/deserialization/DorisJsonDebeziumDeserializationSchema.java
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.deserialization;
+
+import org.apache.doris.flink.exception.DorisException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.ververica.cdc.connectors.shaded.org.apache.kafka.connect.data.ConnectSchema;
+import com.ververica.cdc.connectors.shaded.org.apache.kafka.connect.data.Field;
+import com.ververica.cdc.connectors.shaded.org.apache.kafka.connect.data.Schema;
+import com.ververica.cdc.connectors.shaded.org.apache.kafka.connect.data.Struct;
+import com.ververica.cdc.connectors.shaded.org.apache.kafka.connect.source.SourceRecord;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Currently just use for synchronous mysql non-default.
+ */
+public class DorisJsonDebeziumDeserializationSchema implements DebeziumDeserializationSchema<String> {
+
+    private static final JsonNodeFactory JSON_NODE_FACTORY = JsonNodeFactory.withExactBigDecimals(true);
+    private final ObjectMapper objectMapper;
+
+    public DorisJsonDebeziumDeserializationSchema() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public void deserialize(SourceRecord sourceRecord, Collector<String> collector) throws Exception {
+        Schema schema = sourceRecord.valueSchema();
+        Object value = sourceRecord.value();
+        JsonNode jsonValue = convertToJson(schema, value);
+        byte[] bytes = objectMapper.writeValueAsString(jsonValue).getBytes(StandardCharsets.UTF_8);
+        collector.collect(new String(bytes));
+    }
+
+    private JsonNode convertToJson(Schema schema, Object value) throws DorisException {
+        if (value == null) {
+            if (schema == null) // Any schema is valid and we don't have a default, so treat this as an optional schema
+            {
+                return null;
+            }
+            if (schema.isOptional()) {
+                return JSON_NODE_FACTORY.nullNode();
+            }
+            throw new DorisException(
+                    "Conversion error: null value for field that is required and has no default value");
+        }
+
+        try {
+            final Schema.Type schemaType;
+            if (schema == null) {
+                schemaType = ConnectSchema.schemaType(value.getClass());
+                if (schemaType == null)
+                    throw new DorisException("Java class " + value.getClass() + " does not have corresponding schema type.");
+            } else {
+                schemaType = schema.type();
+            }
+            switch (schemaType) {
+                case INT8:
+                    return JSON_NODE_FACTORY.numberNode((Byte) value);
+                case INT16:
+                    return JSON_NODE_FACTORY.numberNode((Short) value);
+                case INT32:
+                    return JSON_NODE_FACTORY.numberNode((Integer) value);
+                case INT64:
+                    return JSON_NODE_FACTORY.numberNode((Long) value);
+                case FLOAT32:
+                    return JSON_NODE_FACTORY.numberNode((Float) value);
+                case FLOAT64:
+                    return JSON_NODE_FACTORY.numberNode((Double) value);
+                case BOOLEAN:
+                    return JSON_NODE_FACTORY.booleanNode((Boolean) value);
+                case STRING:
+                    CharSequence charSeq = (CharSequence) value;
+                    return JSON_NODE_FACTORY.textNode(charSeq.toString());
+                case BYTES:
+                    if (value instanceof byte[]) {
+                        return JSON_NODE_FACTORY.binaryNode((byte[]) value);
+                    } else if (value instanceof ByteBuffer) {
+                        return JSON_NODE_FACTORY.binaryNode(((ByteBuffer) value).array());
+                    } else {
+                        throw new DorisException("Invalid type for bytes type: " + value.getClass());
+                    }
+                case ARRAY: {
+                    Collection<?> collection = (Collection<?>) value;
+                    ArrayNode list = JSON_NODE_FACTORY.arrayNode();
+                    for (Object elem : collection) {
+                        Schema valueSchema = schema == null ? null : schema.valueSchema();
+                        JsonNode fieldValue = convertToJson(valueSchema, elem);
+                        list.add(fieldValue);
+                    }
+                    return list;
+                }
+                case MAP: {
+                    Map<?, ?> map = (Map<?, ?>) value;
+                    // If true, using string keys and JSON object; if false, using non-string keys and Array-encoding
+                    boolean objectMode;
+                    if (schema == null) {
+                        objectMode = true;
+                        for (Map.Entry<?, ?> entry : map.entrySet()) {
+                            if (!(entry.getKey() instanceof String)) {
+                                objectMode = false;
+                                break;
+                            }
+                        }
+                    } else {
+                        objectMode = schema.keySchema().type() == Schema.Type.STRING;
+                    }
+                    ObjectNode obj = null;
+                    ArrayNode list = null;
+                    if (objectMode) {
+                        obj = JSON_NODE_FACTORY.objectNode();
+                    } else {
+                        list = JSON_NODE_FACTORY.arrayNode();
+                    }
+                    for (Map.Entry<?, ?> entry : map.entrySet()) {
+                        Schema keySchema = schema == null ? null : schema.keySchema();
+                        Schema valueSchema = schema == null ? null : schema.valueSchema();
+                        JsonNode mapKey = convertToJson(keySchema, entry.getKey());
+                        JsonNode mapValue = convertToJson(valueSchema, entry.getValue());
+
+                        if (objectMode) {
+                            obj.set(mapKey.asText(), mapValue);
+                        } else {
+                            list.add(JSON_NODE_FACTORY.arrayNode().add(mapKey).add(mapValue));
+                        }
+                    }
+                    return objectMode ? obj : list;
+                }
+                case STRUCT: {
+                    Struct struct = (Struct) value;
+                    if (!struct.schema().equals(schema)) {
+                        throw new DorisException("Mismatching schema.");
+                    }
+                    ObjectNode obj = JSON_NODE_FACTORY.objectNode();
+                    for (Field field : schema.fields()) {
+                        obj.set(field.name(), convertToJson(field.schema(), struct.getWithoutDefault(field.name())));
+                    }
+                    return obj;
+                }
+            }
+            throw new DorisException("Couldn't convert " + value + " to JSON.");
+        } catch (ClassCastException e) {
+            String schemaTypeStr = (schema != null) ? schema.type().toString() : "unknown schema";
+            throw new DorisException("Invalid type for " + schemaTypeStr + ": " + value.getClass());
+        }
+    }
+
+    @Override
+    public TypeInformation<String> getProducedType() {
+        return BasicTypeInfo.STRING_TYPE_INFO;
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/JsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/JsonDebeziumSchemaSerializer.java
@@ -43,7 +43,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -62,18 +64,19 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
     private static final String OP_DELETE = "d"; // delete
 
     public static final String EXECUTE_DDL = "ALTER TABLE %s %s COLUMN %s %s"; //alter table tbl add cloumn aca int
-    private static final String addDropDDLRegex = "ALTER\\s+TABLE\\s+[^\\s]+\\s+(ADD|DROP)\\s+(COLUMN\\s+)?([^\\s]+)(\\s+([^\\s]+))?.*";
-    private final Pattern addDropDDLPattern;
+    private static final String addDropDDLRegex = "(?i)ALTER\\s+TABLE\\s+[^\\s]+\\s+(ADD|DROP)\\s+(COLUMN\\s+)?([^\\s]+)(\\s+([^\\s]+))?.*";
     private DorisOptions dorisOptions;
     private ObjectMapper objectMapper = new ObjectMapper();
     private String database;
     private String table;
     //table name of the cdc upstream, format is db.tbl
     private String sourceTableName;
+    private String ddlOp;
+    private String ddlColumn;
+    private boolean isDropColumn;
 
     public JsonDebeziumSchemaSerializer(DorisOptions dorisOptions, Pattern pattern, String sourceTableName) {
         this.dorisOptions = dorisOptions;
-        this.addDropDDLPattern = pattern == null ? Pattern.compile(addDropDDLRegex, Pattern.CASE_INSENSITIVE) : pattern;
         String[] tableInfo = dorisOptions.getTableIdentifier().split("\\.");
         this.database = tableInfo[0];
         this.table = tableInfo[1];
@@ -125,7 +128,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
                 LOG.info("ddl can not do schema change:{}", recordRoot);
                 return false;
             }
-            boolean doSchemaChange = checkSchemaChange(ddl);
+            boolean doSchemaChange = checkSchemaChange();
             status = doSchemaChange && execSchemaChange(ddl);
             LOG.info("schema change status:{}", status);
         }catch (Exception ex){
@@ -152,9 +155,9 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         }
     }
 
-    private boolean checkSchemaChange(String ddl) throws IOException, IllegalArgumentException {
+    private boolean checkSchemaChange() throws IOException, IllegalArgumentException {
         String requestUrl = String.format(CHECK_SCHEMA_CHANGE_API, RestService.randomEndpoint(dorisOptions.getFenodes(), LOG), database, table);
-        Map<String,Object> param = buildRequestParam(ddl);
+        Map<String,Object> param = buildRequestParam();
         if(param.size() != 2){
             return false;
         }
@@ -175,15 +178,10 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
      * "columnName" : "column"
      * }
      */
-    protected Map<String, Object> buildRequestParam(String ddl) {
+    protected Map<String, Object> buildRequestParam() {
         Map<String,Object> params = new HashMap<>();
-        Matcher matcher = addDropDDLPattern.matcher(ddl);
-        if(matcher.find()){
-            String op = matcher.group(1);
-            String col = matcher.group(3);
-            params.put("isDropColumn", op.equalsIgnoreCase("DROP"));
-            params.put("columnName", col);
-        }
+        params.put("isDropColumn", this.isDropColumn);
+        params.put("columnName", this.ddlColumn);
         return params;
     }
 
@@ -195,8 +193,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         httpPost.setHeader(HttpHeaders.AUTHORIZATION, authHeader());
         httpPost.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
         httpPost.setEntity(new StringEntity(objectMapper.writeValueAsString(param)));
-        boolean success = handleResponse(httpPost);
-        return success;
+        return handleResponse(httpPost);
     }
 
     protected String extractDatabase(JsonNode record) {
@@ -257,20 +254,62 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         }
         String ddl = extractJsonNode(objectMapper.readTree(historyRecord), "ddl");
         LOG.debug("received debezium ddl :{}", ddl);
-        if (!Objects.isNull(ddl)) {
-            //filter add/drop operation
-            Matcher matcher = addDropDDLPattern.matcher(ddl);
-            if(matcher.find()){
-                String op = matcher.group(1);
-                String col = matcher.group(3);
-                String type = matcher.group(5);
-                type = handleType(type);
-                ddl = String.format(EXECUTE_DDL, dorisOptions.getTableIdentifier(), op, col, type);
-                LOG.info("parse ddl:{}", ddl);
-                return ddl;
+        return parseDDL(ddl);
+    }
+
+    private String parseDDL(String ddl) {
+        // ADD or DROP column
+        if (!Pattern.matches(addDropDDLRegex, ddl)) {
+            return null;
+        }
+        // ADD or DROP multiple columns
+        if (Pattern.matches("([^\"']|\"[^\"]*\"|'[^']*')*,([^\"']|\"[^\"]*\"|'[^']*')*", ddl)) {
+            return null;
+        }
+
+        // Split according to spaces, excluding spaces within single quotes and double quotes
+        List<String> ddlList = Arrays.asList(ddl.split("\\s+(?=(?:[^'\"]*['\"][^'\"]*['\"])*[^'\"]*$)"));
+        String ddlOp = ddlList.get(3);
+        int columnIndex = 5;
+        if (!Pattern.compile("(ADD|DROP)\\s+COLUMN", Pattern.CASE_INSENSITIVE).matcher(ddl).find()) {
+            columnIndex = 4;
+        }
+        this.isDropColumn = ddlOp.equalsIgnoreCase("DROP");
+        this.ddlColumn = ddlList.get(columnIndex);
+        String defaultValue = "";
+        String commentValue = "";
+        String type = "";
+        if (!isDropColumn) {
+            type = handleType(ddlList.get(columnIndex + 1));
+            for (int i = 6; i < ddlList.size() - 1; i++) {
+                if (ddlList.get(i).equalsIgnoreCase("default")) {
+                    defaultValue = handleDefaultValue(type, ddlList.get(i + 1));
+                } else if (ddlList.get(i).equalsIgnoreCase("comment")) {
+                    commentValue = ddlList.get(i + 1);
+                }
             }
         }
-        return null;
+
+        ddl = String.format(EXECUTE_DDL, dorisOptions.getTableIdentifier(), ddlOp, ddlColumn, type);
+        if (!defaultValue.isEmpty()) {
+            ddl = ddl + " default " + defaultValue;
+        }
+        if (!commentValue.isEmpty()) {
+            ddl = ddl + " comment " + commentValue;
+        }
+        LOG.info("parse ddl:{}", ddl);
+        return ddl;
+    }
+
+    /**
+     * Due to historical reasons, doris needs to add quotes to the default value of the new column.
+     */
+    private String handleDefaultValue(String type, String defaultValue) {
+        boolean containsQuotes = Pattern.matches("['\"].*?['\"]", defaultValue);
+        if (containsQuotes || defaultValue.equalsIgnoreCase("current_timestamp")) {
+            return defaultValue;
+        }
+        return "'" + defaultValue + "'";
     }
 
     private String authHeader() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
@@ -57,6 +57,8 @@ public class CdcTools {
         String tableSuffix = params.get("table-suffix");
         String includingTables = params.get("including-tables");
         String excludingTables = params.get("excluding-tables");
+        boolean includeTableDefaultValue =
+                Boolean.parseBoolean(params.get("including-table-default-value", "true"));
 
         Map<String, String> mysqlMap = getConfigMap(params, "mysql-conf");
         Map<String, String> sinkMap = getConfigMap(params, "sink-conf");
@@ -67,7 +69,8 @@ public class CdcTools {
         Configuration sinkConfig = Configuration.fromMap(sinkMap);
 
         DatabaseSync databaseSync = new MysqlDatabaseSync();
-        databaseSync.create(env, database, mysqlConfig, tablePrefix, tableSuffix, includingTables, excludingTables, sinkConfig, tableMap);
+        databaseSync.create(env, database, mysqlConfig, tablePrefix, tableSuffix, includingTables, excludingTables,
+                includeTableDefaultValue, sinkConfig, tableMap);
         databaseSync.build();
 
         if(StringUtils.isNullOrWhitespaceOnly(jobName)){

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
@@ -57,8 +57,8 @@ public class CdcTools {
         String tableSuffix = params.get("table-suffix");
         String includingTables = params.get("including-tables");
         String excludingTables = params.get("excluding-tables");
-        boolean includeTableDefaultValue =
-                Boolean.parseBoolean(params.get("including-table-default-value", "true"));
+        boolean ignoreDefaultValue =
+                Boolean.parseBoolean(params.get("ignore-default-value", "false"));
 
         Map<String, String> mysqlMap = getConfigMap(params, "mysql-conf");
         Map<String, String> sinkMap = getConfigMap(params, "sink-conf");
@@ -70,7 +70,7 @@ public class CdcTools {
 
         DatabaseSync databaseSync = new MysqlDatabaseSync();
         databaseSync.create(env, database, mysqlConfig, tablePrefix, tableSuffix, includingTables, excludingTables,
-                includeTableDefaultValue, sinkConfig, tableMap);
+                ignoreDefaultValue, sinkConfig, tableMap);
         databaseSync.build();
 
         if(StringUtils.isNullOrWhitespaceOnly(jobName)){

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -57,7 +57,7 @@ public abstract class DatabaseSync {
     protected Pattern excludingPattern;
     protected Map<String, String> tableConfig;
     protected Configuration sinkConfig;
-    protected boolean includeTableDefaultValue;
+    protected boolean ignoreDefaultValue;
     public StreamExecutionEnvironment env;
 
     public abstract Connection getConnection() throws SQLException;
@@ -69,7 +69,7 @@ public abstract class DatabaseSync {
 
     public void create(StreamExecutionEnvironment env, String database, Configuration config,
                        String tablePrefix, String tableSuffix, String includingTables,
-                       String excludingTables, boolean includeTableDefaultValue,
+                       String excludingTables, boolean ignoreDefaultValue,
             Configuration sinkConfig, Map<String, String> tableConfig) {
         this.env = env;
         this.config = config;
@@ -77,7 +77,7 @@ public abstract class DatabaseSync {
         this.converter = new TableNameConverter(tablePrefix, tableSuffix);
         this.includingPattern = includingTables == null ? null : Pattern.compile(includingTables);
         this.excludingPattern = excludingTables == null ? null : Pattern.compile(excludingTables);
-        this.includeTableDefaultValue = includeTableDefaultValue;
+        this.ignoreDefaultValue = ignoreDefaultValue;
         this.sinkConfig = sinkConfig;
         this.tableConfig = tableConfig == null ? new HashMap<>() : tableConfig;
         //default enable light schema change

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -57,6 +57,7 @@ public abstract class DatabaseSync {
     protected Pattern excludingPattern;
     protected Map<String, String> tableConfig;
     protected Configuration sinkConfig;
+    protected boolean includeTableDefaultValue;
     public StreamExecutionEnvironment env;
 
     public abstract Connection getConnection() throws SQLException;
@@ -68,13 +69,15 @@ public abstract class DatabaseSync {
 
     public void create(StreamExecutionEnvironment env, String database, Configuration config,
                        String tablePrefix, String tableSuffix, String includingTables,
-                       String excludingTables, Configuration sinkConfig, Map<String, String> tableConfig) {
+                       String excludingTables, boolean includeTableDefaultValue,
+            Configuration sinkConfig, Map<String, String> tableConfig) {
         this.env = env;
         this.config = config;
         this.database = database;
         this.converter = new TableNameConverter(tablePrefix, tableSuffix);
         this.includingPattern = includingTables == null ? null : Pattern.compile(includingTables);
         this.excludingPattern = excludingTables == null ? null : Pattern.compile(excludingTables);
+        this.includeTableDefaultValue = includeTableDefaultValue;
         this.sinkConfig = sinkConfig;
         this.tableConfig = tableConfig == null ? new HashMap<>() : tableConfig;
         //default enable light schema change

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSync.java
@@ -183,12 +183,12 @@ public class MysqlDatabaseSync extends DatabaseSync {
         sourceBuilder.jdbcProperties(jdbcProperties);
         sourceBuilder.debeziumProperties(debeziumProperties);
         DebeziumDeserializationSchema<String> schema;
-        if (includeTableDefaultValue) {
+        if (ignoreDefaultValue) {
+            schema = new DorisJsonDebeziumDeserializationSchema();
+        } else {
             Map<String, Object> customConverterConfigs = new HashMap<>();
             customConverterConfigs.put(JsonConverterConfig.DECIMAL_FORMAT_CONFIG, "numeric");
             schema = new JsonDebeziumDeserializationSchema(false, customConverterConfigs);
-        } else {
-            schema = new DorisJsonDebeziumDeserializationSchema();
         }
         MySqlSource<String> mySqlSource = sourceBuilder.deserializer(schema).includeSchemaChanges(true).build();
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
@@ -64,7 +64,7 @@ public class CdcMysqlSyncDatabaseCase {
 
         String includingTables = "tbl1|tbl2|tbl3";
         String excludingTables = "";
-        boolean includeTableDefaultValue = false;
+        boolean includeTableDefaultValue = true;
         DatabaseSync databaseSync = new MysqlDatabaseSync();
         databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,includeTableDefaultValue,sinkConf,tableConfig);
         databaseSync.build();

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
@@ -64,8 +64,9 @@ public class CdcMysqlSyncDatabaseCase {
 
         String includingTables = "tbl1|tbl2|tbl3";
         String excludingTables = "";
+        boolean includeTableDefaultValue = false;
         DatabaseSync databaseSync = new MysqlDatabaseSync();
-        databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,sinkConf,tableConfig);
+        databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,includeTableDefaultValue,sinkConf,tableConfig);
         databaseSync.build();
         env.execute(String.format("MySQL-Doris Database Sync: %s", database));
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
@@ -64,9 +64,9 @@ public class CdcMysqlSyncDatabaseCase {
 
         String includingTables = "tbl1|tbl2|tbl3";
         String excludingTables = "";
-        boolean includeTableDefaultValue = true;
+        boolean ignoreDefaultValue = false;
         DatabaseSync databaseSync = new MysqlDatabaseSync();
-        databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,includeTableDefaultValue,sinkConf,tableConfig);
+        databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,ignoreDefaultValue,sinkConf,tableConfig);
         databaseSync.build();
         env.execute(String.format("MySQL-Doris Database Sync: %s", database));
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcOraclelSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcOraclelSyncDatabaseCase.java
@@ -70,8 +70,9 @@ public class CdcOraclelSyncDatabaseCase {
 
         String includingTables = "test.*";
         String excludingTables = "";
+        boolean ignoreDefaultValue = false;
         DatabaseSync databaseSync = new OracleDatabaseSync();
-        databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,sinkConf,tableConfig, false);
+        databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,ignoreDefaultValue,sinkConf,tableConfig, false);
         databaseSync.build();
         env.execute(String.format("Oracle-Doris Database Sync: %s", database));
 


### PR DESCRIPTION
# Proposed changes

At present, when the mysql database sync to doris , there is a default value in the field, but the actual data is null, the data cannot maintain consistency.

Like: when mysql schema has a default value and the insertion is ` null `, the data synchronized to doris uses the default value.
```  sql
CREATE TABLE `test_sink` (
  `id` int NOT NULL,
  `name` varchar(50) DEFAULT 'test_default',
  `age` int DEFAULT '10000',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

insert into test_sink (id,name,age) values(6, null, 666);
insert into test_sink (id,name,age) values(5, 'zhaoliu', null);
```

Configure  `--ignore-default-value`, the default value will not be synchronized, otherwise it will be synchronized.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
