### PR TITLE
[Bug] Fix the state compatibility problem

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -130,6 +130,10 @@ public class DorisWriter<IN> implements StatefulSink.StatefulSinkWriter<IN, Dori
              if(!state.getLabelPrefix().equals(labelPrefix)){
                  LOG.warn("Label prefix from previous execution {} has changed to {}.", state.getLabelPrefix(), executionOptions.getLabelPrefix());
              }
+             if (state.getDatabase() == null || state.getTable() == null) {
+                 LOG.warn("Transactions cannot be aborted when restore because the last used flink-doris-connector version less than 1.5.0.");
+                 continue;
+             }
              String key = state.getDatabase() + "." + state.getTable();
              DorisStreamLoad streamLoader = getStreamLoader(key);
              streamLoader.abortPreCommit(state.getLabelPrefix(), curCheckpointId);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #256

## Problem Summary:

#224 Made a change to DorisWriterState without considering connector state compatibility, resulting in an upgrade to 1.5.0 error, So I wana to fix this.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
