### PR TITLE
[fix] improve char length proplem

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlType.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlType.java
@@ -142,7 +142,7 @@ public class MysqlType {
             case CHAR:
             case VARCHAR:
                 Preconditions.checkNotNull(length);
-                return length * 4 > 65533 ? DorisType.STRING : String.format("%s(%s)", DorisType.VARCHAR, length * 4);
+                return length * 3 > 65533 ? DorisType.STRING : String.format("%s(%s)", DorisType.VARCHAR, length * 3);
             case TINYTEXT:
             case TEXT:
             case MEDIUMTEXT:

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestJsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestJsonDebeziumSchemaSerializer.java
@@ -253,7 +253,7 @@ public class TestJsonDebeziumSchemaSerializer {
     public void testFillOriginSchema() throws IOException {
         Map<String, FieldSchema> srcFiledSchemaMap = new LinkedHashMap<>();
         srcFiledSchemaMap.put("id", new FieldSchema("id", "INT", null, null));
-        srcFiledSchemaMap.put("name", new FieldSchema("name", "VARCHAR(200)", null, null));
+        srcFiledSchemaMap.put("name", new FieldSchema("name", "VARCHAR(150)", null, null));
         srcFiledSchemaMap.put("test_time", new FieldSchema("test_time", "DATETIMEV2(0)", null, null));
         srcFiledSchemaMap.put("c1", new FieldSchema("c1", "INT", "'100'", null));
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The length of char needs to be multiplied by 3 as a judgment
At the same time, modify the length of varchar to 3. If you need longer characters, you can use string instead.
Reference here: https://doris.apache.org/zh-CN/docs/dev/sql-manual/sql-reference/Data-Types/VARCHAR/

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
