### PR TITLE
[fix] fix type mapping with mysql and pg

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlType.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlType.java
@@ -140,8 +140,6 @@ public class MysqlType {
             case TIMESTAMP:
                 return String.format("%s(%s)", DorisType.DATETIME_V2, Math.min(length == null ? 0 : length, 6));
             case CHAR:
-                Preconditions.checkNotNull(length);
-                return String.format("%s(%s)", DorisType.CHAR, length);
             case VARCHAR:
                 Preconditions.checkNotNull(length);
                 return length * 3 > 65533 ? DorisType.STRING : String.format("%s(%s)", DorisType.VARCHAR, length * 3);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/postgres/PostgresType.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/postgres/PostgresType.java
@@ -67,6 +67,9 @@ public class PostgresType {
 
     public static String toDorisType(String postgresType, Integer precision, Integer scale) {
         postgresType = postgresType.toLowerCase();
+        if(postgresType.startsWith("_")){
+          return DorisType.STRING;
+        }
         switch (postgresType){
             case INT2:
             case SMALLSERIAL:
@@ -121,6 +124,8 @@ public class PostgresType {
             case JSON:
             case JSONB:
                 return DorisType.JSONB;
+            /* Compatible with doris1.2 array type can only be used in dup table,
+               and then converted to array in the next version
             case _BOOL:
                 return String.format("%s<%s>", DorisType.ARRAY, DorisType.BOOLEAN);
             case _INT2:
@@ -139,6 +144,7 @@ public class PostgresType {
                 return String.format("%s<%s>", DorisType.ARRAY, DorisType.DATE_V2);
             case _TIMESTAMP:
                 return String.format("%s<%s>", DorisType.ARRAY, DorisType.DATETIME_V2);
+            **/
             default:
                 throw new UnsupportedOperationException("Unsupported Postgres Type: " + postgresType);
         }


### PR DESCRIPTION
## Problem Summary:

1. mysql char => doris varchar
2. pg array<T> => doris string, Compatible with doris 1.2

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
