### PR TITLE
[fix](cdc) fix datetime precision and regular matching format errors after turning on single-sink

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumSchemaChangeImplV2.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumSchemaChangeImplV2.java
@@ -337,6 +337,9 @@ public class JsonDebeziumSchemaChangeImplV2 extends JsonDebeziumSchemaChange {
         String dorisTypeName;
         switch (sourceConnector) {
             case MYSQL:
+                if (sourceTypeName.equals("DATETIME") || sourceTypeName.equals("TIMESTAMP")) {
+                    length = 20 + length;
+                }
                 dorisTypeName = MysqlType.toDorisType(sourceTypeName, length, scale);
                 break;
             case ORACLE:

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -79,7 +79,7 @@ public abstract class DatabaseSync {
     protected String tablePrefix;
     protected String tableSuffix;
     protected boolean singleSink;
-    private Map<String, String> tableMapping = new HashMap<>();
+    private final Map<String, String> tableMapping = new HashMap<>();
 
     public abstract void registerDriver() throws SQLException;
 
@@ -92,7 +92,7 @@ public abstract class DatabaseSync {
     /** Get the prefix of a specific tableList, for example, mysql is database, oracle is schema. */
     public abstract String getTableListPrefix();
 
-    public DatabaseSync() throws SQLException {
+    protected DatabaseSync() throws SQLException {
         registerDriver();
     }
 
@@ -312,6 +312,9 @@ public abstract class DatabaseSync {
                     .collect(Collectors.joining("|"));
         } else {
             // includingTablePattern and ^excludingPattern
+            if (includingTables == null) {
+                includingTables = ".*";
+            }
             String includingPattern =
                     String.format("(%s)\\.(%s)", getTableListPrefix(), includingTables);
             if (StringUtils.isNullOrWhitespaceOnly(excludingTables)) {


### PR DESCRIPTION
when synchronizing the entire database  use `single-sink`, the following two problems will occur:
1. MySQL DATETIME/TIMESTAMP precision mapping error.

3. When including_tables is null, it will cause a regular expression format error，for example:
```java
org.apache.flink.util.FlinkRuntimeException: Failed to discovery tables to capture
	at com.ververica.cdc.connectors.mysql.source.assigners.MySqlSnapshotSplitAssigner.discoveryCaptureTables(MySqlSnapshotSplitAssigner.java:197)
	at com.ververica.cdc.connectors.mysql.source.assigners.MySqlSnapshotSplitAssigner.open(MySqlSnapshotSplitAssigner.java:182)
	at com.ververica.cdc.connectors.mysql.source.assigners.MySqlHybridSplitAssigner.open(MySqlHybridSplitAssigner.java:93)
	at com.ververica.cdc.connectors.mysql.source.enumerator.MySqlSourceEnumerator.start(MySqlSourceEnumerator.java:92)
	at org.apache.flink.runtime.source.coordinator.SourceCoordinator.lambda$start$1(SourceCoordinator.java:233)
	at org.apache.flink.runtime.source.coordinator.SourceCoordinator.lambda$runInEventLoop$10(SourceCoordinator.java:469)
	at org.apache.flink.util.ThrowableCatchingRunnable.run(ThrowableCatchingRunnable.java:40)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.IllegalArgumentException: Can't find any matched tables, please check your configured database-name: [test_cdc] and table-name: [(test_cdc)\.(null)]
	at com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.discoverCapturedTables(DebeziumUtils.java:196)
	at com.ververica.cdc.connectors.mysql.source.assigners.MySqlSnapshotSplitAssigner.discoveryCaptureTables(MySqlSnapshotSplitAssigner.java:193)
	... 13 more
```
Thus, when `including_tables` is null, you can set `including-tables= '.*'` to solve this problem.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
