### PR TITLE
[Bug] [Connector] Empty readOptions in the Build() method of setDoris…

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
@@ -63,6 +63,9 @@ public class DorisSourceBuilder<OUT> {
     }
 
     public DorisSource<OUT> build() {
+        if(readOptions == null){
+            readOptions = DorisReadOptions.builder().build();
+        }
         return new DorisSource<>(options, readOptions, boundedness, deserializer);
     }
 }


### PR DESCRIPTION
…ReadOptions

# Proposed changes

Issue Number: https://github.com/apache/doris-flink-connector/issues/174

## Problem Summary:
In the DorisExecutionOptions constructor mode, some code is redundant. When building DorisSink, the dorisReadOptions property is nulled in the Build() method. The setDorisReadOptions(DorisReadOptions.builder().build()) configuration is not required when creating a connection, but it is not used in the build() method of creating DorisSource. Therefore, the above configuration must be added when creating a DorisSource connection. However, this configuration only provides DorisReadOptions objects without explicit property configuration. 
Describe the overview of changes.
 It is not necessary to add this configuration when creating a connection. You are also advised to follow the DorisSink method when creating a DorisSource connection. In the Build() method of setDorisReadOptions, empty readOptions. If it is empty, assign a value to it. it does not need to add this configuration when creating a connection.
## Checklist(Required)

1. Does it affect the original behavior: (NO)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (Yes)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
