### PR TITLE
[fix]fix Load Doris data failed, schema size of fetch data is wrong

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/serialization/RowBatch.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/serialization/RowBatch.java
@@ -115,7 +115,7 @@ public class RowBatch {
             this.root = arrowStreamReader.getVectorSchemaRoot();
             while (arrowStreamReader.loadNextBatch()) {
                 fieldVectors = root.getFieldVectors();
-                if (fieldVectors.size() != schema.size()) {
+                if (fieldVectors.size() > schema.size()) {
                     logger.error("Schema size '{}' is not equal to arrow field size '{}'.",
                             fieldVectors.size(), schema.size());
                     throw new DorisException("Load Doris data failed, schema size of fetch data is wrong.");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

If the table model is a unique model and the __DORIS_DELETE_SIGN__ column is not specified in doris.read.field when reading, the error "Load Doris data failed, schema size of fetch data is wrong" will appear.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
