### PR TITLE
[fix] If there are single quotes in ddl statements, table creation fails

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
@@ -180,7 +180,7 @@ public class DorisSystem {
         //append table comment
         if(!StringUtils.isNullOrWhitespaceOnly(schema.getTableComment())){
             sb.append(" COMMENT '")
-                    .append(schema.getTableComment())
+                    .append(schema.getTableComment().replace("'",""))
                     .append("' ");
         }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
@@ -180,7 +180,7 @@ public class DorisSystem {
         //append table comment
         if(!StringUtils.isNullOrWhitespaceOnly(schema.getTableComment())){
             sb.append(" COMMENT '")
-                    .append(schema.getTableComment().replace("'",""))
+                    .append(quoteComment(schema.getTableComment()))
                     .append("' ");
         }
 


### PR DESCRIPTION
If there are single quotes in ddl statements, table creation fails
as shown below
![image](https://github.com/apache/doris-flink-connector/assets/57290855/26a9a5b5-10db-4d87-bed4-7e5443cf3068)
