### PR TITLE
[Improve]Optimize method for constructing builder object based on Builder pattern

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -70,6 +70,13 @@ public class DorisExecutionOptions implements Serializable {
         return new Builder();
     }
 
+    public static Builder builderDefaults() {
+        Properties properties = new Properties();
+        properties.setProperty("format", "json");
+        properties.setProperty("read_json_by_line", "true");
+        return new Builder().setStreamLoadProp(properties);
+    }
+    
     public static DorisExecutionOptions defaults() {
         Properties properties = new Properties();
         properties.setProperty("format", "json");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Add a builderDefaults() method which returns Builder in stead of DorisExecutionOptions. 
According to the Builder pattern, this method can not only configure the json format and reading json by line, but also configure other parameters that developers need to set.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
