### PR TITLE
[Fix] catalog queries fenodes compatibility

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalog.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalog.java
@@ -246,7 +246,7 @@ public class DorisCatalog extends AbstractCatalog {
             ResultSetMetaData metaData = resultSet.getMetaData();
             for (int i = 1; i <= metaData.getColumnCount(); i++) {
                 String columnName = metaData.getColumnName(i);
-                if(columnName.equalsIgnoreCase("IP") || columnName.equalsIgnoreCase("Host")){
+                if (columnName.equalsIgnoreCase("IP") || columnName.equalsIgnoreCase("Host")) {
                     field = columnName;
                     break;
                 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalog.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalog.java
@@ -63,6 +63,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -239,8 +240,20 @@ public class DorisCatalog extends AbstractCatalog {
             StringJoiner fenodes = new StringJoiner(",");
             PreparedStatement ps = conn.prepareStatement("SHOW FRONTENDS");
             ResultSet resultSet = ps.executeQuery();
+
+            // find target ip column name, Version 1.2 is IP, version 2.x is Host
+            String field = "";
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                String columnName = metaData.getColumnName(i);
+                if(columnName.equalsIgnoreCase("IP") || columnName.equalsIgnoreCase("Host")){
+                    field = columnName;
+                    break;
+                }
+            }
+
             while (resultSet.next()) {
-                String ip = resultSet.getString("IP");
+                String ip = resultSet.getString(field);
                 String port = resultSet.getString("HttpPort");
                 fenodes.add(ip + ":" + port);
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When catalog does not fill in fenodes, the query fe will be displayed. Before 1.2, the IP was returned, and after 2.0, the Host was returned, so it is compatible.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
