### PR TITLE
[improve] improve commit retry strategy

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -29,7 +29,7 @@ public class DorisExecutionOptions implements Serializable {
 
     private static final long serialVersionUID = 1L;
     public static final int DEFAULT_CHECK_INTERVAL = 10000;
-    public static final int DEFAULT_MAX_RETRY_TIMES = 1;
+    public static final int DEFAULT_MAX_RETRY_TIMES = 3;
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 1024;
     private static final int DEFAULT_BUFFER_COUNT = 3;
     //batch flush

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
@@ -74,7 +74,7 @@ public class BackendUtil {
         throw new DorisRuntimeException("no available backend.");
     }
 
-    public boolean tryHttpConnection(String backend) {
+    public static boolean tryHttpConnection(String backend) {
         try {
             backend = "http://" + backend;
             URL url = new URL(backend);

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/committer/TestDorisCommitter.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/committer/TestDorisCommitter.java
@@ -21,7 +21,8 @@ import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisRuntimeException;
 import org.apache.doris.flink.rest.RestService;
-import org.apache.doris.flink.rest.models.BackendV2.BackendRowV2;
+import org.apache.doris.flink.rest.models.BackendV2;
+import org.apache.doris.flink.sink.BackendUtil;
 import org.apache.doris.flink.sink.DorisCommittable;
 import org.apache.doris.flink.sink.HttpEntityMock;
 import org.apache.doris.flink.sink.OptionUtils;
@@ -32,9 +33,10 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.MockedStatic;
-import org.slf4j.Logger;
 
 import java.util.Collections;
 
@@ -52,6 +54,9 @@ public class TestDorisCommitter {
     DorisCommittable dorisCommittable;
     HttpEntityMock entityMock;
     private MockedStatic<RestService> restServiceMockedStatic;
+    private MockedStatic<BackendUtil> backendUtilMockedStatic;
+    @Rule
+    public ExpectedException thrown= ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -63,15 +68,17 @@ public class TestDorisCommitter {
         CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
         StatusLine normalLine = new BasicStatusLine(new ProtocolVersion("http", 1, 0), 200, "");
         restServiceMockedStatic = mockStatic(RestService.class);
-        Logger mockLogger = mock(Logger.class);
-        mock(RestService.class);
+        backendUtilMockedStatic = mockStatic(BackendUtil.class);
 
         when(httpClient.execute(any())).thenReturn(httpResponse);
         when(httpResponse.getStatusLine()).thenReturn(normalLine);
         when(httpResponse.getEntity()).thenReturn(entityMock);
-        when(RestService.getBackendsV2(dorisOptions, readOptions, mockLogger)).thenReturn(
-                Collections.singletonList(new BackendRowV2()));
-        dorisCommitter = new DorisCommitter(dorisOptions, readOptions, 2, httpClient);
+
+        restServiceMockedStatic.when(()-> RestService.getBackendsV2(any(),any(),any()))
+                .thenReturn(Collections.singletonList(BackendV2.BackendRowV2.of("127.0.0.1", 8040,true)));
+        backendUtilMockedStatic.when(()-> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+
+        dorisCommitter = new DorisCommitter(dorisOptions, readOptions, 3, httpClient);
     }
 
     @Test
@@ -83,11 +90,13 @@ public class TestDorisCommitter {
         this.entityMock.setValue(response);
         final MockCommitRequest<DorisCommittable> request = new MockCommitRequest<>(dorisCommittable);
         dorisCommitter.commit(Collections.singletonList(request));
-
     }
 
-    @Test(expected = DorisRuntimeException.class)
+    @Test
     public void testCommitAbort() throws Exception {
+        thrown.expect(DorisRuntimeException.class);
+        thrown.expectMessage("commit transaction error");
+
         String response = "{\n" +
                 "\"status\": \"Fail\",\n" +
                 "\"msg\": \"errCode = 2, detailMessage = transaction [25] is already aborted. abort reason: User Abort\"\n" +
@@ -100,5 +109,6 @@ public class TestDorisCommitter {
     @After
     public void after() {
         restServiceMockedStatic.close();
+        backendUtilMockedStatic.close();
     }
 }


### PR DESCRIPTION
# Proposed changes

1. Modify the number of retry times under datastream
2. Modify the problem of reducing the number of retry attempts once
3. Fix that retry does not take effect. Currently, DorisRunntimeException is thrown and IOException is captured.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
