### PR TITLE
[BUG] Fix concurrency issues during flush

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -124,7 +124,7 @@ public class DorisBatchStreamLoad implements Serializable {
      * @param record
      * @throws IOException
      */
-    public void writeRecord(byte[] record) throws InterruptedException {
+    public synchronized void writeRecord(byte[] record) throws InterruptedException {
         checkFlushException();
         if(buffer == null){
             buffer = takeRecordFromWriteQueue();
@@ -137,7 +137,7 @@ public class DorisBatchStreamLoad implements Serializable {
         }
     }
 
-    public void flush(boolean waitUtilDone) throws InterruptedException {
+    public synchronized void flush(boolean waitUtilDone) throws InterruptedException {
         checkFlushException();
         if (buffer == null) {
             LOG.debug("buffer is empty, skip flush.");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

In batch write mode, timed flush may cause concurrency issues with the write method, which can lead to serious data inconsistency issues

## Checklist(Required)

1. Does it affect the original behavior: Yes
2. Has unit tests been added:  No Need
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: NO

