### PR TITLE
[fix] Add dist dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ flink-doris-connector/release.properties
 .idea
 *.iml
 *.DS_Store
+dist


### PR DESCRIPTION
## Problem Summary:

The connector jar file was unversioned after building, we should add the dist dir to `.gitignore`.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)