### PR TITLE
[bug](lookup) Fix the duplicate data problem that may be caused by lookup

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/DorisJdbcLookupReader.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/DorisJdbcLookupReader.java
@@ -94,9 +94,12 @@ public class DorisJdbcLookupReader extends DorisLookupReader {
 
     private List<RowData> convertRowDataList(List<Record> records) {
         List<RowData> results = new ArrayList<>();
-        for (Record record : records) {
+        for (int index = 0; index < records.size(); index++){
+            Record record = records.get(index);
             RowData rowData = convertRowData(record);
             results.add(rowData);
+            //Recycle memory
+            records.set(index, null);
         }
         return results;
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/DorisJdbcLookupReader.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/DorisJdbcLookupReader.java
@@ -94,12 +94,9 @@ public class DorisJdbcLookupReader extends DorisLookupReader {
 
     private List<RowData> convertRowDataList(List<Record> records) {
         List<RowData> results = new ArrayList<>();
-        for (int index = 0; index < records.size(); index++){
-            Record record = records.get(index);
+        for (Record record : records) {
             RowData rowData = convertRowData(record);
             results.add(rowData);
-            //Recycle memory
-            records.set(index, null);
         }
         return results;
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
@@ -22,6 +22,7 @@ import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.connection.JdbcConnectionProvider;
 import org.apache.doris.flink.connection.SimpleJdbcConnectionProvider;
 import org.apache.doris.flink.exception.DorisRuntimeException;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,9 +30,12 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -91,12 +95,13 @@ public class Worker implements Runnable {
         }
         LookupSchema schema = action.getGetList().get(0).getRecord().getSchema();
         List<Get> recordList = action.getGetList();
-
+        List<Get> deduplicateList = deduplicateRecords(recordList);
+        LOG.debug("record size {}, after deduplicate size {}", recordList.size(), deduplicateList.size());
         StringBuilder sb = new StringBuilder();
         boolean first;
-        for (int i = 0; i < recordList.size(); i++) {
+        for (int i = 0; i < deduplicateList.size(); i++) {
             if (i > 0) {
-                sb.append(" union ");
+                sb.append(" union all ");
             }
             first = true;
             appendSelect(sb, schema);
@@ -112,9 +117,8 @@ public class Worker implements Runnable {
         }
 
         String sql = sb.toString();
-        LOG.debug("query sql is {}", sql);
         try {
-            Map<RecordKey, List<Record>> resultRecordMap = executeQuery(sql, recordList, schema);
+            Map<RecordKey, List<Record>> resultRecordMap = executeQuery(sql, deduplicateList, schema);
             for (Get get : recordList) {
                 Record record = get.getRecord();
                 if (get.getFuture() != null) {
@@ -130,6 +134,20 @@ public class Worker implements Runnable {
                 }
             }
         }
+    }
+
+    /**
+     * Sometimes, there will be duplicate key filtering conditions in a batch of data,
+     * which can be removed in advance to reduce query pressure.
+     * */
+    @VisibleForTesting
+    public static List<Get> deduplicateRecords(List<Get> recordList) {
+        if(recordList == null || recordList.size() <= 1){
+            return recordList;
+        }
+        Set<Get> recordSet = new TreeSet<>((r1, r2) -> Arrays.equals(r1.getRecord().getValues(), r2.getRecord().getValues()) ? 0 : -1);
+        recordSet.addAll(recordList);
+        return new ArrayList<>(recordSet);
     }
 
     private void appendSelect(StringBuilder sb, LookupSchema schema){

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
@@ -96,7 +96,7 @@ public class Worker implements Runnable {
         boolean first;
         for (int i = 0; i < recordList.size(); i++) {
             if (i > 0) {
-                sb.append(" union all ");
+                sb.append(" union ");
             }
             first = true;
             appendSelect(sb, schema);


### PR DESCRIPTION
# Proposed changes

The upstream sends a batch of data with the same key. When querying using union all, it will cause the same key and multiple duplicate values to appear in the resultRecordMap. When getting the value again, it will lead to repeated circular assignment, so the data of lookup join will increase.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
