### PR TITLE
[Improve](schemaChange)schema change ddl supports multi-column changes, synchronous defaults

### DIFF
--- a/flink-doris-connector/pom.xml
+++ b/flink-doris-connector/pom.xml
@@ -245,7 +245,7 @@ under the License.
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-sql-connector-mysql-cdc</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/FieldSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/FieldSchema.java
@@ -19,6 +19,7 @@ package org.apache.doris.flink.catalog.doris;
 public class FieldSchema {
     private String name;
     private String typeString;
+    private String defaultValue;
     private String comment;
 
     public FieldSchema() {
@@ -27,6 +28,13 @@ public class FieldSchema {
     public FieldSchema(String name, String typeString, String comment) {
         this.name = name;
         this.typeString = typeString;
+        this.comment = comment;
+    }
+
+    public FieldSchema(String name, String typeString, String defaultValue, String comment) {
+        this.name = name;
+        this.typeString = typeString;
+        this.defaultValue = defaultValue;
         this.comment = comment;
     }
 
@@ -52,5 +60,13 @@ public class FieldSchema {
 
     public void setComment(String comment) {
         this.comment = comment;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/JsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/JsonDebeziumSchemaSerializer.java
@@ -23,11 +23,18 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
 import org.apache.commons.codec.binary.Base64;
+
+import org.apache.doris.flink.catalog.doris.FieldSchema;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.exception.IllegalArgumentException;
 import org.apache.doris.flink.rest.RestService;
 import org.apache.doris.flink.sink.HttpGetWithEntity;
+import org.apache.doris.flink.sink.writer.SchemaChangeHelper.DDLSchema;
+import org.apache.doris.flink.tools.cdc.mysql.MysqlType;
+
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.StringUtils;
 import org.apache.http.HttpHeaders;
@@ -44,8 +51,11 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,8 +80,12 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
     private String table;
     //table name of the cdc upstream, format is db.tbl
     private String sourceTableName;
+    private boolean firstLoad;
+    private boolean firstSchemaChange;
+    private Map<String, FieldSchema> originFieldSchemaMap;
+    private final boolean newSchemaChange;
 
-    public JsonDebeziumSchemaSerializer(DorisOptions dorisOptions, Pattern pattern, String sourceTableName) {
+    public JsonDebeziumSchemaSerializer(DorisOptions dorisOptions, Pattern pattern, String sourceTableName, boolean newSchemaChange) {
         this.dorisOptions = dorisOptions;
         this.addDropDDLPattern = pattern == null ? Pattern.compile(addDropDDLRegex, Pattern.CASE_INSENSITIVE) : pattern;
         String[] tableInfo = dorisOptions.getTableIdentifier().split("\\.");
@@ -82,6 +96,9 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         this.objectMapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
         JsonNodeFactory jsonNodeFactory = JsonNodeFactory.withExactBigDecimals(true);
         this.objectMapper.setNodeFactory(jsonNodeFactory);
+        this.newSchemaChange = newSchemaChange;
+        this.firstLoad = true;
+        this.firstSchemaChange = true;
     }
 
     @Override
@@ -91,8 +108,16 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         String op = extractJsonNode(recordRoot, "op");
         if (Objects.isNull(op)) {
             //schema change ddl
-            schemaChange(recordRoot);
+            if (newSchemaChange) {
+                schemaChangeV2(recordRoot);
+            } else {
+                schemaChange(recordRoot);
+            }
             return null;
+        }
+
+        if (newSchemaChange && firstLoad) {
+            initOriginFieldSchema(recordRoot);
         }
         Map<String, String> valueMap;
         switch (op) {
@@ -111,6 +136,67 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
                 return null;
         }
         return objectMapper.writeValueAsString(valueMap).getBytes(StandardCharsets.UTF_8);
+    }
+
+    public boolean schemaChangeV2(JsonNode recordRoot) {
+        boolean status = false;
+        try {
+            if (!StringUtils.isNullOrWhitespaceOnly(sourceTableName) && !checkTable(recordRoot)) {
+                return false;
+            }
+            List<String> ddlSqlList = extractDDLList(recordRoot);
+            if (CollectionUtils.isEmpty(ddlSqlList)) {
+                LOG.info("ddl can not do schema change:{}", recordRoot);
+                return false;
+            }
+
+            List<DDLSchema> ddlSchemas = SchemaChangeHelper.getDdlSchemas();
+            for (int i = 0; i < ddlSqlList.size(); i++) {
+                DDLSchema ddlSchema = ddlSchemas.get(i);
+                String ddlSql = ddlSqlList.get(i);
+                boolean doSchemaChange = checkSchemaChange(ddlSchema);
+                status = doSchemaChange && execSchemaChange(ddlSql);
+                LOG.info("schema change status:{}", status);
+            }
+        } catch (Exception ex) {
+            LOG.warn("schema change error :", ex);
+        }
+        return status;
+    }
+
+    private boolean checkSchemaChange(DDLSchema ddlSchema) throws IOException, IllegalArgumentException {
+        String requestUrl = String.format(CHECK_SCHEMA_CHANGE_API, RestService.randomEndpoint(dorisOptions.getFenodes(), LOG), database, table);
+        Map<String,Object> param = buildRequestParam(ddlSchema);
+        HttpGetWithEntity httpGet = new HttpGetWithEntity(requestUrl);
+        httpGet.setHeader(HttpHeaders.AUTHORIZATION, authHeader());
+        httpGet.setEntity(new StringEntity(objectMapper.writeValueAsString(param)));
+        boolean success = handleResponse(httpGet);
+        if (!success) {
+            LOG.warn("schema change can not do table {}.{}",database,table);
+        }
+        return success;
+    }
+
+    private List<String> extractDDLList(JsonNode record) throws JsonProcessingException {
+        JsonNode historyRecord = objectMapper.readTree(extractJsonNode(record, "historyRecord"));
+        JsonNode tableChanges = historyRecord.get("tableChanges");
+        JsonNode tableChange = tableChanges.get(0);
+        if (Objects.isNull(tableChange)|| !tableChange.get("type").asText().equals("ALTER")) {
+            return null;
+        }
+        JsonNode columns = tableChange.get("table").get("columns");
+        if (firstSchemaChange) {
+            fillOriginSchema(columns);
+        }
+        String ddl = extractJsonNode(historyRecord, "ddl");
+        LOG.debug("received debezium ddl :{}", ddl);
+
+        Map<String, FieldSchema> updateFiledSchema = new LinkedHashMap<>();
+        for (JsonNode column : columns) {
+            buildFieldSchema(updateFiledSchema, column);
+        }
+        SchemaChangeHelper.compareSchema(updateFiledSchema, originFieldSchemaMap);
+        return SchemaChangeHelper.generateDDLSql(dorisOptions.getTableIdentifier());
     }
 
     @VisibleForTesting
@@ -166,6 +252,13 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
             LOG.warn("schema change can not do table {}.{}",database,table);
         }
         return success;
+    }
+
+    protected Map<String, Object> buildRequestParam(DDLSchema ddlSchema) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("isDropColumn", ddlSchema.isDropColumn());
+        params.put("columnName", ddlSchema.getColumnName());
+        return params;
     }
 
     /**
@@ -233,7 +326,8 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
     }
 
     private String extractJsonNode(JsonNode record, String key) {
-        return record != null && record.get(key) != null ? record.get(key).asText() : null;
+        return record != null && record.get(key) != null &&
+                !(record.get(key) instanceof NullNode) ? record.get(key).asText() : null;
     }
 
     private Map<String, String> extractBeforeRow(JsonNode record) {
@@ -277,6 +371,68 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         return "Basic " + new String(Base64.encodeBase64((dorisOptions.getUsername() + ":" + dorisOptions.getPassword()).getBytes(StandardCharsets.UTF_8)));
     }
 
+    private void fillOriginSchema(JsonNode columns) {
+        if (Objects.nonNull(originFieldSchemaMap)) {
+            for (JsonNode column : columns) {
+                String fieldName = column.get("name").asText();
+                if (originFieldSchemaMap.containsKey(fieldName)) {
+                    JsonNode length = column.get("length");
+                    JsonNode scale = column.get("scale");
+                    String type = MysqlType.toDorisType(column.get("typeName").asText(),
+                            length == null ? 0 : length.asInt(),
+                            scale == null ? 0 : scale.asInt());
+                    String defaultValue = handleDefaultValue(extractJsonNode(column, "defaultValueExpression"));
+                    String comment = extractJsonNode(column, "comment");
+                    FieldSchema fieldSchema = originFieldSchemaMap.get(fieldName);
+                    fieldSchema.setName(fieldName);
+                    fieldSchema.setTypeString(type);
+                    fieldSchema.setComment(comment);
+                    fieldSchema.setDefaultValue(defaultValue);
+                }
+            }
+        } else {
+            originFieldSchemaMap = new LinkedHashMap<>();
+            columns.forEach(column -> buildFieldSchema(originFieldSchemaMap, column));
+        }
+        firstSchemaChange = false;
+        firstLoad = false;
+    }
+
+    private void buildFieldSchema(Map<String, FieldSchema> filedSchemaMap, JsonNode column) {
+        String fieldName = column.get("name").asText();
+        JsonNode length = column.get("length");
+        JsonNode scale = column.get("scale");
+        String type = MysqlType.toDorisType(column.get("typeName").asText(),
+                length == null ? 0 : length.asInt(), scale == null ? 0 : scale.asInt());
+        String defaultValue = handleDefaultValue(extractJsonNode(column, "defaultValueExpression"));
+        String comment = extractJsonNode(column, "comment");
+        filedSchemaMap.put(fieldName, new FieldSchema(fieldName, type, defaultValue, comment));
+    }
+
+    private String handleDefaultValue(String defaultValue) {
+        if (StringUtils.isNullOrWhitespaceOnly(defaultValue)) {
+            return null;
+        }
+        // Due to historical reasons, doris needs to add quotes to the default value of the new column
+        if (Pattern.matches("['\"].*?['\"]", defaultValue)) {
+            return defaultValue;
+        } else if (defaultValue.equals("1970-01-01 00:00:00")) {
+            // TODO: The default value of setting the current time in CDC is 1970-01-01 00:00:00
+            return "current_timestamp";
+        }
+        return "'" + defaultValue + "'";
+    }
+
+    private void initOriginFieldSchema(JsonNode recordRoot) {
+        originFieldSchemaMap = new LinkedHashMap<>();
+        Set<String> columnNameSet = extractAfterRow(recordRoot).keySet();
+        if (CollectionUtils.isEmpty(columnNameSet)) {
+            columnNameSet = extractBeforeRow(recordRoot).keySet();
+        }
+        columnNameSet.forEach(columnName -> originFieldSchemaMap.put(columnName, new FieldSchema()));
+        firstLoad = false;
+    }
+
     public static JsonDebeziumSchemaSerializer.Builder builder() {
         return new JsonDebeziumSchemaSerializer.Builder();
     }
@@ -288,9 +444,15 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         private DorisOptions dorisOptions;
         private Pattern addDropDDLPattern;
         private String sourceTableName;
+        private boolean newSchemaChange;
 
         public JsonDebeziumSchemaSerializer.Builder setDorisOptions(DorisOptions dorisOptions) {
             this.dorisOptions = dorisOptions;
+            return this;
+        }
+
+        public JsonDebeziumSchemaSerializer.Builder setNewSchemaChange(boolean newSchemaChange) {
+            this.newSchemaChange = newSchemaChange;
             return this;
         }
 
@@ -305,7 +467,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         }
 
         public JsonDebeziumSchemaSerializer build() {
-            return new JsonDebeziumSchemaSerializer(dorisOptions, addDropDDLPattern, sourceTableName);
+            return new JsonDebeziumSchemaSerializer(dorisOptions, addDropDDLPattern, sourceTableName, newSchemaChange);
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/SchemaChangeHelper.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/SchemaChangeHelper.java
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.writer;
+
+import org.apache.doris.flink.catalog.doris.FieldSchema;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.compress.utils.Lists;
+import org.apache.flink.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class SchemaChangeHelper {
+    private static final List<String> dropFieldSchemas = Lists.newArrayList();
+    private static final List<FieldSchema> addFieldSchemas = Lists.newArrayList();
+    // Used to determine whether the doris table supports ddl
+    private static final List<DDLSchema> ddlSchemas = Lists.newArrayList();
+    public static final String ADD_DDL = "ALTER TABLE %s ADD COLUMN %s %s";
+    public static final String DROP_DDL = "ALTER TABLE %s DROP COLUMN %s";
+
+    public static void compareSchema(Map<String, FieldSchema> updateFiledSchemaMap,
+            Map<String, FieldSchema> originFieldSchemaMap) {
+        for (Entry<String, FieldSchema> updateFieldSchema : updateFiledSchemaMap.entrySet()) {
+            String columName = updateFieldSchema.getKey();
+            if (!originFieldSchemaMap.containsKey(columName)) {
+                addFieldSchemas.add(updateFieldSchema.getValue());
+                originFieldSchemaMap.put(columName, updateFieldSchema.getValue());
+            }
+        }
+        for (Entry<String, FieldSchema> originFieldSchema : originFieldSchemaMap.entrySet()) {
+            String columName = originFieldSchema.getKey();
+            if (!updateFiledSchemaMap.containsKey(columName)) {
+                dropFieldSchemas.add(columName);
+            }
+        }
+        if (CollectionUtils.isNotEmpty(dropFieldSchemas)) {
+            dropFieldSchemas.forEach(originFieldSchemaMap::remove);
+        }
+    }
+
+    public static List<String> generateDDLSql(String table) {
+        ddlSchemas.clear();
+        List<String> ddlList = Lists.newArrayList();
+        for (FieldSchema fieldSchema : addFieldSchemas) {
+            String name = fieldSchema.getName();
+            String type = fieldSchema.getTypeString();
+            String defaultValue = fieldSchema.getDefaultValue();
+            String comment = fieldSchema.getComment();
+            String addDDL = String.format(ADD_DDL, table, name, type);
+            if (!StringUtils.isNullOrWhitespaceOnly(defaultValue)) {
+                addDDL = addDDL + " DEFAULT " + defaultValue;
+            }
+            if (!StringUtils.isNullOrWhitespaceOnly(comment)) {
+                addDDL = addDDL + " COMMENT " + comment;
+            }
+            ddlList.add(addDDL);
+            ddlSchemas.add(new DDLSchema(name, false));
+        }
+        for (String columName : dropFieldSchemas) {
+            String dropDDL = String.format(DROP_DDL, table, columName);
+            ddlList.add(dropDDL);
+            ddlSchemas.add(new DDLSchema(columName, true));
+        }
+
+        dropFieldSchemas.clear();
+        addFieldSchemas.clear();
+        return ddlList;
+    }
+
+    public static List<DDLSchema> getDdlSchemas() {
+        return ddlSchemas;
+    }
+
+    static class DDLSchema {
+        private final String columnName;
+        private final boolean isDropColumn;
+
+        public DDLSchema(String columnName, boolean isDropColumn) {
+            this.columnName = columnName;
+            this.isDropColumn = isDropColumn;
+        }
+
+        public String getColumnName() {
+            return columnName;
+        }
+
+        public boolean isDropColumn() {
+            return isDropColumn;
+        }
+    }
+
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
@@ -79,13 +79,14 @@ public class CdcTools {
         String excludingTables = params.get("excluding-tables");
         boolean createTableOnly = params.has("create-table-only");
         boolean ignoreDefaultValue = params.has("ignore-default-value");
+        boolean useNewSchemaChange = params.has("use-new-schema-change");
 
         Map<String, String> sinkMap = getConfigMap(params, "sink-conf");
         Map<String, String> tableMap = getConfigMap(params, "table-conf");
         Configuration sinkConfig = Configuration.fromMap(sinkMap);
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        databaseSync.create(env, database, config, tablePrefix, tableSuffix, includingTables, excludingTables, ignoreDefaultValue, sinkConfig, tableMap, createTableOnly);
+        databaseSync.create(env, database, config, tablePrefix, tableSuffix, includingTables, excludingTables, ignoreDefaultValue, sinkConfig, tableMap, createTableOnly, useNewSchemaChange);
         databaseSync.build();
         if(StringUtils.isNullOrWhitespaceOnly(jobName)){
             jobName = String.format("%s-Doris Sync Database: %s", type, config.getString("database-name","db"));

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -60,6 +60,7 @@ public abstract class DatabaseSync {
     protected boolean ignoreDefaultValue;
     public StreamExecutionEnvironment env;
     private boolean createTableOnly = false;
+    private boolean newSchemaChange;
 
     public abstract Connection getConnection() throws SQLException;
 
@@ -70,7 +71,7 @@ public abstract class DatabaseSync {
     public void create(StreamExecutionEnvironment env, String database, Configuration config,
                        String tablePrefix, String tableSuffix, String includingTables,
                        String excludingTables, boolean ignoreDefaultValue, Configuration sinkConfig,
-            Map<String, String> tableConfig, boolean createTableOnly) {
+            Map<String, String> tableConfig, boolean createTableOnly, boolean useNewSchemaChange) {
         this.env = env;
         this.config = config;
         this.database = database;
@@ -85,6 +86,7 @@ public abstract class DatabaseSync {
             this.tableConfig.put(LIGHT_SCHEMA_CHANGE, "true");
         }
         this.createTableOnly = createTableOnly;
+        this.newSchemaChange = useNewSchemaChange;
     }
 
     public void build() throws Exception {
@@ -185,7 +187,10 @@ public abstract class DatabaseSync {
         }
         builder.setDorisReadOptions(DorisReadOptions.builder().build())
                 .setDorisExecutionOptions(executionBuilder.build())
-                .setSerializer(JsonDebeziumSchemaSerializer.builder().setDorisOptions(dorisBuilder.build()).build())
+                .setSerializer(JsonDebeziumSchemaSerializer.builder()
+                        .setDorisOptions(dorisBuilder.build())
+                        .setNewSchemaChange(newSchemaChange)
+                        .build())
                 .setDorisOptions(dorisBuilder.build());
         return builder.build();
     }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/CDCSchemaChangeExample.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/CDCSchemaChangeExample.java
@@ -78,7 +78,7 @@ public class CDCSchemaChangeExample {
         builder.setDorisReadOptions(DorisReadOptions.builder().build())
                 .setDorisExecutionOptions(executionBuilder.build())
                 .setDorisOptions(dorisOptions)
-                .setSerializer(JsonDebeziumSchemaSerializer.builder().setDorisOptions(dorisOptions).build());
+                .setSerializer(JsonDebeziumSchemaSerializer.builder().setDorisOptions(dorisOptions).setNewSchemaChange(true).build());
 
         env.fromSource(mySqlSource, WatermarkStrategy.noWatermarks(), "MySQL Source")//.print();
                 .sinkTo(builder.build());

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
@@ -65,7 +65,7 @@ public class CdcMysqlSyncDatabaseCase {
         String includingTables = "tbl1|tbl2|tbl3";
         String excludingTables = "";
         boolean ignoreDefaultValue = false;
-        boolean useNewSchemaChange = true;
+        boolean useNewSchemaChange = false;
         DatabaseSync databaseSync = new MysqlDatabaseSync();
         databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,ignoreDefaultValue,sinkConf,tableConfig, false, useNewSchemaChange);
         databaseSync.build();

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
@@ -65,8 +65,9 @@ public class CdcMysqlSyncDatabaseCase {
         String includingTables = "tbl1|tbl2|tbl3";
         String excludingTables = "";
         boolean ignoreDefaultValue = false;
+        boolean useNewSchemaChange = true;
         DatabaseSync databaseSync = new MysqlDatabaseSync();
-        databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,ignoreDefaultValue,sinkConf,tableConfig, false);
+        databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,ignoreDefaultValue,sinkConf,tableConfig, false, useNewSchemaChange);
         databaseSync.build();
         env.execute(String.format("MySQL-Doris Database Sync: %s", database));
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcOraclelSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcOraclelSyncDatabaseCase.java
@@ -71,8 +71,9 @@ public class CdcOraclelSyncDatabaseCase {
         String includingTables = "test.*";
         String excludingTables = "";
         boolean ignoreDefaultValue = false;
+        boolean useNewSchemaChange = false;
         DatabaseSync databaseSync = new OracleDatabaseSync();
-        databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,ignoreDefaultValue,sinkConf,tableConfig, false);
+        databaseSync.create(env,database,config,tablePrefix,tableSuffix,includingTables,excludingTables,ignoreDefaultValue,sinkConf,tableConfig, false, useNewSchemaChange);
         databaseSync.build();
         env.execute(String.format("Oracle-Doris Database Sync: %s", database));
 


### PR DESCRIPTION
# Proposed changes

The old schema change need to use regular expressions to match, resulting in comparison limitations.

The new schema change:
1. supports multi-column changes
2. support for synchronous defaults.

MySQL multi-table import enables new schema change only by configuring `--use-new-schema-change`, oracle does not currently support


## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
