### PR TITLE
[fix] Fix NPE when getting map params

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
@@ -148,7 +148,7 @@ public class CdcTools {
 
     private static Map<String, String> getConfigMap(MultipleParameterTool params, String key) {
         if (!params.has(key)) {
-            return null;
+            return new HashMap<>();
         }
 
         Map<String, String> map = new HashMap<>();
@@ -163,7 +163,6 @@ public class CdcTools {
             }
 
             System.err.println("Invalid " + key + " " + param + ".\n");
-            return null;
         }
         return map;
     }


### PR DESCRIPTION
# Proposed changes

close #260

## Problem Summary:

Return a new map instead of null when the key-value parameters are invalid or not specified.

## Checklist(Required)

1. Does it affect the original behavior: (No
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)