### PR TITLE
[bug] fix buffer memory grow bug

### DIFF
--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestBatchRecordBuffer.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestBatchRecordBuffer.java
@@ -55,21 +55,38 @@ public class TestBatchRecordBuffer {
         BatchRecordBuffer recordBuffer = new BatchRecordBuffer("\n".getBytes(StandardCharsets.UTF_8),1);
         recordBuffer.ensureCapacity(10);
 
-        Assert.assertEquals(recordBuffer.getBuffer().capacity(), 10 + 1);
+        //grow at least 1MB
+        Assert.assertEquals(recordBuffer.getBuffer().capacity(), 1024 * 1024 + 1);
 
         recordBuffer.ensureCapacity(100);
-        Assert.assertEquals(recordBuffer.getBuffer().capacity(), 100 + 11);
+        Assert.assertEquals(recordBuffer.getBuffer().capacity(), 1024 * 1024 + 1);
 
         recordBuffer.ensureCapacity(1024);
-        Assert.assertEquals(recordBuffer.getBuffer().capacity(), 1024 + 111);
+        Assert.assertEquals(recordBuffer.getBuffer().capacity(), 1024 * 1024 + 1);
 
+        //not need grow
         recordBuffer = new BatchRecordBuffer("\n".getBytes(StandardCharsets.UTF_8),16);
-        recordBuffer.ensureCapacity(16);
+        recordBuffer.ensureCapacity(15);
         Assert.assertEquals(recordBuffer.getBuffer().capacity(), 16);
 
         recordBuffer.insert("1234567890".getBytes(StandardCharsets.UTF_8));
         recordBuffer.ensureCapacity(8);
-        Assert.assertEquals(recordBuffer.getBuffer().capacity(), 32);
+        Assert.assertEquals(recordBuffer.getBuffer().capacity(), 1024 * 1024 + 16);
+
+        recordBuffer = new BatchRecordBuffer("\n".getBytes(StandardCharsets.UTF_8),10);
+        recordBuffer.insert("1234567".getBytes(StandardCharsets.UTF_8));
+        recordBuffer.insert("123456789012345678901234567890".getBytes(StandardCharsets.UTF_8));
+
+        //
+        recordBuffer = new BatchRecordBuffer("\n".getBytes(StandardCharsets.UTF_8),10);
+        recordBuffer.ensureCapacity(2 * 1024 * 1024);
+        Assert.assertEquals(recordBuffer.getBuffer().capacity(), 2 * 1024 * 1024 - 10 + 1 + 10);
+
+        //grow at least 50% of the current size
+        recordBuffer = new BatchRecordBuffer("\n".getBytes(StandardCharsets.UTF_8),5 * 1024 * 1024);
+        recordBuffer.insert(ByteBuffer.allocate(2 * 1024 * 1024).array());
+        recordBuffer.insert(ByteBuffer.allocate(3 * 1024 * 1024 + 1).array());
+        Assert.assertEquals(recordBuffer.getBuffer().capacity(), 5 * 1024 * 1024 + 5 * 1024 * 1024 / 2);
     }
 
 }


### PR DESCRIPTION
# Proposed changes

When importing in batch mode, when a row of data is too large and is larger than the remaining buffer, insert will report an error.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
