### PR TITLE
[mysql] add mysql chunk column options

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -94,6 +94,7 @@ public abstract class DatabaseSync {
         DorisSystem dorisSystem = new DorisSystem(options);
 
         List<SourceSchema> schemaList = getSchemaList();
+        Preconditions.checkState(!schemaList.isEmpty(), "No tables to be synchronized.");
         if (!dorisSystem.databaseExists(database)) {
             LOG.info("database {} not exist, created", database);
             dorisSystem.createDatabase(database);
@@ -118,9 +119,7 @@ public abstract class DatabaseSync {
             System.exit(0);
         }
 
-        Preconditions.checkState(!syncTables.isEmpty(), "No tables to be synchronized.");
         config.setString(TABLE_NAME_OPTIONS, "(" + String.join("|", syncTables) + ")");
-
         DataStreamSource<String> streamSource = buildCdcSource(env);
         SingleOutputStreamOperator<Void> parsedStream = streamSource.process(new ParsingProcessFunction(converter));
         for (String table : dorisTables) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/sqlserver/SqlServerType.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/sqlserver/SqlServerType.java
@@ -47,8 +47,11 @@ public class SqlServerType {
     private static final String BINARY = "binary";
     private static final String VARBINARY = "varbinary";
 
-    public static String toDorisType(String sqlServerType, Integer precision, Integer scale) {
-        sqlServerType = sqlServerType.toLowerCase();
+    public static String toDorisType(String originSqlServerType, Integer precision, Integer scale) {
+        originSqlServerType = originSqlServerType.toLowerCase();
+        // For sqlserver IDENTITY type, such as 'INT IDENTITY'
+        // originSqlServerType is "int identity", so we only get "int".
+        String sqlServerType = originSqlServerType.split(" ")[0];
         switch (sqlServerType){
             case BIT:
                 return DorisType.BOOLEAN;


### PR DESCRIPTION
# Proposed changes

add mysql column key column:
`--mysql-conf scan.incremental.snapshot.chunk.key-column = db.tbl1:col1,db.tbl2:col2`

mysqlcdc version must be greater than 2.4

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
