### PR TITLE
[fix] DorisSource build () Solution to null pointer exception

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
@@ -63,6 +63,7 @@ public class DorisSourceBuilder<OUT> {
     }
 
     public DorisSource<OUT> build() {
+
         if(readOptions == null) {
             readOptions = DorisReadOptions.builder().build();
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
@@ -63,7 +63,6 @@ public class DorisSourceBuilder<OUT> {
     }
 
     public DorisSource<OUT> build() {
-
         if(readOptions == null) {
             readOptions = DorisReadOptions.builder().build();
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSourceBuilder.java
@@ -63,6 +63,9 @@ public class DorisSourceBuilder<OUT> {
     }
 
     public DorisSource<OUT> build() {
+        if(readOptions == null) {
+            readOptions = DorisReadOptions.builder().build();
+        }
         return new DorisSource<>(options, readOptions, boundedness, deserializer);
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

If you do not configure DorisReadOptions.builder().build() in DorisSink, you will not report a null pointer exception, but a null pointer exception will occur in DorisSource, causing you to have to force this configuration to run properly. The configuration should have been used on demand, so some changes were made to build in DorisSource.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No
3. Has document been added or modified:No
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
