### PR TITLE
[feature] support  struct and map type

### DIFF
--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/serialization/TestRowBatch.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/serialization/TestRowBatch.java
@@ -41,6 +41,7 @@ import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.util.Text;
 import org.apache.doris.flink.exception.DorisException;
 import org.apache.doris.flink.rest.RestService;
 import org.apache.doris.flink.rest.models.Schema;
@@ -520,11 +521,11 @@ public class TestRowBatch {
 
         RowBatch rowBatch = new RowBatch(scanBatchResult, schema).readArrow();
         Assert.assertTrue(rowBatch.hasNext());
-        Assert.assertEquals(ImmutableMap.of("k1","0"), rowBatch.next().get(0));
+        Assert.assertTrue(ImmutableMap.of("k1", 0).equals(rowBatch.next().get(0)));
         Assert.assertTrue(rowBatch.hasNext());
-        Assert.assertEquals(ImmutableMap.of("k2", "1"),rowBatch.next().get(0));
+        Assert.assertTrue(ImmutableMap.of("k2", 1).equals(rowBatch.next().get(0)));
         Assert.assertTrue(rowBatch.hasNext());
-        Assert.assertEquals(ImmutableMap.of("k3", "2"), rowBatch.next().get(0));
+        Assert.assertTrue(ImmutableMap.of("k3", 2).equals(rowBatch.next().get(0)));
         Assert.assertFalse(rowBatch.hasNext());
 
     }
@@ -583,7 +584,6 @@ public class TestRowBatch {
 
         RowBatch rowBatch = new RowBatch(scanBatchResult, schema).readArrow();
         Assert.assertTrue(rowBatch.hasNext());
-        Assert.assertEquals("{\"a\":\"a1\",\"b\":1}", rowBatch.next().get(0));
-
+        Assert.assertTrue(ImmutableMap.of("a", new Text("a1"),"b",1).equals(rowBatch.next().get(0)));
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/serialization/TestRowBatch.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/serialization/TestRowBatch.java
@@ -579,7 +579,6 @@ public class TestRowBatch {
 
         String schemaStr = "{\"properties\":[{\"type\":\"STRUCT\",\"name\":\"col_struct\",\"comment\":\"\"}" +
                 "], \"status\":200}";
-
         Schema schema = RestService.parseSchema(schemaStr, logger);
 
         RowBatch rowBatch = new RowBatch(scanBatchResult, schema).readArrow();


### PR DESCRIPTION
# Proposed changes
Support doris map, struct type reading and writing

```java
//doris create table
CREATE TABLE `simple_map2` (
  `id` int(11) NULL,
  `m` MAP<text,int(11)> NULL,
  `s_info` STRUCT<s_id:int(11),s_name:text,s_address:text> NULL
) ENGINE=OLAP
DUPLICATE KEY(`id`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`id`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"is_being_synced" = "false",
"storage_format" = "V2",
"light_schema_change" = "true",
"disable_auto_compaction" = "false",
"enable_single_replica_compaction" = "false"
); 

//datagen->doris
tEnv.executeSql(
         "CREATE TABLE doris_test (" +
         "  id int,\n" +
         "  task Map<String,int>,\n" +
         "  buyer ROW<s_id int,s_name string, s_address string>\n" +
         ") " +
         "WITH (\n" +
         "  'connector' = 'datagen', \n" +
         "  'number-of-rows' = '11' \n" +
         ")");

tEnv.executeSql("CREATE TABLE blackhole_table (" +
         "id int," +
         "m Map<String,int>," +
         "s_info Row<s_id int,s_name string, s_address string>" +
         ") WITH (" +
         "  'connector' = 'doris',\n" +
         "  'fenodes' = '127.0.0.1:8030',\n" +
         "  'table.identifier' = 'test.simple_map2',\n" +
         "  'sink.enable-2pc' = 'false',\n" +
         "  'username' = 'root',\n" +
         "  'password' = '',\n" +
         "  'sink.properties.format' = 'json',\n" +
         "  'sink.properties.read_json_by_line' = 'true'\n" +
         ");");

tEnv.executeSql("INSERT INTO blackhole_table select * from doris_test");
 


//doris->doris
tEnv.executeSql(
        "CREATE TABLE doris_source (" +
        "id int," +
        "m Map<String,int>," +
        "s_info Row<s_id int,s_name string, s_address string>" +
        ") " +
        "WITH (\n" +
        "  'connector' = 'doris',\n" +
        "  'fenodes' = '127.0.0.1:8030',\n" +
        "  'table.identifier' = 'test.simple_map',\n" +
        "  'username' = 'root',\n" +
        "  'password' = ''\n" +
        ")");

tEnv.executeSql("CREATE TABLE blackhole_table (" +
                "id int," +
                "m Map<String,int>," +
                "s_info Row<s_id int,s_name string, s_address string>" +
                ") WITH (" +
                "  'connector' = 'doris',\n" +
                "  'fenodes' = '127.0.0.1:8030',\n" +
                "  'table.identifier' = 'test.simple_map2',\n" +
                "  'sink.enable-2pc' = 'false',\n" +
                "  'username' = 'root',\n" +
                "  'password' = '',\n" +
                "  'sink.properties.format' = 'json',\n" +
                "  'sink.properties.read_json_by_line' = 'true'\n" +
                ");");

tEnv.executeSql("insert into blackhole_table select * from doris_source");

```
## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
