### PR TITLE
[improve] add auto redirect and uniq default open 2pc

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisConnectionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisConnectionOptions.java
@@ -32,6 +32,11 @@ public class DorisConnectionOptions implements Serializable {
     protected final String password;
     protected String jdbcUrl;
     protected String benodes;
+    /**
+     * Used to enable automatic redirection of fe,
+     * When it is not enabled, it will actively request the be list, and the polling will initiate a streamload request to be.
+     */
+    protected boolean autoRedirect;
 
     public DorisConnectionOptions(String fenodes, String username, String password) {
         this.fenodes = Preconditions.checkNotNull(fenodes, "fenodes  is empty");
@@ -45,10 +50,11 @@ public class DorisConnectionOptions implements Serializable {
     }
 
     public DorisConnectionOptions(String fenodes, String benodes,  String username, String password,
-            String jdbcUrl) {
+            String jdbcUrl, boolean autoRedirect) {
         this(fenodes, username, password);
         this.benodes = benodes;
         this.jdbcUrl = jdbcUrl;
+        this.autoRedirect = autoRedirect;
     }
 
     public String getFenodes() {
@@ -71,18 +77,28 @@ public class DorisConnectionOptions implements Serializable {
         return jdbcUrl;
     }
 
+    public boolean isAutoRedirect() {
+        return autoRedirect;
+    }
+
     /**
      * Builder for {@link DorisConnectionOptions}.
      */
     public static class DorisConnectionOptionsBuilder {
         private String fenodes;
+        private String benodes;
         private String username;
         private String password;
-
         private String jdbcUrl;
+        private boolean autoRedirect;
 
         public DorisConnectionOptionsBuilder withFenodes(String fenodes) {
             this.fenodes = fenodes;
+            return this;
+        }
+
+        public DorisConnectionOptionsBuilder withBenodes(String benodes) {
+            this.benodes = benodes;
             return this;
         }
 
@@ -101,8 +117,13 @@ public class DorisConnectionOptions implements Serializable {
             return this;
         }
 
+        public DorisConnectionOptionsBuilder withAutoRedirect(boolean autoRedirect) {
+            this.autoRedirect = autoRedirect;
+            return this;
+        }
+
         public DorisConnectionOptions build() {
-            return new DorisConnectionOptions(fenodes, username, password, jdbcUrl);
+            return new DorisConnectionOptions(fenodes, benodes, username, password, jdbcUrl, autoRedirect);
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -49,7 +49,8 @@ public class DorisExecutionOptions implements Serializable {
      */
     private final Properties streamLoadProp;
     private final Boolean enableDelete;
-    private final Boolean enable2PC;
+    private Boolean enable2PC;
+    private boolean force2PC;
 
     //batch mode param
     private final int flushQueueSize;
@@ -73,7 +74,8 @@ public class DorisExecutionOptions implements Serializable {
                                  int bufferFlushMaxRows,
                                  int bufferFlushMaxBytes,
                                  long bufferFlushIntervalMs,
-                                 boolean ignoreUpdateBefore) {
+                                 boolean ignoreUpdateBefore,
+                                 boolean force2PC) {
         Preconditions.checkArgument(maxRetries >= 0);
         this.checkInterval = checkInterval;
         this.maxRetries = maxRetries;
@@ -84,6 +86,7 @@ public class DorisExecutionOptions implements Serializable {
         this.streamLoadProp = streamLoadProp;
         this.enableDelete = enableDelete;
         this.enable2PC = enable2PC;
+        this.force2PC = force2PC;
 
         this.enableBatchMode = enableBatchMode;
         this.flushQueueSize = flushQueueSize;
@@ -176,6 +179,14 @@ public class DorisExecutionOptions implements Serializable {
         return ignoreUpdateBefore;
     }
 
+    public void setEnable2PC(Boolean enable2PC) {
+        this.enable2PC = enable2PC;
+    }
+
+    public boolean force2PC() {
+        return force2PC;
+    }
+
     /**
      * Builder of {@link DorisExecutionOptions}.
      */
@@ -189,6 +200,9 @@ public class DorisExecutionOptions implements Serializable {
         private Properties streamLoadProp = new Properties();
         private boolean enableDelete = true;
         private boolean enable2PC = true;
+
+        //A flag used to determine whether to forcibly open 2pc. By default, the uniq model close 2pc.
+        private boolean force2PC = false;
 
         private int flushQueueSize = DEFAULT_FLUSH_QUEUE_SIZE;
         private int bufferFlushMaxRows = DEFAULT_BUFFER_FLUSH_MAX_ROWS;
@@ -244,6 +258,13 @@ public class DorisExecutionOptions implements Serializable {
             return this;
         }
 
+        public Builder enable2PC() {
+            this.enable2PC = true;
+            //Force open 2pc
+            this.force2PC = true;
+            return this;
+        }
+
         public Builder enableBatchMode() {
             this.enableBatchMode = true;
             return this;
@@ -278,7 +299,7 @@ public class DorisExecutionOptions implements Serializable {
         public DorisExecutionOptions build() {
             return new DorisExecutionOptions(checkInterval, maxRetries, bufferSize, bufferCount, labelPrefix, useCache,
                     streamLoadProp, enableDelete, enable2PC, enableBatchMode, flushQueueSize, bufferFlushMaxRows,
-                    bufferFlushMaxBytes, bufferFlushIntervalMs, ignoreUpdateBefore);
+                    bufferFlushMaxBytes, bufferFlushIntervalMs, ignoreUpdateBefore, force2PC);
         }
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisOptions.java
@@ -43,8 +43,8 @@ public class DorisOptions extends DorisConnectionOptions {
     }
 
     public DorisOptions(String fenodes, String beNodes, String username, String password,
-            String tableIdentifier, String jdbcUrl) {
-        super(fenodes, beNodes, username, password, jdbcUrl);
+            String tableIdentifier, String jdbcUrl, boolean redirect) {
+        super(fenodes, beNodes, username, password, jdbcUrl, redirect);
         this.tableIdentifier = tableIdentifier;
     }
 
@@ -70,6 +70,7 @@ public class DorisOptions extends DorisConnectionOptions {
         private String jdbcUrl;
         private String username;
         private String password;
+        private boolean autoRedirect;
         private String tableIdentifier;
 
         /**
@@ -120,10 +121,15 @@ public class DorisOptions extends DorisConnectionOptions {
             return this;
         }
 
+        public Builder setAutoRedirect(boolean autoRedirect) {
+            this.autoRedirect = autoRedirect;
+            return this;
+        }
+
         public DorisOptions build() {
             checkNotNull(fenodes, "No fenodes supplied.");
             checkNotNull(tableIdentifier, "No tableIdentifier supplied.");
-            return new DorisOptions(fenodes, benodes, username, password, tableIdentifier, jdbcUrl);
+            return new DorisOptions(fenodes, benodes, username, password, tableIdentifier, jdbcUrl, autoRedirect);
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/ConnectedFailedException.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/ConnectedFailedException.java
@@ -19,10 +19,10 @@ package org.apache.doris.flink.exception;
 
 public class ConnectedFailedException extends DorisRuntimeException {
     public ConnectedFailedException(String server, Throwable cause) {
-        super("Connect to " + server + "failed.", cause);
+        super("Connect to " + server + " failed.", cause);
     }
 
     public ConnectedFailedException(String server, int statusCode, Throwable cause) {
-        super("Connect to " + server + "failed, status code is " + statusCode + ".", cause);
+        super("Connect to " + server + " failed, status code is " + statusCode + ".", cause);
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/BackendV2.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/BackendV2.java
@@ -75,5 +75,13 @@ public class BackendV2 {
             return ip + ":" + httpPort;
         }
 
+        public static BackendRowV2 of(String ip, int httpPort, boolean alive){
+            BackendRowV2 rowV2 = new BackendRowV2();
+            rowV2.setIp(ip);
+            rowV2.setHttpPort(httpPort);
+            rowV2.setAlive(alive);
+            return rowV2;
+        }
+
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -44,8 +44,8 @@ public class DorisConfigOptions {
     public static final ConfigOption<String> TABLE_IDENTIFIER = ConfigOptions.key("table.identifier").stringType().noDefaultValue().withDescription("the doris table name.");
     public static final ConfigOption<String> USERNAME = ConfigOptions.key("username").stringType().noDefaultValue().withDescription("the doris user name.");
     public static final ConfigOption<String> PASSWORD = ConfigOptions.key("password").stringType().noDefaultValue().withDescription("the doris password.");
-
     public static final ConfigOption<String> JDBC_URL = ConfigOptions.key("jdbc-url").stringType().noDefaultValue().withDescription("doris jdbc url address.");
+    public static final ConfigOption<Boolean> AUTO_REDIRECT = ConfigOptions.key("auto-redirect").booleanType().defaultValue(false).withDescription("Use automatic redirection of fe without explicitly obtaining the be list");
 
     // source config options
     public static final ConfigOption<String> DORIS_READ_FIELD = ConfigOptions
@@ -176,7 +176,7 @@ public class DorisConfigOptions {
     public static final ConfigOption<Integer> SINK_BUFFER_SIZE = ConfigOptions
             .key("sink.buffer-size")
             .intType()
-            .defaultValue(256 * 1024)
+            .defaultValue(1024 * 1024)
             .withDescription("the buffer size to cache data for stream load.");
     public static final ConfigOption<Integer> SINK_BUFFER_COUNT = ConfigOptions
             .key("sink.buffer-count")

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -190,9 +190,12 @@ public abstract class DatabaseSync {
         sinkConfig.getOptional(DorisConfigOptions.SINK_MAX_RETRIES).ifPresent(executionBuilder::setMaxRetries);
         sinkConfig.getOptional(DorisConfigOptions.SINK_IGNORE_UPDATE_BEFORE).ifPresent(executionBuilder::setIgnoreUpdateBefore);
 
-        boolean enable2pc = sinkConfig.getBoolean(DorisConfigOptions.SINK_ENABLE_2PC);
-        if(!enable2pc){
+
+        if(!sinkConfig.getBoolean(DorisConfigOptions.SINK_ENABLE_2PC)){
             executionBuilder.disable2PC();
+        } else if(sinkConfig.getOptional(DorisConfigOptions.SINK_ENABLE_2PC).isPresent()){
+            //force open 2pc
+            executionBuilder.enable2PC();
         }
 
         //batch option

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -137,6 +137,7 @@ public abstract class DatabaseSync {
 
     private DorisConnectionOptions getDorisConnectionOptions() {
         String fenodes = sinkConfig.getString(DorisConfigOptions.FENODES);
+        String benodes = sinkConfig.getString(DorisConfigOptions.BENODES);
         String user = sinkConfig.getString(DorisConfigOptions.USERNAME);
         String passwd = sinkConfig.getString(DorisConfigOptions.PASSWORD, "");
         String jdbcUrl = sinkConfig.getString(DorisConfigOptions.JDBC_URL);
@@ -145,6 +146,7 @@ public abstract class DatabaseSync {
         Preconditions.checkNotNull(jdbcUrl, "jdbcurl is empty in sink-conf");
         DorisConnectionOptions.DorisConnectionOptionsBuilder builder = new DorisConnectionOptions.DorisConnectionOptionsBuilder()
                 .withFenodes(fenodes)
+                .withBenodes(benodes)
                 .withUsername(user)
                 .withPassword(passwd)
                 .withJdbcUrl(jdbcUrl);
@@ -168,6 +170,7 @@ public abstract class DatabaseSync {
                 .setTableIdentifier(database + "." + table)
                 .setUsername(user)
                 .setPassword(passwd);
+        sinkConfig.getOptional(DorisConfigOptions.AUTO_REDIRECT).ifPresent(dorisBuilder::setAutoRedirect);
 
         Properties pro = new Properties();
         //default json data format


### PR DESCRIPTION
# Proposed changes

1. When currently writing, the be list is obtained first, and then the streamload request is initiated to be in rotation. Add auto-redirect parameter to turn on fe automatic redirection
2. when writing uniq model, 2pc is closed by default (supports forced opening)

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
