### PR TITLE
[fix](cdc)fix the error mapping default values from RDBMS to Doris

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
@@ -249,13 +249,8 @@ public class DorisSystem implements Serializable {
                     String.format("%s(%s)", DorisType.VARCHAR, DorisTypeMapper.MAX_VARCHAR_SIZE);
         }
         sql.append(identifier(field.getName())).append(" ").append(fieldType);
-        // The nextval() is a built-in function in PostgreSQL that allows the use of sequences
-        // on the database to automatically set values by incrementing the set of default
-        // values.
-        // Tus, we can't use nextval() as a default value for numeric columns in Doris.
-        // see https://www.postgresql.org/docs/current/ddl-default.html
         String defaultValue = field.getDefaultValue();
-        if (defaultValue != null && !defaultValue.toUpperCase().contains("NEXTVAL(")) {
+        if (defaultValue != null) {
             sql.append(" DEFAULT ").append(quoteDefaultValue(defaultValue));
         }
         sql.append(" COMMENT '").append(quoteComment(field.getComment())).append("',");

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/TableSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/TableSchema.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 public class TableSchema {
+    public static final String TABLE_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]*$";
     private String database;
     private String table;
     private String tableComment;
@@ -31,7 +32,6 @@ public class TableSchema {
     private DataModel model = DataModel.DUPLICATE;
     private List<String> distributeKeys = new ArrayList<>();
     private Map<String, String> properties = new HashMap<>();
-
     private Integer tableBuckets;
 
     public String getDatabase() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/SourceSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/SourceSchema.java
@@ -19,7 +19,9 @@ package org.apache.doris.flink.tools.cdc;
 
 import org.apache.flink.util.StringUtils;
 
+import org.apache.doris.flink.catalog.DorisTypeMapper;
 import org.apache.doris.flink.catalog.doris.DataModel;
+import org.apache.doris.flink.catalog.doris.DorisType;
 import org.apache.doris.flink.catalog.doris.FieldSchema;
 import org.apache.doris.flink.catalog.doris.TableSchema;
 
@@ -33,6 +35,9 @@ import java.util.Map;
 import java.util.StringJoiner;
 
 public abstract class SourceSchema {
+    public static final String DEFAULT_FUNCTION_REGEX = ".*\\(.*\\)";
+    public static final String DEFAULT_STRING_SINGLE_QUOTE = "(?<!')'";
+    public static final String DEFAULT_CURRENT_TIMESTAMP = "CURRENT_TIMESTAMP";
     private final String databaseName;
     private final String schemaName;
     private final String tableName;
@@ -50,9 +55,8 @@ public abstract class SourceSchema {
             throws Exception {
         this.databaseName = databaseName;
         this.schemaName = schemaName;
-        this.tableName = tableName;
         this.tableComment = tableComment;
-
+        // Oracle support '/' in table name, we give it a special treatment
         fields = new LinkedHashMap<>();
         try (ResultSet rs = metaData.getColumns(databaseName, schemaName, tableName, null)) {
             while (rs.next()) {
@@ -70,8 +74,10 @@ public abstract class SourceSchema {
                     scale = null;
                 }
                 String dorisTypeStr = convertToDorisType(fieldType, precision, scale);
+                String convertedDefault = convertToDoriDefaultValue(defaultValue, dorisTypeStr);
                 fields.put(
-                        fieldName, new FieldSchema(fieldName, dorisTypeStr, defaultValue, comment));
+                        fieldName,
+                        new FieldSchema(fieldName, dorisTypeStr, convertedDefault, comment));
             }
         }
 
@@ -82,6 +88,101 @@ public abstract class SourceSchema {
                 primaryKeys.add(fieldName);
             }
         }
+        this.tableName = tableName.replace("%", "_");
+    }
+
+    public String convertToDoriDefaultValue(String defaultStr, String dorisType) {
+        if (defaultStr == null) {
+            return null;
+        }
+        String dorisTypeStrUpperCase = dorisType.toUpperCase();
+        switch (dorisTypeStrUpperCase) {
+            case DorisType.TINYINT:
+            case DorisType.SMALLINT:
+            case DorisType.INT:
+            case DorisType.BIGINT:
+            case DorisType.LARGEINT:
+            case DorisType.DOUBLE:
+                return convertNoDateTimeDefault(defaultStr, dorisType);
+            case DorisType.JSON:
+            case DorisType.JSONB:
+                return convertStringDefault(defaultStr, dorisType);
+            default:
+                if (dorisTypeStrUpperCase.startsWith(DorisType.CHAR)
+                        || dorisTypeStrUpperCase.startsWith(DorisType.VARCHAR)
+                        || dorisTypeStrUpperCase.startsWith(DorisType.STRING)) {
+                    return convertStringDefault(defaultStr, dorisType);
+                } else if (dorisTypeStrUpperCase.startsWith(DorisType.DATETIME)
+                        || dorisTypeStrUpperCase.startsWith(DorisType.DATETIME_V2)) {
+                    return convertDateTimeDefault(defaultStr, dorisType);
+                } else if (dorisTypeStrUpperCase.startsWith(DorisType.DECIMAL)
+                        || dorisTypeStrUpperCase.startsWith(DorisType.DECIMAL_V3)) {
+                    return convertNoDateTimeDefault(defaultStr, dorisType);
+                } else if (dorisTypeStrUpperCase.startsWith(DorisType.DATE)
+                        || dorisTypeStrUpperCase.startsWith(DorisType.DATE_V2)) {
+                    return convertDateTimeDefault(defaultStr, dorisType);
+                }
+                return null;
+        }
+    }
+
+    /**
+     * Convert default value of numeric type to Doris type. In MySQL8.x, the default function may
+     * like `((rand() * rand()))`, `((curdate() + interval 1 year))`, etc. We can't convert these
+     * default value to Doris default value, so we return null.
+     *
+     * @param defaultStr default value of source Database
+     * @param dorisType the type of the field in Doris
+     */
+    public String convertNoDateTimeDefault(String defaultStr, String dorisType) {
+        if (defaultStr.matches(DEFAULT_FUNCTION_REGEX)) {
+            return null;
+        }
+        return defaultStr.replaceAll(DEFAULT_STRING_SINGLE_QUOTE, "").replace(" ", "");
+    }
+
+    public String convertDateTimeDefault(String defaultStr, String dorisType) {
+        String defaultStrUpperCase = defaultStr.toUpperCase();
+        if (defaultStrUpperCase.startsWith(DEFAULT_CURRENT_TIMESTAMP)) {
+            long length = 0;
+            int startIndex = defaultStrUpperCase.indexOf('(') + 1;
+            int endIndex = defaultStrUpperCase.indexOf(')');
+            // In MariaDB, the CURRENT_TIMESTAMP() is the same as CURRENT_TIMESTAMP(0) in MySQL.
+            if (endIndex >= 0) {
+                String substring = defaultStrUpperCase.substring(startIndex, endIndex).trim();
+                length = substring.isEmpty() ? 0 : Long.parseLong(substring);
+                if (length > DorisTypeMapper.MAX_SUPPORTED_DATE_TIME_PRECISION) {
+                    length = DorisTypeMapper.MAX_SUPPORTED_DATE_TIME_PRECISION;
+                }
+            }
+            return String.format("CURRENT_TIMESTAMP(%d)", length);
+        } else if (defaultStrUpperCase.matches(DEFAULT_FUNCTION_REGEX)) {
+            return null;
+        }
+        return handleTimestampNanoseconds(defaultStr);
+    }
+
+    public String handleTimestampNanoseconds(String defaultStr) {
+        if (null == defaultStr || defaultStr.isEmpty()) {
+            return null;
+        }
+
+        if (defaultStr.length() < 20) {
+            return defaultStr;
+        }
+        String[] split = defaultStr.split("\\.");
+        if (split.length != 2) {
+            return null;
+        }
+        String nanoseconds = split[1];
+        if (nanoseconds.length() > 6) {
+            nanoseconds = nanoseconds.substring(0, 6);
+        }
+        return split[0] + "." + nanoseconds;
+    }
+
+    public String convertStringDefault(String defaultStr, String dorisType) {
+        return defaultStr.replaceAll("'", "");
     }
 
     public abstract String convertToDorisType(String fieldType, Integer precision, Integer scale);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleDatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleDatabaseSync.java
@@ -32,6 +32,7 @@ import com.ververica.cdc.debezium.DebeziumSourceFunction;
 import com.ververica.cdc.debezium.JsonDebeziumDeserializationSchema;
 import com.ververica.cdc.debezium.table.DebeziumOptions;
 import org.apache.doris.flink.catalog.doris.DataModel;
+import org.apache.doris.flink.catalog.doris.TableSchema;
 import org.apache.doris.flink.tools.cdc.DatabaseSync;
 import org.apache.doris.flink.tools.cdc.SourceSchema;
 import org.slf4j.Logger;
@@ -115,6 +116,13 @@ public class OracleDatabaseSync extends DatabaseSync {
                 while (tables.next()) {
                     String tableName = tables.getString("TABLE_NAME");
                     String tableComment = tables.getString("REMARKS");
+                    if (!tableName.matches(TableSchema.TABLE_REGEX)) {
+                        LOG.warn(
+                                "table name {} is not valid in Doris, the regex of Doris table name is {}",
+                                tableName,
+                                TableSchema.TABLE_REGEX);
+                        continue;
+                    }
                     if (!isSyncNeeded(tableName)) {
                         continue;
                     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleSchema.java
@@ -17,11 +17,21 @@
 
 package org.apache.doris.flink.tools.cdc.oracle;
 
+import org.apache.doris.flink.catalog.DorisTypeMapper;
 import org.apache.doris.flink.tools.cdc.SourceSchema;
 
 import java.sql.DatabaseMetaData;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class OracleSchema extends SourceSchema {
+    private static final Pattern TO_DATE =
+            Pattern.compile("TO_DATE\\('(.*)',[ ]*'(.*)'\\)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern TO_TIMESTAMP =
+            Pattern.compile("TO_TIMESTAMP\\('(.*)',[ ]*'(.*)'\\)", Pattern.CASE_INSENSITIVE);
+
+    private static final String ORACLE_DATE_PATTERN = "YYYY-MM-DD";
+    private static final String ORACLE_DATETIME_PATTERN = "YYYY-MM-DD HH24:MI:SS";
 
     public OracleSchema(
             DatabaseMetaData metaData,
@@ -36,5 +46,115 @@ public class OracleSchema extends SourceSchema {
     @Override
     public String convertToDorisType(String fieldType, Integer precision, Integer scale) {
         return OracleType.toDorisType(fieldType, precision, scale);
+    }
+
+    @Override
+    public String convertStringDefault(String defaultStr, String dorisType) {
+        return defaultStr.replaceAll(SourceSchema.DEFAULT_STRING_SINGLE_QUOTE, "");
+    }
+
+    @Override
+    public String convertDateTimeDefault(String defaultStr, String dorisType) {
+        if (defaultStr == null || defaultStr.isEmpty()) {
+            return null;
+        }
+        String defaultStrUpperCase = defaultStr.toUpperCase();
+        if (defaultStrUpperCase.startsWith(DEFAULT_CURRENT_TIMESTAMP)) {
+            // In Oracle, the precision of CURRENT_TIMESTAMP is optional, and the default precision
+            // is 6.
+            long length = 6;
+            int startIndex = defaultStrUpperCase.indexOf('(') + 1;
+            int endIndex = defaultStrUpperCase.indexOf(')');
+            if (endIndex >= 0) {
+                String substring = defaultStrUpperCase.substring(startIndex, endIndex).trim();
+                length = substring.isEmpty() ? 0 : Long.parseLong(substring);
+                if (length > DorisTypeMapper.MAX_SUPPORTED_DATE_TIME_PRECISION) {
+                    length = DorisTypeMapper.MAX_SUPPORTED_DATE_TIME_PRECISION;
+                }
+            }
+            return String.format("CURRENT_TIMESTAMP(%d)", length);
+        }
+        return handleOracleTimestampDefault(defaultStr);
+    }
+
+    private String handleOracleTimestampDefault(String data) {
+        final Matcher toTimestampMatcher = TO_TIMESTAMP.matcher(data);
+        if (toTimestampMatcher.matches()) {
+            String datetimeText = toTimestampMatcher.group(1);
+            String timestampPattern = toTimestampMatcher.group(2);
+            return normalizeDateValue(datetimeText, timestampPattern);
+        }
+
+        final Matcher toDateMatcher = TO_DATE.matcher(data);
+        if (toDateMatcher.matches()) {
+            String dateString = toDateMatcher.group(1);
+            String datePattern = toDateMatcher.group(2);
+            return normalizeDateValue(dateString, datePattern);
+        }
+        return null;
+    }
+
+    private String normalizeDateValue(String stringValue, String datePattern) {
+        if (datePattern.length() <= ORACLE_DATE_PATTERN.length()) {
+            return normalizeDate(stringValue) + " 00:00:00";
+        } else if (datePattern.length() <= ORACLE_DATETIME_PATTERN.length()) {
+            return normalizeDateTime(stringValue);
+        } else if (datePattern.length() <= ORACLE_DATETIME_PATTERN.length() + 4) {
+            return normalizeDateTimeWithNanoseconds(stringValue);
+        }
+        return null;
+    }
+
+    private String normalizeDate(String stringValue) {
+        String[] split = stringValue.split("-");
+        if (split.length != 3) {
+            return null;
+        }
+        String month = padWithZeroIfNeeded(split[1]);
+        String day = padWithZeroIfNeeded(split[2]);
+
+        return split[0] + "-" + month + "-" + day;
+    }
+
+    private String normalizeDateTime(String stringValue) {
+        String[] split = stringValue.split(" ");
+        if (split.length != 2) {
+            return null;
+        }
+
+        String normalizedDate = normalizeDate(split[0]);
+        String[] timeArr = split[1].split(":");
+        StringBuilder timeStr = new StringBuilder();
+        for (int i = 0; i < timeArr.length; i++) {
+            timeStr.append(padWithZeroIfNeeded(timeArr[i]));
+            if (i < 2) {
+                timeStr.append(":");
+            }
+        }
+        int diff = 3 - timeArr.length;
+        for (int i = 0; i < diff; i++) {
+            timeStr.append("00");
+            if (i != diff - 1) {
+                timeStr.append(":");
+            }
+        }
+        return normalizedDate + " " + timeStr;
+    }
+
+    private String normalizeDateTimeWithNanoseconds(String stringValue) {
+        String[] split = stringValue.split("\\.");
+        if (split.length != 2) {
+            return null;
+        }
+        String normalizedDateTime = normalizeDateTime(split[0]);
+        String nanoseconds = split[1];
+        if (nanoseconds.length() > 6) {
+            nanoseconds = nanoseconds.substring(0, 6);
+        }
+        return normalizedDateTime + "." + nanoseconds;
+    }
+
+    private String padWithZeroIfNeeded(String component) {
+        return component.length() == 1 ? "0" + component : component;
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
@@ -285,13 +285,13 @@ public class TestJsonDebeziumSchemaChangeImplV2 extends TestJsonDebeziumChangeBa
                 "test_ts_0", new FieldSchema("test_ts_0", "DATETIMEV2(0)", null, null));
         srcFiledSchemaMap.put(
                 "test_ts_1",
-                new FieldSchema("test_ts_1", "DATETIMEV2(1)", "current_timestamp", null));
+                new FieldSchema("test_ts_1", "DATETIMEV2(1)", "CURRENT_TIMESTAMP(1)", null));
         srcFiledSchemaMap.put(
                 "test_ts_3",
-                new FieldSchema("test_ts_3", "DATETIMEV2(3)", "current_timestamp", null));
+                new FieldSchema("test_ts_3", "DATETIMEV2(3)", "CURRENT_TIMESTAMP(3)", null));
         srcFiledSchemaMap.put(
                 "test_ts_6",
-                new FieldSchema("test_ts_6", "DATETIMEV2(6)", "current_timestamp", null));
+                new FieldSchema("test_ts_6", "DATETIMEV2(6)", "CURRENT_TIMESTAMP(6)", null));
 
         schemaChange.setSourceConnector("mysql");
         String columnsString =


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
Currently, Doris only supports `current_timestamp` as the default function.
In relational databases, the composition of different default values varies. Here are some examples:
1.MySQL
In MySQL, default values for numeric types are represented as `1.0` or `0`, while for string and date types, they are enclosed in single quotes.
In MySQL5.7.x,you can create SQL statements using the following syntax:
```sql
create table test_str
(
    id         int auto_increment primary key,
    t2_varchar varchar(10) default '''doris'''''   null,
    t1_varchar varchar(10) default 'doris'''       null,
    t3_varchar varchar(20) default '''''doris''''' null,
    t_int int default 1,
   t_float default 1.1
);
```
In MySQL8.0.x,you can create table with default function.
```sql
create table t1
(
    i int auto_increment
        primary key,
    c varchar(10) default ''                              null,
    f float       default ((rand() * rand()))             null,
    b binary(16)  default (uuid_to_bin(uuid()))           null,
    d date        default ((curdate() + interval 1 year)) null,
    j json        default (json_array())                  null
);
```
2.Oracle
In Oracle, character types are enclosed in single quotes, while the default values for timestamps and dates are obtained through the `TO_TIMESTAMP` and `TO_DATE` functions, respectively. Here are some specific examples:
```sql
create table TEST_ALL_TYPES
(
    ID              NUMBER not null constraint TEST_ALL_TYPES_PK primary key,
    N1              NUMBER,
    NUM2        NUMBER(5, -2)                default (100 / 3),
    NUM4        NUMBER(5, 7),
    T1              DATE                         default to_date('2010-2-12 10:20:30', 'YYYY-MM-DD HH24:MI:SS'),
    T2            TIMESTAMP(7)                 default TO_TIMESTAMP('2023-01-01 00:00:00.0000001'
```

3.PostgreSQL
In PostgreSQL, default values for character and numeric types are composed of the value itself, followed by `::` and the type.

```sql
create table test_all_types
(
    id              integer        default 1 not null,
    char_value      char(100)      default 'doris'::bpchar,
    varchar_value   varchar(128)   default 'make doris greate'::character varying,
    date_value      date           default '2024-01-01'::date,
    smallint_value  smallint       default 12,
    int_value       integer        default 100,
    bigint_value    bigint         default 10000,
    timestamp_value timestamp      default '2024-01-01 01:01:01.000001'::timestamp without time zone,
    decimal_value   numeric(10, 3) default 1.23,
    bit_value       bit,
    ts_decimal      numeric(38)    default 12,
    text_value      text           default 'make doris greate'::text
);
```
4.SQLSever
In SQL Server, numeric types are enclosed in double parentheses `()`, while string and time types are enclosed in single parentheses `()`.

```sql
create table all_type
(
    id                   int not null primary key,
    name                 varchar(10)     default 'kevin',
    age                      int             default 1,
    smalldatetime_value  smalldatetime   default '2024-01-01 00:00:00.00000001',
    datetimeoffset_value datetimeoffset  default '2024-01-01 00:00:00.0000001',
    bit_value            bit             default 1,
    c1                   varchar(255)    default 12.11
)
go
```

In this PR, you can automatically map default values from MySQL, Oracle, PostgreSQL, and SQL Server to Doris default values. Currently, only the translation of the time default function current_timestamp is supported.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
