### PR TITLE
[fix](oracle) add oracle regexp like compatible

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/ExecutionPool.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/ExecutionPool.java
@@ -104,9 +104,9 @@ public class ExecutionPool implements Closeable {
     public void close() throws IOException {
         if (started.compareAndSet(true, false)) {
             LOG.info("close executorService");
-            actionWatcherExecutorService.shutdownNow();
+            actionWatcherExecutorService.shutdown();
+            workerExecutorService.shutdown();
             workerStated.set(false);
-            workerExecutorService.shutdownNow();
             this.actionWatcherExecutorService = null;
             this.workerExecutorService = null;
             this.semaphore = null;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -61,6 +61,8 @@ public abstract class DatabaseSync {
     public StreamExecutionEnvironment env;
     private boolean createTableOnly = false;
     private boolean newSchemaChange;
+    protected String includingTables;
+    protected String excludingTables;
 
     public abstract Connection getConnection() throws SQLException;
 
@@ -76,6 +78,8 @@ public abstract class DatabaseSync {
         this.config = config;
         this.database = database;
         this.converter = new TableNameConverter(tablePrefix, tableSuffix);
+        this.includingTables = includingTables;
+        this.excludingTables = excludingTables;
         this.includingPattern = includingTables == null ? null : Pattern.compile(includingTables);
         this.excludingPattern = excludingTables == null ? null : Pattern.compile(excludingTables);
         this.ignoreDefaultValue = ignoreDefaultValue;


### PR DESCRIPTION
## Problem Summary:
When include-tables has too many table names, and debezium incrementally reads, it will be judged based on `regexp_like`. When the regular length exceeds 512, an error will be reported, like `ORA-12733: regular expression too long`

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
