### PR TITLE
[Improvement]Improve-DorisSource's-validation-for-DorisReadOptions

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
@@ -63,6 +63,9 @@ public class DorisSourceBuilder<OUT> {
     }
 
     public DorisSource<OUT> build() {
+        if(dorisReadOptions == null) {
+            dorisReadOptions = DorisReadOptions.builder().build();
+        }
         return new DorisSource<>(options, readOptions, boundedness, deserializer);
     }
 }


### PR DESCRIPTION
To maintain the same standards as Doris Sink

## Problem Summary:

There is no validation for DorisReadOptions in DorisSource

## Changes:

Maintain the same standards as DorisSink builder
