### PR TITLE
[fix]Add a log prompt to perform schame change table update when there is no data in the table

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/JsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/JsonDebeziumSchemaSerializer.java
@@ -396,6 +396,8 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
                 }
             }
         } else {
+            LOG.error("Current schema change failed! You need to ensure that "
+                    + "there is data in the table." + dorisOptions.getTableIdentifier());
             originFieldSchemaMap = new LinkedHashMap<>();
             columns.forEach(column -> buildFieldSchema(originFieldSchemaMap, column));
         }


### PR DESCRIPTION


# Proposed changes

We fully consider that doing schema changes when there is no data in the table is a relatively low-frequency operation. The existing framework is compatible with this kind of operation and the changes are relatively large, so only the prompt log is added.

Related pr: https://github.com/apache/doris-flink-connector/pull/243

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
