### PR TITLE
[Improve]add sink.ignore-update-before

### DIFF
--- a/flink-doris-connector/pom.xml
+++ b/flink-doris-connector/pom.xml
@@ -251,7 +251,7 @@ under the License.
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-sql-connector-oracle-cdc</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -50,11 +50,12 @@ public class DorisExecutionOptions implements Serializable {
     private final Boolean enable2PC;
 
     //batch mode param
-    private int flushQueueSize;
-    private int bufferFlushMaxRows;
-    private int bufferFlushMaxBytes;
-    private long bufferFlushIntervalMs;
-    private boolean enableBatchMode;
+    private final int flushQueueSize;
+    private final int bufferFlushMaxRows;
+    private final int bufferFlushMaxBytes;
+    private final long bufferFlushIntervalMs;
+    private final boolean enableBatchMode;
+    private final boolean ignoreUpdateBefore;
 
     public DorisExecutionOptions(int checkInterval,
                                  int maxRetries,
@@ -68,7 +69,8 @@ public class DorisExecutionOptions implements Serializable {
                                  int flushQueueSize,
                                  int bufferFlushMaxRows,
                                  int bufferFlushMaxBytes,
-                                 long bufferFlushIntervalMs) {
+                                 long bufferFlushIntervalMs,
+                                 boolean ignoreUpdateBefore) {
         Preconditions.checkArgument(maxRetries >= 0);
         this.checkInterval = checkInterval;
         this.maxRetries = maxRetries;
@@ -84,6 +86,8 @@ public class DorisExecutionOptions implements Serializable {
         this.bufferFlushMaxRows = bufferFlushMaxRows;
         this.bufferFlushMaxBytes = bufferFlushMaxBytes;
         this.bufferFlushIntervalMs = bufferFlushIntervalMs;
+
+        this.ignoreUpdateBefore = ignoreUpdateBefore;
     }
 
     public static Builder builder() {
@@ -160,6 +164,10 @@ public class DorisExecutionOptions implements Serializable {
         return enableBatchMode;
     }
 
+    public boolean getIgnoreUpdateBefore(){
+        return ignoreUpdateBefore;
+    }
+
     /**
      * Builder of {@link DorisExecutionOptions}.
      */
@@ -178,6 +186,8 @@ public class DorisExecutionOptions implements Serializable {
         private int bufferFlushMaxBytes = DEFAULT_BUFFER_FLUSH_MAX_BYTES;
         private long bufferFlushIntervalMs = DEFAULT_BUFFER_FLUSH_INTERVAL_MS;
         private boolean enableBatchMode = false;
+
+        private boolean ignoreUpdateBefore = true;
 
 
         public Builder setCheckInterval(Integer checkInterval) {
@@ -246,9 +256,15 @@ public class DorisExecutionOptions implements Serializable {
             return this;
         }
 
+        public Builder setIgnoreUpdateBefore(boolean ignoreUpdateBefore) {
+            this.ignoreUpdateBefore = ignoreUpdateBefore;
+            return this;
+        }
+
         public DorisExecutionOptions build() {
             return new DorisExecutionOptions(checkInterval, maxRetries, bufferSize, bufferCount, labelPrefix,
-                    streamLoadProp, enableDelete, enable2PC, enableBatchMode, flushQueueSize, bufferFlushMaxRows, bufferFlushMaxBytes, bufferFlushIntervalMs);
+                    streamLoadProp, enableDelete, enable2PC, enableBatchMode, flushQueueSize, bufferFlushMaxRows,
+                    bufferFlushMaxBytes, bufferFlushIntervalMs, ignoreUpdateBefore);
         }
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -227,6 +227,13 @@ public class DorisConfigOptions {
             .withDescription("the flush interval mills, over this time, asynchronous threads will flush data. The " +
                     "default value is 10s.");
 
+    public static final ConfigOption<Boolean> SINK_IGNORE_UPDATE_BEFORE = ConfigOptions
+            .key("sink.ignore.update-before")
+            .booleanType()
+            .defaultValue(true)
+            .withDescription("In the CDC scenario, when the primary key of the upstream is inconsistent with that of the downstream, the update-before data needs to be passed to the downstream as deleted data, otherwise the data cannot be deleted.\n" +
+                    "The default is to ignore, that is, perform upsert semantics.");
+
     // Prefix for Doris StreamLoad specific properties.
     public static final String STREAM_LOAD_PROP_PREFIX = "sink.properties.";
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
@@ -68,6 +68,7 @@ import static org.apache.doris.flink.table.DorisConfigOptions.SINK_ENABLE_2PC;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_ENABLE_BATCH_MODE;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_ENABLE_DELETE;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_FLUSH_QUEUE_SIZE;
+import static org.apache.doris.flink.table.DorisConfigOptions.SINK_IGNORE_UPDATE_BEFORE;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_LABEL_PREFIX;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_MAX_RETRIES;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_PARALLELISM;
@@ -134,6 +135,7 @@ public final class DorisDynamicTableFactory implements DynamicTableSourceFactory
         options.add(SINK_BUFFER_SIZE);
         options.add(SINK_BUFFER_COUNT);
         options.add(SINK_PARALLELISM);
+        options.add(SINK_IGNORE_UPDATE_BEFORE);
 
         options.add(SINK_ENABLE_BATCH_MODE);
         options.add(SINK_BUFFER_FLUSH_MAX_ROWS);
@@ -203,6 +205,7 @@ public final class DorisDynamicTableFactory implements DynamicTableSourceFactory
         builder.setLabelPrefix(readableConfig.get(SINK_LABEL_PREFIX));
         builder.setStreamLoadProp(streamLoadProp);
         builder.setDeletable(readableConfig.get(SINK_ENABLE_DELETE));
+        builder.setIgnoreUpdateBefore(readableConfig.get(SINK_IGNORE_UPDATE_BEFORE));
         if (!readableConfig.get(SINK_ENABLE_2PC)) {
             builder.disable2PC();
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSink.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSink.java
@@ -24,14 +24,12 @@ import org.apache.doris.flink.rest.RestService;
 import org.apache.doris.flink.sink.DorisSink;
 import org.apache.doris.flink.sink.batch.DorisBatchSink;
 import org.apache.doris.flink.sink.writer.RowDataSerializer;
-
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkProvider;
 import org.apache.flink.table.connector.sink.SinkV2Provider;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,11 +70,11 @@ public class DorisDynamicTableSink implements DynamicTableSink {
 
     @Override
     public ChangelogMode getChangelogMode(ChangelogMode changelogMode) {
-        return ChangelogMode.newBuilder()
-                .addContainedKind(RowKind.INSERT)
-                .addContainedKind(RowKind.DELETE)
-                .addContainedKind(RowKind.UPDATE_AFTER)
-                .build();
+        if(executionOptions.getIgnoreUpdateBefore()){
+            return ChangelogMode.upsert();
+        }else{
+            return ChangelogMode.all();
+        }
     }
 
     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -180,16 +180,19 @@ public abstract class DatabaseSync {
         sinkConfig.getOptional(DorisConfigOptions.SINK_BUFFER_SIZE).ifPresent(executionBuilder::setBufferSize);
         sinkConfig.getOptional(DorisConfigOptions.SINK_CHECK_INTERVAL).ifPresent(executionBuilder::setCheckInterval);
         sinkConfig.getOptional(DorisConfigOptions.SINK_MAX_RETRIES).ifPresent(executionBuilder::setMaxRetries);
+        sinkConfig.getOptional(DorisConfigOptions.SINK_IGNORE_UPDATE_BEFORE).ifPresent(executionBuilder::setIgnoreUpdateBefore);
 
         boolean enable2pc = sinkConfig.getBoolean(DorisConfigOptions.SINK_ENABLE_2PC);
         if(!enable2pc){
             executionBuilder.disable2PC();
         }
+        DorisExecutionOptions executionOptions = executionBuilder.build();
         builder.setDorisReadOptions(DorisReadOptions.builder().build())
-                .setDorisExecutionOptions(executionBuilder.build())
+                .setDorisExecutionOptions(executionOptions)
                 .setSerializer(JsonDebeziumSchemaSerializer.builder()
                         .setDorisOptions(dorisBuilder.build())
                         .setNewSchemaChange(newSchemaChange)
+                        .setExecutionOptions(executionOptions)
                         .build())
                 .setDorisOptions(dorisBuilder.build());
         return builder.build();


### PR DESCRIPTION
## Problem Summary:

In the CDC scenario, when the primary key of the upstream is inconsistent with that of the downstream, the update-before data needs to be passed to the downstream as deleted data, otherwise the data cannot be deleted. The default is to ignore, that is, perform upsert semantics.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
