### PR TITLE
[feature][cdc] specify bucket when synchronizing database

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
@@ -218,7 +218,7 @@ public class DorisSystem implements Serializable {
         int skipProNum = 0;
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             // skip table-buckets
-            if (entry.getKey().contains(TABLE_BUCKETS)) {
+            if (entry.getKey().equals(TABLE_BUCKETS)) {
                 skipProNum++;
                 continue;
             }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
@@ -199,7 +199,21 @@ public class DorisSystem implements Serializable {
         // append distribute key
         sb.append(" DISTRIBUTED BY HASH(")
                 .append(String.join(",", identifier(schema.getDistributeKeys())))
-                .append(") BUCKETS AUTO ");
+                .append(")");
+        if (schema.getTableBuckets().isEmpty()) {
+            sb.append(" BUCKETS AUTO ");
+        } else {
+            int bucketsNum;
+            try {
+                bucketsNum = Integer.parseInt(schema.getTableBuckets());
+                if (bucketsNum <= 0) {
+                    throw new CreateTableException("buckets num must be positive ");
+                }
+                sb.append(" BUCKETS ").append(bucketsNum);
+            } catch (NumberFormatException e) {
+                throw new CreateTableException("buckets num must be integer ");
+            }
+        }
 
         // append properties
         int index = 0;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
@@ -203,16 +203,13 @@ public class DorisSystem implements Serializable {
                 .append(")");
 
         Map<String, String> properties = schema.getProperties();
-        if (properties.containsKey(TABLE_BUCKETS)) {
-            try {
-                int bucketsNum = Integer.parseInt(properties.get(TABLE_BUCKETS));
-                if (bucketsNum <= 0) {
-                    throw new CreateTableException("The number of buckets must be positive.");
-                }
-                sb.append(" BUCKETS ").append(bucketsNum);
-            } catch (NumberFormatException e) {
-                throw new CreateTableException("The number of buckets must be an integer.");
+        if (schema.getTableBuckets() != null) {
+
+            int bucketsNum = schema.getTableBuckets();
+            if (bucketsNum <= 0) {
+                throw new CreateTableException("The number of buckets must be positive.");
             }
+            sb.append(" BUCKETS ").append(bucketsNum);
         } else {
             sb.append(" BUCKETS AUTO ");
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/TableSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/TableSchema.java
@@ -30,7 +30,6 @@ public class TableSchema {
     private List<String> keys = new ArrayList<>();
     private DataModel model = DataModel.DUPLICATE;
     private List<String> distributeKeys = new ArrayList<>();
-    private String tableBuckets;
     private Map<String, String> properties = new HashMap<>();
 
     public String getDatabase() {
@@ -91,14 +90,6 @@ public class TableSchema {
 
     public void setDistributeKeys(List<String> distributeKeys) {
         this.distributeKeys = distributeKeys;
-    }
-
-    public String getTableBuckets() {
-        return tableBuckets;
-    }
-
-    public void setTableBuckets(String tableBuckets) {
-        this.tableBuckets = tableBuckets;
     }
 
     public void setProperties(Map<String, String> properties) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/TableSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/TableSchema.java
@@ -32,6 +32,8 @@ public class TableSchema {
     private List<String> distributeKeys = new ArrayList<>();
     private Map<String, String> properties = new HashMap<>();
 
+    private Integer tableBuckets;
+
     public String getDatabase() {
         return database;
     }
@@ -94,5 +96,13 @@ public class TableSchema {
 
     public void setProperties(Map<String, String> properties) {
         this.properties = properties;
+    }
+
+    public void setTableBuckets(Integer tableBuckets) {
+        this.tableBuckets = tableBuckets;
+    }
+
+    public Integer getTableBuckets() {
+        return tableBuckets;
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/TableSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/TableSchema.java
@@ -30,6 +30,7 @@ public class TableSchema {
     private List<String> keys = new ArrayList<>();
     private DataModel model = DataModel.DUPLICATE;
     private List<String> distributeKeys = new ArrayList<>();
+    private String tableBuckets;
     private Map<String, String> properties = new HashMap<>();
 
     public String getDatabase() {
@@ -90,6 +91,14 @@ public class TableSchema {
 
     public void setDistributeKeys(List<String> distributeKeys) {
         this.distributeKeys = distributeKeys;
+    }
+
+    public String getTableBuckets() {
+        return tableBuckets;
+    }
+
+    public void setTableBuckets(String tableBuckets) {
+        this.tableBuckets = tableBuckets;
     }
 
     public void setProperties(Map<String, String> properties) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
@@ -28,6 +28,7 @@ import org.apache.doris.flink.tools.cdc.postgres.PostgresDatabaseSync;
 import org.apache.doris.flink.tools.cdc.sqlserver.SqlServerDatabaseSync;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +39,7 @@ public class CdcTools {
     private static final String ORACLE_SYNC_DATABASE = "oracle-sync-database";
     private static final String POSTGRES_SYNC_DATABASE = "postgres-sync-database";
     private static final String SQLSERVER_SYNC_DATABASE = "sqlserver-sync-database";
-    private static final List<String> EMPTY_KEYS = Arrays.asList("password");
+    private static final List<String> EMPTY_KEYS = Collections.singletonList("password");
 
     public static void main(String[] args) throws Exception {
         String operation = args[0].toLowerCase();
@@ -109,6 +110,7 @@ public class CdcTools {
         String excludingTables = params.get("excluding-tables");
         String multiToOneOrigin = params.get("multi-to-one-origin");
         String multiToOneTarget = params.get("multi-to-one-target");
+        String tableBuckets = params.get("table-buckets");
         boolean createTableOnly = params.has("create-table-only");
         boolean ignoreDefaultValue = params.has("ignore-default-value");
         boolean useNewSchemaChange = params.has("use-new-schema-change");
@@ -135,6 +137,7 @@ public class CdcTools {
                 .setCreateTableOnly(createTableOnly)
                 .setNewSchemaChange(useNewSchemaChange)
                 .setSingleSink(singleSink)
+                .setTableBuckets(tableBuckets)
                 .create();
         databaseSync.build();
         if (StringUtils.isNullOrWhitespaceOnly(jobName)) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
@@ -110,7 +110,6 @@ public class CdcTools {
         String excludingTables = params.get("excluding-tables");
         String multiToOneOrigin = params.get("multi-to-one-origin");
         String multiToOneTarget = params.get("multi-to-one-target");
-        String tableBuckets = params.get("table-buckets");
         boolean createTableOnly = params.has("create-table-only");
         boolean ignoreDefaultValue = params.has("ignore-default-value");
         boolean useNewSchemaChange = params.has("use-new-schema-change");
@@ -137,7 +136,6 @@ public class CdcTools {
                 .setCreateTableOnly(createTableOnly)
                 .setNewSchemaChange(useNewSchemaChange)
                 .setSingleSink(singleSink)
-                .setTableBuckets(tableBuckets)
                 .create();
         databaseSync.build();
         if (StringUtils.isNullOrWhitespaceOnly(jobName)) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -43,9 +43,11 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -117,6 +119,12 @@ public abstract class DatabaseSync {
 
         List<String> syncTables = new ArrayList<>();
         List<String> dorisTables = new ArrayList<>();
+
+        Map<String, Integer> tableBucketsMap = null;
+        if (tableConfig.containsKey("table-buckets")) {
+            tableBucketsMap = getTableBuckets(tableConfig.get("table-buckets"));
+        }
+        Set<String> bucketsTable = new HashSet<>();
         for (SourceSchema schema : schemaList) {
             syncTables.add(schema.getTableName());
             String dorisTable = converter.convert(schema.getTableName());
@@ -129,6 +137,9 @@ public abstract class DatabaseSync {
                 // set doris target database
                 dorisSchema.setDatabase(database);
                 dorisSchema.setTable(dorisTable);
+                if (tableBucketsMap != null) {
+                    setTableSchemaBuckets(tableBucketsMap, dorisSchema, dorisTable, bucketsTable);
+                }
                 dorisSystem.createTable(dorisSchema);
             }
             if (!dorisTables.contains(dorisTable)) {
@@ -336,6 +347,67 @@ public abstract class DatabaseSync {
             System.exit(1);
         }
         return multiToOneRulesPattern;
+    }
+
+    /**
+     * Get table buckets Map.
+     *
+     * @param tableBuckets the string of tableBuckets, eg:student:10,student_info:20,student.*:30
+     * @return The table name and buckets map. The key is table name, the value is buckets.
+     */
+    public Map<String, Integer> getTableBuckets(String tableBuckets) {
+        Map<String, Integer> tableBucketsMap = new HashMap<>();
+        String[] tableBucketsArray = tableBuckets.split(",");
+        for (String tableBucket : tableBucketsArray) {
+            String[] tableBucketArray = tableBucket.split(":");
+            tableBucketsMap.put(
+                    tableBucketArray[0].trim(), Integer.parseInt(tableBucketArray[1].trim()));
+        }
+        return tableBucketsMap;
+    }
+
+    /**
+     * Set table schema buckets.
+     *
+     * @param tableBucketsMap The table name and buckets map. The key is table name, the value is
+     *     buckets.
+     * @param dorisSchema @{TableSchema}
+     * @param dorisTable the table name need to set buckets
+     * @param tableHasSet The buckets table is set
+     */
+    public void setTableSchemaBuckets(
+            Map<String, Integer> tableBucketsMap,
+            TableSchema dorisSchema,
+            String dorisTable,
+            Set<String> tableHasSet) {
+
+        if (tableBucketsMap != null) {
+            // Firstly, if the table name is in the table-buckets map, set the buckets of the table.
+            if (tableBucketsMap.containsKey(dorisTable)) {
+                dorisSchema.setTableBuckets(tableBucketsMap.get(dorisTable));
+                tableHasSet.add(dorisTable);
+                return;
+            }
+            // Secondly, iterate over the map to find a corresponding regular expression match,
+            // excluding .* matches
+            for (Map.Entry<String, Integer> entry : tableBucketsMap.entrySet()) {
+                if (tableHasSet.contains(entry.getKey())) {
+                    continue;
+                }
+
+                Pattern pattern = Pattern.compile(entry.getKey());
+                if (!entry.getKey().equals(".*") && pattern.matcher(dorisTable).matches()) {
+                    dorisSchema.setTableBuckets(entry.getValue());
+                    return;
+                }
+            }
+            // Thirdly, set the number of buckets matched by .* regular expression.
+            if (tableBucketsMap.containsKey(".*")) {
+                Integer num = tableBucketsMap.get(".*");
+                dorisSchema.setTableBuckets(num);
+                tableHasSet.add(dorisTable);
+            }
+        }
     }
 
     public DatabaseSync setEnv(StreamExecutionEnvironment env) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -130,7 +130,6 @@ public abstract class DatabaseSync {
                 // set doris target database
                 dorisSchema.setDatabase(database);
                 dorisSchema.setTable(dorisTable);
-                dorisSchema.setTableBuckets(tableBuckets);
                 dorisSystem.createTable(dorisSchema);
             }
             if (!dorisTables.contains(dorisTable)) {
@@ -412,11 +411,6 @@ public abstract class DatabaseSync {
 
     public DatabaseSync setTableSuffix(String tableSuffix) {
         this.tableSuffix = tableSuffix;
-        return this;
-    }
-
-    public DatabaseSync setTableBuckets(String tableBuckets) {
-        this.tableBuckets = tableBuckets;
         return this;
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -76,6 +76,7 @@ public abstract class DatabaseSync {
     protected String tablePrefix;
     protected String tableSuffix;
     protected boolean singleSink;
+    protected String tableBuckets;
     private Map<String, String> tableMapping = new HashMap<>();
 
     public abstract void registerDriver() throws SQLException;
@@ -129,6 +130,7 @@ public abstract class DatabaseSync {
                 // set doris target database
                 dorisSchema.setDatabase(database);
                 dorisSchema.setTable(dorisTable);
+                dorisSchema.setTableBuckets(tableBuckets);
                 dorisSystem.createTable(dorisSchema);
             }
             if (!dorisTables.contains(dorisTable)) {
@@ -410,6 +412,11 @@ public abstract class DatabaseSync {
 
     public DatabaseSync setTableSuffix(String tableSuffix) {
         this.tableSuffix = tableSuffix;
+        return this;
+    }
+
+    public DatabaseSync setTableBuckets(String tableBuckets) {
+        this.tableBuckets = tableBuckets;
         return this;
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -44,6 +44,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -356,7 +357,7 @@ public abstract class DatabaseSync {
      * @return The table name and buckets map. The key is table name, the value is buckets.
      */
     public Map<String, Integer> getTableBuckets(String tableBuckets) {
-        Map<String, Integer> tableBucketsMap = new HashMap<>();
+        Map<String, Integer> tableBucketsMap = new LinkedHashMap<>();
         String[] tableBucketsArray = tableBuckets.split(",");
         for (String tableBucket : tableBucketsArray) {
             String[] tableBucketArray = tableBucket.split(":");
@@ -389,23 +390,16 @@ public abstract class DatabaseSync {
                 return;
             }
             // Secondly, iterate over the map to find a corresponding regular expression match,
-            // excluding .* matches
             for (Map.Entry<String, Integer> entry : tableBucketsMap.entrySet()) {
                 if (tableHasSet.contains(entry.getKey())) {
                     continue;
                 }
 
                 Pattern pattern = Pattern.compile(entry.getKey());
-                if (!entry.getKey().equals(".*") && pattern.matcher(dorisTable).matches()) {
+                if (pattern.matcher(dorisTable).matches()) {
                     dorisSchema.setTableBuckets(entry.getValue());
                     return;
                 }
-            }
-            // Thirdly, set the number of buckets matched by .* regular expression.
-            if (tableBucketsMap.containsKey(".*")) {
-                Integer num = tableBucketsMap.get(".*");
-                dorisSchema.setTableBuckets(num);
-                tableHasSet.add(dorisTable);
             }
         }
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -398,6 +398,7 @@ public abstract class DatabaseSync {
                 Pattern pattern = Pattern.compile(entry.getKey());
                 if (pattern.matcher(dorisTable).matches()) {
                     dorisSchema.setTableBuckets(entry.getValue());
+                    tableHasSet.add(dorisTable);
                     return;
                 }
             }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -76,7 +76,6 @@ public abstract class DatabaseSync {
     protected String tablePrefix;
     protected String tableSuffix;
     protected boolean singleSink;
-    protected String tableBuckets;
     private Map<String, String> tableMapping = new HashMap<>();
 
     public abstract void registerDriver() throws SQLException;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/SourceSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/SourceSchema.java
@@ -138,7 +138,7 @@ public abstract class SourceSchema {
         return tableName;
     }
 
-    public LinkedHashMap<String, FieldSchema> getFields() {
+    public Map<String, FieldSchema> getFields() {
         return fields;
     }
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
@@ -64,7 +64,7 @@ public class CdcMysqlSyncDatabaseCase {
 
         Map<String, String> tableConfig = new HashMap<>();
         tableConfig.put("replication_num", "1");
-        //        tableConfig.put("table-buckets","50");
+        tableConfig.put("table-buckets", "tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50");
         // String includingTables = "tbl1|tbl2|tbl3";
         String includingTables = "a_.*|b_.*|c";
         String excludingTables = "";

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
@@ -65,7 +65,7 @@ public class CdcMysqlSyncDatabaseCase {
 
         Map<String, String> tableConfig = new HashMap<>();
         tableConfig.put("replication_num", "1");
-
+        //        tableConfig.put("table-buckets","50");
         // String includingTables = "tbl1|tbl2|tbl3";
         String includingTables = "a_.*|b_.*|c";
         String excludingTables = "";
@@ -89,7 +89,6 @@ public class CdcMysqlSyncDatabaseCase {
                 .setTableConfig(tableConfig)
                 .setCreateTableOnly(false)
                 .setNewSchemaChange(useNewSchemaChange)
-                .setTableBuckets(tableBuckets)
                 .create();
         databaseSync.build();
         env.execute(String.format("MySQL-Doris Database Sync: %s", database));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
@@ -44,7 +44,6 @@ public class CdcMysqlSyncDatabaseCase {
         String database = "db1";
         String tablePrefix = "";
         String tableSuffix = "";
-        String tableBuckets = "10";
         Map<String, String> mysqlConfig = new HashMap<>();
         mysqlConfig.put("database-name", "db1");
         mysqlConfig.put("hostname", "127.0.0.1");

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
@@ -44,6 +44,7 @@ public class CdcMysqlSyncDatabaseCase {
         String database = "db1";
         String tablePrefix = "";
         String tableSuffix = "";
+        String tableBuckets = "10";
         Map<String, String> mysqlConfig = new HashMap<>();
         mysqlConfig.put("database-name", "db1");
         mysqlConfig.put("hostname", "127.0.0.1");
@@ -88,6 +89,7 @@ public class CdcMysqlSyncDatabaseCase {
                 .setTableConfig(tableConfig)
                 .setCreateTableOnly(false)
                 .setNewSchemaChange(useNewSchemaChange)
+                .setTableBuckets(tableBuckets)
                 .create();
         databaseSync.build();
         env.execute(String.format("MySQL-Doris Database Sync: %s", database));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcOraclelSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcOraclelSyncDatabaseCase.java
@@ -69,7 +69,7 @@ public class CdcOraclelSyncDatabaseCase {
 
         Map<String, String> tableConfig = new HashMap<>();
         tableConfig.put("replication_num", "1");
-        //        tableConfig.put("table-buckets","50");
+        tableConfig.put("table-buckets", "tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50");
         String includingTables = "a_.*|b_.*|c";
         String excludingTables = "";
         String multiToOneOrigin = "a_.*|b_.*";

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcOraclelSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcOraclelSyncDatabaseCase.java
@@ -46,6 +46,7 @@ public class CdcOraclelSyncDatabaseCase {
         String database = "db1";
         String tablePrefix = "";
         String tableSuffix = "";
+        String tableBuckets = "10";
         Map<String, String> sourceConfig = new HashMap<>();
         sourceConfig.put("database-name", "XE");
         sourceConfig.put("schema-name", "ADMIN");
@@ -92,6 +93,7 @@ public class CdcOraclelSyncDatabaseCase {
                 .setTableConfig(tableConfig)
                 .setCreateTableOnly(false)
                 .setNewSchemaChange(useNewSchemaChange)
+                .setTableBuckets(tableBuckets)
                 .create();
         databaseSync.build();
         env.execute(String.format("Oracle-Doris Database Sync: %s", database));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcOraclelSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcOraclelSyncDatabaseCase.java
@@ -46,7 +46,6 @@ public class CdcOraclelSyncDatabaseCase {
         String database = "db1";
         String tablePrefix = "";
         String tableSuffix = "";
-        String tableBuckets = "10";
         Map<String, String> sourceConfig = new HashMap<>();
         sourceConfig.put("database-name", "XE");
         sourceConfig.put("schema-name", "ADMIN");
@@ -70,7 +69,7 @@ public class CdcOraclelSyncDatabaseCase {
 
         Map<String, String> tableConfig = new HashMap<>();
         tableConfig.put("replication_num", "1");
-
+        //        tableConfig.put("table-buckets","50");
         String includingTables = "a_.*|b_.*|c";
         String excludingTables = "";
         String multiToOneOrigin = "a_.*|b_.*";
@@ -93,7 +92,6 @@ public class CdcOraclelSyncDatabaseCase {
                 .setTableConfig(tableConfig)
                 .setCreateTableOnly(false)
                 .setNewSchemaChange(useNewSchemaChange)
-                .setTableBuckets(tableBuckets)
                 .create();
         databaseSync.build();
         env.execute(String.format("Oracle-Doris Database Sync: %s", database));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcPostgresSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcPostgresSyncDatabaseCase.java
@@ -72,7 +72,7 @@ public class CdcPostgresSyncDatabaseCase {
 
         Map<String, String> tableConfig = new HashMap<>();
         tableConfig.put("replication_num", "1");
-
+        tableConfig.put("table-buckets", "tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50");
         String includingTables = "a_.*|b_.*|c";
         String excludingTables = "";
         String multiToOneOrigin = "a_.*|b_.*";

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcPostgresSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcPostgresSyncDatabaseCase.java
@@ -46,6 +46,7 @@ public class CdcPostgresSyncDatabaseCase {
         String database = "db2";
         String tablePrefix = "";
         String tableSuffix = "";
+        String tableBuckets = "10";
         Map<String, String> sourceConfig = new HashMap<>();
         sourceConfig.put("database-name", "postgres");
         sourceConfig.put("schema-name", "public");
@@ -95,6 +96,7 @@ public class CdcPostgresSyncDatabaseCase {
                 .setTableConfig(tableConfig)
                 .setCreateTableOnly(false)
                 .setNewSchemaChange(useNewSchemaChange)
+                .setTableBuckets(tableBuckets)
                 .create();
         databaseSync.build();
         env.execute(String.format("Postgres-Doris Database Sync: %s", database));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcPostgresSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcPostgresSyncDatabaseCase.java
@@ -46,7 +46,6 @@ public class CdcPostgresSyncDatabaseCase {
         String database = "db2";
         String tablePrefix = "";
         String tableSuffix = "";
-        String tableBuckets = "10";
         Map<String, String> sourceConfig = new HashMap<>();
         sourceConfig.put("database-name", "postgres");
         sourceConfig.put("schema-name", "public");
@@ -96,7 +95,6 @@ public class CdcPostgresSyncDatabaseCase {
                 .setTableConfig(tableConfig)
                 .setCreateTableOnly(false)
                 .setNewSchemaChange(useNewSchemaChange)
-                .setTableBuckets(tableBuckets)
                 .create();
         databaseSync.build();
         env.execute(String.format("Postgres-Doris Database Sync: %s", database));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcSqlServerSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcSqlServerSyncDatabaseCase.java
@@ -46,7 +46,6 @@ public class CdcSqlServerSyncDatabaseCase {
         String database = "db2";
         String tablePrefix = "";
         String tableSuffix = "";
-        String tableBuckets = "10";
         Map<String, String> sourceConfig = new HashMap<>();
         sourceConfig.put("database-name", "CDC_DB");
         sourceConfig.put("schema-name", "dbo");

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcSqlServerSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcSqlServerSyncDatabaseCase.java
@@ -46,6 +46,7 @@ public class CdcSqlServerSyncDatabaseCase {
         String database = "db2";
         String tablePrefix = "";
         String tableSuffix = "";
+        String tableBuckets = "10";
         Map<String, String> sourceConfig = new HashMap<>();
         sourceConfig.put("database-name", "CDC_DB");
         sourceConfig.put("schema-name", "dbo");
@@ -93,6 +94,7 @@ public class CdcSqlServerSyncDatabaseCase {
                 .setTableConfig(tableConfig)
                 .setCreateTableOnly(false)
                 .setNewSchemaChange(useNewSchemaChange)
+                .setTableBuckets(tableBuckets)
                 .create();
         databaseSync.build();
         env.execute(String.format("SqlServer-Doris Database Sync: %s", database));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcSqlServerSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcSqlServerSyncDatabaseCase.java
@@ -71,7 +71,7 @@ public class CdcSqlServerSyncDatabaseCase {
 
         Map<String, String> tableConfig = new HashMap<>();
         tableConfig.put("replication_num", "1");
-
+        //        tableConfig.put("table-buckets","50");
         String includingTables = "a_.*|b_.*|c";
         String excludingTables = "";
         String multiToOneOrigin = "a_.*|b_.*";
@@ -94,7 +94,6 @@ public class CdcSqlServerSyncDatabaseCase {
                 .setTableConfig(tableConfig)
                 .setCreateTableOnly(false)
                 .setNewSchemaChange(useNewSchemaChange)
-                .setTableBuckets(tableBuckets)
                 .create();
         databaseSync.build();
         env.execute(String.format("SqlServer-Doris Database Sync: %s", database));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcSqlServerSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcSqlServerSyncDatabaseCase.java
@@ -70,7 +70,7 @@ public class CdcSqlServerSyncDatabaseCase {
 
         Map<String, String> tableConfig = new HashMap<>();
         tableConfig.put("replication_num", "1");
-        //        tableConfig.put("table-buckets","50");
+        tableConfig.put("table-buckets", "tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50");
         String includingTables = "a_.*|b_.*|c";
         String excludingTables = "";
         String multiToOneOrigin = "a_.*|b_.*";

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/DatabaseSyncTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/DatabaseSyncTest.java
@@ -19,11 +19,19 @@ package org.apache.doris.flink.tools.cdc;
 
 import org.apache.flink.configuration.Configuration;
 
+import org.apache.doris.flink.catalog.doris.TableSchema;
 import org.apache.doris.flink.tools.cdc.mysql.MysqlDatabaseSync;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /** Unit tests for the {@link DatabaseSync}. */
 public class DatabaseSyncTest {
@@ -54,5 +62,53 @@ public class DatabaseSyncTest {
         databaseSync.setConfig(config);
         String syncTableList = databaseSync.getSyncTableList(Arrays.asList("tbl_1", "tbl_2"));
         Assert.assertEquals("db\\.tbl_1|db\\.tbl_2", syncTableList);
+    }
+
+    @Test
+    public void getTableBucketsTest() throws SQLException {
+        String tableBuckets = "tbl1:10,tbl2 : 20,a.* :30,b.*:40,.*:50";
+        DatabaseSync databaseSync = new MysqlDatabaseSync();
+        Map<String, Integer> tableBucketsMap = databaseSync.getTableBuckets(tableBuckets);
+        Assert.assertEquals(10, tableBucketsMap.get("tbl1").intValue());
+        Assert.assertEquals(20, tableBucketsMap.get("tbl2").intValue());
+        Assert.assertEquals(30, tableBucketsMap.get("a.*").intValue());
+        Assert.assertEquals(40, tableBucketsMap.get("b.*").intValue());
+        Assert.assertEquals(50, tableBucketsMap.get(".*").intValue());
+    }
+
+    @Test
+    public void setTableSchemaBucketsTest() throws SQLException {
+        DatabaseSync databaseSync = new MysqlDatabaseSync();
+        String tableSchemaBuckets = "tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50";
+        Map<String, Integer> tableBucketsMap = databaseSync.getTableBuckets(tableSchemaBuckets);
+        List<String> tableList =
+                Arrays.asList(
+                        "tbl1", "tbl2", "tbl3", "tbl4", "a1", "a2", "b1", "b2", "c1", "c2", "d1");
+        HashMap<String, Integer> matchedTableBucketsMap = mockTableBuckets();
+        Set<String> tableSet = new HashSet<>();
+        for (String tableName : tableList) {
+            TableSchema tableSchema = new TableSchema();
+            tableSchema.setTable(tableName);
+            databaseSync.setTableSchemaBuckets(tableBucketsMap, tableSchema, tableName, tableSet);
+            Assert.assertEquals(
+                    matchedTableBucketsMap.get(tableName), tableSchema.getTableBuckets());
+        }
+    }
+
+    @NotNull
+    private static HashMap<String, Integer> mockTableBuckets() {
+        HashMap<String, Integer> matchedTableBucketsMap = new HashMap<>();
+        matchedTableBucketsMap.put("tbl1", 10);
+        matchedTableBucketsMap.put("tbl2", 20);
+        matchedTableBucketsMap.put("a1", 30);
+        matchedTableBucketsMap.put("a2", 30);
+        matchedTableBucketsMap.put("b1", 40);
+        matchedTableBucketsMap.put("b2", 40);
+        matchedTableBucketsMap.put("c1", 50);
+        matchedTableBucketsMap.put("c2", 50);
+        matchedTableBucketsMap.put("d1", 50);
+        matchedTableBucketsMap.put("tbl3", 50);
+        matchedTableBucketsMap.put("tbl4", 50);
+        return matchedTableBucketsMap;
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/DatabaseSyncTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/DatabaseSyncTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.doris.flink.catalog.doris.TableSchema;
 import org.apache.doris.flink.tools.cdc.mysql.MysqlDatabaseSync;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -32,6 +31,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
 
 /** Unit tests for the {@link DatabaseSync}. */
 public class DatabaseSyncTest {
@@ -61,38 +62,60 @@ public class DatabaseSyncTest {
         config.setString("table-name", "tbl.*");
         databaseSync.setConfig(config);
         String syncTableList = databaseSync.getSyncTableList(Arrays.asList("tbl_1", "tbl_2"));
-        Assert.assertEquals("db\\.tbl_1|db\\.tbl_2", syncTableList);
+        assertEquals("db\\.tbl_1|db\\.tbl_2", syncTableList);
     }
 
     @Test
     public void getTableBucketsTest() throws SQLException {
-        String tableBuckets = "tbl1:10,tbl2 : 20,a.* :30,b.*:40,.*:50";
+        String tableBuckets = "tbl1:10,tbl2 : 20, a.* :30,b.*:40,.*:50";
         DatabaseSync databaseSync = new MysqlDatabaseSync();
         Map<String, Integer> tableBucketsMap = databaseSync.getTableBuckets(tableBuckets);
-        Assert.assertEquals(10, tableBucketsMap.get("tbl1").intValue());
-        Assert.assertEquals(20, tableBucketsMap.get("tbl2").intValue());
-        Assert.assertEquals(30, tableBucketsMap.get("a.*").intValue());
-        Assert.assertEquals(40, tableBucketsMap.get("b.*").intValue());
-        Assert.assertEquals(50, tableBucketsMap.get(".*").intValue());
+        assertEquals(10, tableBucketsMap.get("tbl1").intValue());
+        assertEquals(20, tableBucketsMap.get("tbl2").intValue());
+        assertEquals(30, tableBucketsMap.get("a.*").intValue());
+        assertEquals(40, tableBucketsMap.get("b.*").intValue());
+        assertEquals(50, tableBucketsMap.get(".*").intValue());
     }
 
     @Test
     public void setTableSchemaBucketsTest() throws SQLException {
         DatabaseSync databaseSync = new MysqlDatabaseSync();
-        String tableSchemaBuckets = "tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50";
+        String tableSchemaBuckets = "tbl1:10,tbl2:20,a11.*:30,a1.*:40,b.*:50,b1.*:60,.*:70";
         Map<String, Integer> tableBucketsMap = databaseSync.getTableBuckets(tableSchemaBuckets);
         List<String> tableList =
                 Arrays.asList(
-                        "tbl1", "tbl2", "tbl3", "tbl4", "a1", "a2", "b1", "b2", "c1", "c2", "d1");
+                        "tbl1", "tbl2", "tbl3", "a11", "a111", "a12", "a13", "b1", "b11", "b2",
+                        "c1", "d1");
         HashMap<String, Integer> matchedTableBucketsMap = mockTableBuckets();
         Set<String> tableSet = new HashSet<>();
-        for (String tableName : tableList) {
-            TableSchema tableSchema = new TableSchema();
-            tableSchema.setTable(tableName);
-            databaseSync.setTableSchemaBuckets(tableBucketsMap, tableSchema, tableName, tableSet);
-            Assert.assertEquals(
-                    matchedTableBucketsMap.get(tableName), tableSchema.getTableBuckets());
-        }
+        tableList.forEach(
+                tableName -> {
+                    TableSchema tableSchema = new TableSchema();
+                    tableSchema.setTable(tableName);
+                    databaseSync.setTableSchemaBuckets(
+                            tableBucketsMap, tableSchema, tableName, tableSet);
+                    assertEquals(
+                            matchedTableBucketsMap.get(tableName), tableSchema.getTableBuckets());
+                });
+    }
+
+    @Test
+    public void setTableSchemaBucketsTest1() throws SQLException {
+        DatabaseSync databaseSync = new MysqlDatabaseSync();
+        String tableSchemaBuckets = ".*:10,a.*:20,tbl:30,b.*:40";
+        Map<String, Integer> tableBucketsMap = databaseSync.getTableBuckets(tableSchemaBuckets);
+        List<String> tableList = Arrays.asList("a1", "a2", "a3", "b1", "a");
+        HashMap<String, Integer> matchedTableBucketsMap = mockTableBuckets1();
+        Set<String> tableSet = new HashSet<>();
+        tableList.forEach(
+                tableName -> {
+                    TableSchema tableSchema = new TableSchema();
+                    tableSchema.setTable(tableName);
+                    databaseSync.setTableSchemaBuckets(
+                            tableBucketsMap, tableSchema, tableName, tableSet);
+                    assertEquals(
+                            matchedTableBucketsMap.get(tableName), tableSchema.getTableBuckets());
+                });
     }
 
     @NotNull
@@ -100,15 +123,28 @@ public class DatabaseSyncTest {
         HashMap<String, Integer> matchedTableBucketsMap = new HashMap<>();
         matchedTableBucketsMap.put("tbl1", 10);
         matchedTableBucketsMap.put("tbl2", 20);
-        matchedTableBucketsMap.put("a1", 30);
-        matchedTableBucketsMap.put("a2", 30);
-        matchedTableBucketsMap.put("b1", 40);
-        matchedTableBucketsMap.put("b2", 40);
-        matchedTableBucketsMap.put("c1", 50);
-        matchedTableBucketsMap.put("c2", 50);
-        matchedTableBucketsMap.put("d1", 50);
-        matchedTableBucketsMap.put("tbl3", 50);
-        matchedTableBucketsMap.put("tbl4", 50);
+        matchedTableBucketsMap.put("a11", 30);
+        matchedTableBucketsMap.put("a111", 30);
+        matchedTableBucketsMap.put("a12", 40);
+        matchedTableBucketsMap.put("a13", 40);
+        matchedTableBucketsMap.put("b1", 50);
+        matchedTableBucketsMap.put("b11", 50);
+        matchedTableBucketsMap.put("b2", 50);
+        matchedTableBucketsMap.put("c1", 70);
+        matchedTableBucketsMap.put("d1", 70);
+        matchedTableBucketsMap.put("tbl3", 70);
+        return matchedTableBucketsMap;
+    }
+
+    @NotNull
+    private static HashMap<String, Integer> mockTableBuckets1() {
+        HashMap<String, Integer> matchedTableBucketsMap = new HashMap<>();
+        matchedTableBucketsMap.put("a", 10);
+        matchedTableBucketsMap.put("a1", 10);
+        matchedTableBucketsMap.put("a2", 10);
+        matchedTableBucketsMap.put("a3", 10);
+        matchedTableBucketsMap.put("b1", 10);
+        matchedTableBucketsMap.put("tbl1", 10);
         return matchedTableBucketsMap;
     }
 }


### PR DESCRIPTION
# Proposed changes

The `--table-conf  table-buckets = table1:num1,table2:num2,tbl.*:num3,.*:num4` option can be used to specify the number of buckets for different tables when synchronizing databases and specifying buckets. Therefore, the number of buckets for `table1` and `table2` is represented by `num1`and `num2` respectively. All buckets prefixed with `tbl1` are assigned the value of `num3`, while all other buckets are assigned the value of `num4`.

```sql
bin/flink run \
    -Dexecution.checkpointing.interval=10s \
    -Dparallelism.default=1 \
    -c org.apache.doris.flink.tools.cdc.CdcTools \
    lib/flink-doris-connector-1.17-1.5.0-SNAPSHOT.jar \
    mysql-sync-database \
    --database student_cdc \
    --mysql-conf hostname=127.0.0.1 \
    --mysql-conf port=3306 \
    --mysql-conf username=root \
    --mysql-conf password=123456 \
    --mysql-conf database-name=demo \
    --sink-conf fenodes=127.0.0.1:8030 \
    --sink-conf username=root \
    --sink-conf password=123456 \
    --sink-conf jdbc-url=jdbc:mysql://127.0.0.1:9030 \
    --sink-conf sink.label-prefix=label \
    --table-conf replication_num=1  \
    --table-conf table-buckets="student:10,student_info:20,e.*:30,c.*40,.*:50"
```



Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
