### PR TITLE
[improve] change option default when format is json

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -22,6 +22,10 @@ import org.apache.flink.util.Preconditions;
 import java.io.Serializable;
 import java.util.Properties;
 
+import static org.apache.doris.flink.sink.writer.LoadConstants.FORMAT_KEY;
+import static org.apache.doris.flink.sink.writer.LoadConstants.JSON;
+import static org.apache.doris.flink.sink.writer.LoadConstants.READ_JSON_BY_LINE;
+
 /**
  * Doris sink batch options.
  */
@@ -297,6 +301,12 @@ public class DorisExecutionOptions implements Serializable {
         }
 
         public DorisExecutionOptions build() {
+            //If format=json is set but read_json_by_line is not set, record may not be written.
+            if(streamLoadProp != null
+                    && streamLoadProp.containsKey(FORMAT_KEY)
+                    && JSON.equals(streamLoadProp.getProperty(FORMAT_KEY))){
+                streamLoadProp.put(READ_JSON_BY_LINE, true);
+            }
             return new DorisExecutionOptions(checkInterval, maxRetries, bufferSize, bufferCount, labelPrefix, useCache,
                     streamLoadProp, enableDelete, enable2PC, enableBatchMode, flushQueueSize, bufferFlushMaxRows,
                     bufferFlushMaxBytes, bufferFlushIntervalMs, ignoreUpdateBefore, force2PC);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisOptions.java
@@ -132,7 +132,8 @@ public class DorisOptions extends DorisConnectionOptions {
 
         public DorisOptions build() {
             checkNotNull(fenodes, "No fenodes supplied.");
-            checkNotNull(tableIdentifier, "No tableIdentifier supplied.");
+            //multi table load, don't need check
+            //checkNotNull(tableIdentifier, "No tableIdentifier supplied.");
             return new DorisOptions(fenodes, benodes, username, password, tableIdentifier, jdbcUrl, autoRedirect);
         }
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LoadConstants.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LoadConstants.java
@@ -31,5 +31,6 @@ public class LoadConstants {
     public static final String CSV = "csv";
     public static final String NULL_VALUE = "\\N";
     public static final String DORIS_DELETE_SIGN = "__DORIS_DELETE_SIGN__";
+    public static final String READ_JSON_BY_LINE = "read_json_by_line";
 
 }


### PR DESCRIPTION
# Proposed changes

If format=json is set but read_json_by_line is not set, record may not be written.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
