### PR TITLE
[Fix] lookup join close executor service

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/connection/SimpleJdbcConnectionProvider.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/connection/SimpleJdbcConnectionProvider.java
@@ -42,7 +42,7 @@ public class SimpleJdbcConnectionProvider implements JdbcConnectionProvider, Ser
 
     @Override
     public Connection getOrEstablishConnection() throws ClassNotFoundException, SQLException {
-        if (connection != null && !connection.isClosed()) {
+        if (connection != null && !connection.isClosed() && connection.isValid(10000)) {
             return connection;
         }
         try {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/DorisJdbcLookupReader.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/DorisJdbcLookupReader.java
@@ -129,4 +129,11 @@ public class DorisJdbcLookupReader extends DorisLookupReader {
             throw new IOException(e);
         }
     }
+
+    @Override
+    public void close() throws IOException {
+        if(this.pool != null){
+            this.pool.close();
+        }
+    }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/DorisLookupReader.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/DorisLookupReader.java
@@ -19,11 +19,12 @@ package org.apache.doris.flink.lookup;
 
 import org.apache.flink.table.data.RowData;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-public abstract class DorisLookupReader {
+public abstract class DorisLookupReader implements Closeable {
 
     public abstract CompletableFuture<List<RowData>> asyncGet(RowData record) throws IOException;
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/ExecutionPool.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/ExecutionPool.java
@@ -103,9 +103,10 @@ public class ExecutionPool implements Closeable {
     @Override
     public void close() throws IOException {
         if (started.compareAndSet(true, false)) {
-            actionWatcherExecutorService.shutdown();
+            LOG.info("close executorService");
+            actionWatcherExecutorService.shutdownNow();
             workerStated.set(false);
-            workerExecutorService.shutdown();
+            workerExecutorService.shutdownNow();
             this.semaphore = null;
         }
     }
@@ -181,6 +182,7 @@ public class ExecutionPool implements Closeable {
                     }
                 }
             }
+            LOG.info("action watcher stop");
         }
 
         @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/ExecutionPool.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/ExecutionPool.java
@@ -107,6 +107,8 @@ public class ExecutionPool implements Closeable {
             actionWatcherExecutorService.shutdownNow();
             workerStated.set(false);
             workerExecutorService.shutdownNow();
+            this.actionWatcherExecutorService = null;
+            this.workerExecutorService = null;
             this.semaphore = null;
         }
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/ExecutionPool.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/ExecutionPool.java
@@ -163,6 +163,7 @@ public class ExecutionPool implements Closeable {
                     if (firstGet != null) {
                         recordList.add(firstGet);
                         queue.drainTo(recordList, batchSize - 1);
+                        LOG.debug("fetch {} records from queue", recordList.size());
                         Map<String, List<Get>> getsByTable = new HashMap<>();
                         for (Get get : recordList) {
                             List<Get> list = getsByTable.computeIfAbsent(get.getRecord().getTableIdentifier(), (s) -> new ArrayList<>());

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
@@ -153,6 +153,7 @@ public class Worker implements Runnable {
         for (int retry = 0; retry <= maxRetryTimes; retry++) {
             resultRecordMap = new HashMap<>();
             try {
+                long start = System.currentTimeMillis();
                 Connection conn = jdbcConnectionProvider.getOrEstablishConnection();
                 try (PreparedStatement ps = conn.prepareStatement(sql)) {
                     int paramIndex = 0;
@@ -174,6 +175,7 @@ public class Worker implements Runnable {
                         }
                     }
                 }
+                LOG.debug("query cost {}ms, batch {} records, sql is {}", System.currentTimeMillis()-start, recordList.size(), sql);
                 return resultRecordMap;
             } catch (Exception e) {
                 LOG.error(String.format("query doris error, retry times = %d", retry), e);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisRowDataAsyncLookupFunction.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisRowDataAsyncLookupFunction.java
@@ -119,6 +119,9 @@ public class DorisRowDataAsyncLookupFunction extends AsyncTableFunction<RowData>
     @Override
     public void close() throws Exception {
         super.close();
+        if(lookupReader != null){
+            lookupReader.close();
+        }
     }
 
     @VisibleForTesting

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisRowDataAsyncLookupFunction.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisRowDataAsyncLookupFunction.java
@@ -68,6 +68,8 @@ public class DorisRowDataAsyncLookupFunction extends AsyncTableFunction<RowData>
     @Override
     public void open(FunctionContext context) throws Exception {
         super.open(context);
+        LOG.info("lookup options: threadSize {}, batchSize {}, queueSize {}",
+                lookupOptions.getJdbcReadThreadSize(), lookupOptions.getJdbcReadBatchSize(), lookupOptions.getJdbcReadBatchQueueSize());
         this.cache = cacheMaxSize == -1 || cacheExpireMs == -1
                 ? null
                 : CacheBuilder.newBuilder()

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisRowDataJdbcLookupFunction.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisRowDataJdbcLookupFunction.java
@@ -111,6 +111,9 @@ public class DorisRowDataJdbcLookupFunction extends TableFunction<RowData> {
     @Override
     public void close() throws Exception {
         super.close();
+        if(lookupReader != null){
+            lookupReader.close();
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## Problem Summary:

When flinkjob or a task is automatically restarted, the thread pool in the previous lookup task is not closed, resulting in a surge in threads

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
