### PR TITLE
[catalog] add array map json type for flink catalog

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalog.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalog.java
@@ -283,7 +283,6 @@ public class DorisCatalog extends AbstractCatalog {
                 String columnType = resultSet.getString("DATA_TYPE");
                 long columnSize = resultSet.getLong("COLUMN_SIZE");
                 long columnDigit = resultSet.getLong("DECIMAL_DIGITS");
-
                 DataType flinkType =
                         DorisTypeMapper.toFlinkType(
                                 columnName, columnType, (int) columnSize, (int) columnDigit);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisTypeMapper.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisTypeMapper.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
 
 import org.apache.doris.flink.catalog.doris.DorisType;
 
+import static org.apache.doris.flink.catalog.doris.DorisType.ARRAY;
 import static org.apache.doris.flink.catalog.doris.DorisType.BIGINT;
 import static org.apache.doris.flink.catalog.doris.DorisType.BOOLEAN;
 import static org.apache.doris.flink.catalog.doris.DorisType.CHAR;
@@ -52,10 +53,13 @@ import static org.apache.doris.flink.catalog.doris.DorisType.DECIMAL_V3;
 import static org.apache.doris.flink.catalog.doris.DorisType.DOUBLE;
 import static org.apache.doris.flink.catalog.doris.DorisType.FLOAT;
 import static org.apache.doris.flink.catalog.doris.DorisType.INT;
+import static org.apache.doris.flink.catalog.doris.DorisType.JSON;
 import static org.apache.doris.flink.catalog.doris.DorisType.JSONB;
 import static org.apache.doris.flink.catalog.doris.DorisType.LARGEINT;
+import static org.apache.doris.flink.catalog.doris.DorisType.MAP;
 import static org.apache.doris.flink.catalog.doris.DorisType.SMALLINT;
 import static org.apache.doris.flink.catalog.doris.DorisType.STRING;
+import static org.apache.doris.flink.catalog.doris.DorisType.STRUCT;
 import static org.apache.doris.flink.catalog.doris.DorisType.TINYINT;
 import static org.apache.doris.flink.catalog.doris.DorisType.VARCHAR;
 
@@ -101,6 +105,12 @@ public class DorisTypeMapper {
             case LARGEINT:
             case STRING:
             case JSONB:
+            case JSON:
+                // Currently, the subtype of the generic cannot be obtained,
+                // so it is mapped to string
+            case ARRAY:
+            case MAP:
+            case STRUCT:
                 return DataTypes.STRING();
             case DATE:
             case DATE_V2:

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisType.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisType.java
@@ -39,4 +39,7 @@ public class DorisType {
     public static final String BITMAP = "BITMAP";
     public static final String ARRAY = "ARRAY";
     public static final String JSONB = "JSONB";
+    public static final String JSON = "JSON";
+    public static final String MAP = "MAP";
+    public static final String STRUCT = "STRUCT";
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/catalog/CatalogExample.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/catalog/CatalogExample.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.catalog;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+
+public class CatalogExample {
+
+    public static void main(String[] args) throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        tEnv.executeSql(
+                "CREATE CATALOG doris_catalog WITH(\n"
+                        + "'type' = 'doris',\n"
+                        + "'default-database' = 'test',\n"
+                        + "'username' = 'root',\n"
+                        + "'password' = '',\n"
+                        + "'fenodes' = '1127.0.0.1:8030',\n"
+                        + "'jdbc-url' = 'jdbc:mysql://127.0.0.1:9030',\n"
+                        + "'sink.label-prefix' = 'label'\n"
+                        + ")");
+        // define a dynamic aggregating query
+        final Table result = tEnv.sqlQuery("SELECT * from doris_catalog.test.type_test");
+
+        // print the result to the console
+        tEnv.toRetractStream(result, Row.class).print();
+        env.execute();
+    }
+}


### PR DESCRIPTION
# Proposed changes
When accessing the table through flink catalog, array, map, json and other types will report errors.
[ERROR] Could not execute SQL statement. Reason:
java.lang.UnsupportedOperationException: Doesn't support Doris type 'ARRAY' on column 'c_column'

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
