### PR TITLE
[Feature](sink) add copy mode to sink

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/CopyLoadException.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/CopyLoadException.java
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.exception;
+
+public class CopyLoadException extends DorisRuntimeException {
+    public CopyLoadException() {
+        super();
+    }
+
+    public CopyLoadException(String message) {
+        super(message);
+    }
+
+    public CopyLoadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CopyLoadException(Throwable cause) {
+        super(cause);
+    }
+
+    protected CopyLoadException(
+            String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/DorisAbstractCommittable.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/DorisAbstractCommittable.java
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink;
+
+public interface DorisAbstractCommittable {}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpPutBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpPutBuilder.java
@@ -58,6 +58,11 @@ public class HttpPutBuilder {
         return this;
     }
 
+    public HttpPutBuilder addFileName(String fileName) {
+        header.put("fileName", fileName);
+        return this;
+    }
+
     public HttpPutBuilder enable2PC() {
         header.put("two_phase_commit", "true");
         return this;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.flink.sink;
 
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -36,5 +38,23 @@ public class HttpUtil {
 
     public CloseableHttpClient getHttpClient() {
         return httpClientBuilder.build();
+    }
+
+    private RequestConfig requestConfig =
+            RequestConfig.custom()
+                    .setConnectTimeout(60 * 1000)
+                    .setConnectionRequestTimeout(60 * 1000)
+                    // default checkpoint timeout is 10min
+                    .setSocketTimeout(9 * 60 * 1000)
+                    .build();
+
+    private final HttpClientBuilder httpClientBuilderWithTimeout =
+            HttpClients.custom().setDefaultRequestConfig(requestConfig);
+
+    public CloseableHttpClient getHttpClientWithTimeout() {
+        return httpClientBuilderWithTimeout
+                // fix failed to respond for commit copy
+                .setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE)
+                .build();
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/ResponseUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/ResponseUtil.java
@@ -30,4 +30,11 @@ public class ResponseUtil {
     public static boolean isCommitted(String msg) {
         return COMMITTED_PATTERN.matcher(msg).find();
     }
+
+    static final Pattern COPY_COMMITTED_PATTERN =
+            Pattern.compile("errCode = 2, detailMessage = No files can be copied.*");
+
+    public static boolean isCopyCommitted(String msg) {
+        return COPY_COMMITTED_PATTERN.matcher(msg).find();
+    }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BackoffAndRetryUtils.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BackoffAndRetryUtils.java
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.copy;
+
+import org.apache.doris.flink.exception.DorisRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BackoffAndRetryUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BackoffAndRetryUtils.class);
+
+    // backoff with 1, 2, 4 seconds
+    private static final int[] backoffSec = {0, 1, 2, 4};
+
+    /** Interfaces to define the lambda function to be used by backoffAndRetry. */
+    public interface BackoffFunction {
+        Object apply() throws Exception;
+    }
+
+    public static Object backoffAndRetry(
+            final LoadOperation operation, final BackoffFunction runnable) throws Exception {
+        String error = "";
+        Throwable resExp = null;
+        for (int index = 0; index < backoffSec.length; index++) {
+            if (index != 0) {
+                int second = backoffSec[index];
+                Thread.sleep(second * 1000L);
+                LOG.info("Retry operation {} {} times", operation, index);
+            }
+            try {
+                return runnable.apply();
+            } catch (Exception e) {
+                resExp = e;
+                error = e.getMessage();
+                LOG.error(
+                        "Request failed, caught an exception for operation {} with message:{}",
+                        operation,
+                        e.getMessage());
+            }
+        }
+        String errMsg =
+                String.format(
+                        "Retry exceeded the max retry limit, operation = %s, error message is %s",
+                        operation, error);
+        LOG.error(errMsg, resExp);
+        throw new DorisRuntimeException(errMsg);
+    }
+
+    public enum LoadOperation {
+        GET_INTERNAL_STAGE_ADDRESS,
+        UPLOAD_FILE,
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
@@ -1,0 +1,414 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.copy;
+
+import org.apache.flink.util.Preconditions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.exception.CopyLoadException;
+import org.apache.doris.flink.exception.DorisBatchLoadException;
+import org.apache.doris.flink.sink.EscapeHandler;
+import org.apache.doris.flink.sink.HttpPutBuilder;
+import org.apache.doris.flink.sink.HttpUtil;
+import org.apache.doris.flink.sink.batch.BatchRecordBuffer;
+import org.apache.doris.flink.sink.writer.LabelGenerator;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.doris.flink.sink.writer.LoadConstants.LINE_DELIMITER_DEFAULT;
+
+/** load data from stage load. */
+public class BatchStageLoad implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(BatchStageLoad.class);
+    private final LabelGenerator labelGenerator;
+    private final byte[] lineDelimiter;
+    private static final String UPLOAD_URL_PATTERN = "http://%s/copy/upload";
+    private static final String LINE_DELIMITER_KEY_WITH_PRETIX = "file.line_delimiter";
+    private String uploadUrl;
+    private String hostPort;
+    private final String username;
+    private final String password;
+    private final Properties loadProps;
+    private Map<String, BatchRecordBuffer> bufferMap = new ConcurrentHashMap<>();
+    private Map<String, List<String>> fileListMap = new ConcurrentHashMap<>();
+    private long currentCheckpointID;
+    private AtomicInteger fileNum;
+    private DorisExecutionOptions executionOptions;
+    private ExecutorService loadExecutorService;
+    private StageLoadAsyncExecutor loadAsyncExecutor;
+    private BlockingQueue<BatchRecordBuffer> flushQueue;
+    private final AtomicBoolean started;
+    private volatile boolean loadThreadAlive = false;
+    private AtomicReference<Throwable> exception = new AtomicReference<>(null);
+    private CloseableHttpClient httpClient = new HttpUtil().getHttpClientWithTimeout();
+
+    public BatchStageLoad(
+            DorisOptions dorisOptions,
+            DorisReadOptions dorisReadOptions,
+            DorisExecutionOptions executionOptions,
+            LabelGenerator labelGenerator) {
+        this.username = dorisOptions.getUsername();
+        this.password = dorisOptions.getPassword();
+        this.loadProps = executionOptions.getStreamLoadProp();
+        this.labelGenerator = labelGenerator;
+        this.hostPort = dorisOptions.getFenodes();
+        this.uploadUrl = String.format(UPLOAD_URL_PATTERN, hostPort);
+        this.fileNum = new AtomicInteger();
+        this.lineDelimiter =
+                EscapeHandler.escapeString(
+                                loadProps.getProperty(
+                                        LINE_DELIMITER_KEY_WITH_PRETIX, LINE_DELIMITER_DEFAULT))
+                        .getBytes();
+        this.executionOptions = executionOptions;
+        this.flushQueue = new LinkedBlockingDeque<>(executionOptions.getFlushQueueSize());
+        this.loadAsyncExecutor = new StageLoadAsyncExecutor();
+        this.loadExecutorService =
+                new ThreadPoolExecutor(
+                        1,
+                        1,
+                        0L,
+                        TimeUnit.MILLISECONDS,
+                        new LinkedBlockingQueue<>(1),
+                        new DefaultThreadFactory("copy-executor"),
+                        new ThreadPoolExecutor.AbortPolicy());
+        this.started = new AtomicBoolean(true);
+        this.loadExecutorService.execute(loadAsyncExecutor);
+    }
+
+    /**
+     * write record into cache.
+     *
+     * @param record
+     * @throws IOException
+     */
+    public synchronized void writeRecord(String database, String table, byte[] record)
+            throws InterruptedException {
+        checkFlushException();
+        String bufferKey = getTableIdentifier(database, table);
+        BatchRecordBuffer buffer =
+                bufferMap.computeIfAbsent(
+                        bufferKey,
+                        k ->
+                                new BatchRecordBuffer(
+                                        database,
+                                        table,
+                                        this.lineDelimiter,
+                                        executionOptions.getBufferFlushMaxBytes()));
+        buffer.insert(record);
+        // When it exceeds 80% of the byteSize,to flush, to avoid triggering bytebuffer expansion
+        if (buffer.getBufferSizeBytes() >= executionOptions.getBufferFlushMaxBytes() * 0.8
+                || (executionOptions.getBufferFlushMaxRows() != 0
+                        && buffer.getNumOfRecords() >= executionOptions.getBufferFlushMaxRows())) {
+            flush(bufferKey, false);
+        }
+    }
+
+    public synchronized void flush(String bufferKey, boolean waitUtilDone)
+            throws InterruptedException {
+        checkFlushException();
+        if (null == bufferKey) {
+            for (String key : bufferMap.keySet()) {
+                flushBuffer(key);
+            }
+        } else if (bufferMap.containsKey(bufferKey)) {
+            flushBuffer(bufferKey);
+        }
+
+        if (waitUtilDone) {
+            waitAsyncLoadFinish();
+        }
+    }
+
+    private synchronized void flushBuffer(String bufferKey) {
+        BatchRecordBuffer buffer = bufferMap.get(bufferKey);
+        buffer.setLabelName(
+                labelGenerator.generateCopyBatchLabel(
+                        buffer.getTable(), currentCheckpointID, fileNum.getAndIncrement()));
+        putRecordToFlushQueue(buffer);
+        bufferMap.remove(bufferKey);
+    }
+
+    private void putRecordToFlushQueue(BatchRecordBuffer buffer) {
+        checkFlushException();
+        if (!loadThreadAlive) {
+            throw new RuntimeException("load thread already exit, write was interrupted");
+        }
+        try {
+            flushQueue.put(buffer);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Failed to put record buffer to flush queue");
+        }
+    }
+
+    public void setCurrentCheckpointID(long currentCheckpointID) {
+        this.currentCheckpointID = currentCheckpointID;
+    }
+
+    private void checkFlushException() {
+        if (exception.get() != null) {
+            throw new DorisBatchLoadException(exception.get());
+        }
+    }
+
+    private void waitAsyncLoadFinish() {
+        for (int i = 0; i < executionOptions.getFlushQueueSize() + 1; i++) {
+            BatchRecordBuffer empty = new BatchRecordBuffer();
+            putRecordToFlushQueue(empty);
+        }
+    }
+
+    private String getTableIdentifier(String database, String table) {
+        return database + "." + table;
+    }
+
+    public void close() {
+        // close async executor
+        this.loadExecutorService.shutdown();
+        this.started.set(false);
+        // clear buffer
+        this.flushQueue.clear();
+        this.fileListMap.clear();
+        this.bufferMap.clear();
+    }
+
+    public Map<String, List<String>> getFileListMap() {
+        return fileListMap;
+    }
+
+    public void clearFileListMap() {
+        this.fileNum.set(0);
+        this.fileListMap.clear();
+    }
+
+    class StageLoadAsyncExecutor implements Runnable {
+        @Override
+        public void run() {
+            LOG.info("StageLoadAsyncExecutor start");
+            loadThreadAlive = true;
+            while (started.get()) {
+                BatchRecordBuffer buffer = null;
+                try {
+                    buffer = flushQueue.poll(2000L, TimeUnit.MILLISECONDS);
+                    if (buffer == null) {
+                        continue;
+                    }
+                    if (buffer.getLabelName() != null) {
+                        String bufferKey =
+                                getTableIdentifier(buffer.getDatabase(), buffer.getTable());
+                        uploadToStorage(buffer.getLabelName(), buffer);
+                        fileListMap
+                                .computeIfAbsent(bufferKey, k -> new ArrayList<>())
+                                .add(buffer.getLabelName());
+                    }
+                } catch (Exception e) {
+                    LOG.error("worker running error", e);
+                    exception.set(e);
+                    // clear queue to avoid writer thread blocking
+                    flushQueue.clear();
+                    fileListMap.clear();
+                    bufferMap.clear();
+                    break;
+                }
+            }
+            LOG.info("StageLoadAsyncExecutor stop");
+            loadThreadAlive = false;
+        }
+
+        /*
+         * upload to storage
+         */
+        public void uploadToStorage(String fileName, BatchRecordBuffer buffer) throws IOException {
+            long start = System.currentTimeMillis();
+            LOG.info("file write started for {}", fileName);
+            String address = getUploadAddress(fileName);
+            long addressTs = System.currentTimeMillis();
+            LOG.info(
+                    "redirect to internalStage address:{}, cost {} ms", address, addressTs - start);
+            String requestId = uploadToInternalStage(address, buffer.getData());
+            LOG.info(
+                    "upload file {} finished, record {} size {}, cost {}ms, with requestId {}",
+                    fileName,
+                    buffer.getNumOfRecords(),
+                    buffer.getBufferSizeBytes(),
+                    System.currentTimeMillis() - addressTs,
+                    requestId);
+        }
+
+        public String uploadToInternalStage(String address, ByteBuffer data)
+                throws CopyLoadException {
+            ByteArrayEntity entity =
+                    new ByteArrayEntity(data.array(), data.arrayOffset(), data.limit());
+            HttpPutBuilder putBuilder = new HttpPutBuilder();
+            putBuilder.setUrl(address).addCommonHeader().setEntity(entity);
+            HttpPut httpPut = putBuilder.build();
+            try {
+                Object result =
+                        BackoffAndRetryUtils.backoffAndRetry(
+                                BackoffAndRetryUtils.LoadOperation.UPLOAD_FILE,
+                                () -> {
+                                    try (CloseableHttpResponse response =
+                                            httpClient.execute(httpPut)) {
+                                        final int statusCode =
+                                                response.getStatusLine().getStatusCode();
+                                        String requestId = getRequestId(response.getAllHeaders());
+                                        if (statusCode == 200 && response.getEntity() != null) {
+                                            String loadResult =
+                                                    EntityUtils.toString(response.getEntity());
+                                            if (loadResult == null || loadResult.isEmpty()) {
+                                                // upload finished
+                                                return requestId;
+                                            }
+                                            LOG.error(
+                                                    "upload file failed, requestId is {}, response result: {}",
+                                                    requestId,
+                                                    loadResult);
+                                            throw new CopyLoadException(
+                                                    "upload file failed: "
+                                                            + response.getStatusLine().toString()
+                                                            + ", with requestId "
+                                                            + requestId);
+                                        }
+                                        throw new CopyLoadException(
+                                                "upload file error: "
+                                                        + response.getStatusLine().toString()
+                                                        + ", with requestId "
+                                                        + requestId);
+                                    }
+                                });
+                return String.valueOf(result);
+            } catch (Exception ex) {
+                LOG.error("Failed to upload data to internal stage ", ex);
+                throw new CopyLoadException(
+                        "Failed to upload data to internal stage, " + ex.getMessage());
+            }
+        }
+
+        /*
+         * get requestId from response Header for upload stage
+         * header key are: x-oss-request-id/x-cos-request-id/x-obs-request-id/x-amz-request-id
+         * @return key:value
+         */
+        public String getRequestId(Header[] headers) {
+            if (headers == null || headers.length == 0) {
+                return null;
+            }
+            for (int i = 0; i < headers.length; i++) {
+                final Header header = headers[i];
+                String name = header.getName();
+                if (name != null && name.toLowerCase().matches("x-\\S+-request-id")) {
+                    return name + ":" + header.getValue();
+                }
+            }
+            return null;
+        }
+
+        /** Get the redirected s3 address. */
+        public String getUploadAddress(String fileName) throws CopyLoadException {
+            HttpPutBuilder putBuilder = new HttpPutBuilder();
+            putBuilder
+                    .setUrl(uploadUrl)
+                    .addFileName(fileName)
+                    .addCommonHeader()
+                    .setEmptyEntity()
+                    .baseAuth(username, password);
+
+            try {
+                Object address =
+                        BackoffAndRetryUtils.backoffAndRetry(
+                                BackoffAndRetryUtils.LoadOperation.GET_INTERNAL_STAGE_ADDRESS,
+                                () -> {
+                                    try (CloseableHttpResponse execute =
+                                            httpClient.execute(putBuilder.build())) {
+                                        int statusCode = execute.getStatusLine().getStatusCode();
+                                        String reason = execute.getStatusLine().getReasonPhrase();
+                                        if (statusCode == 307) {
+                                            Header location = execute.getFirstHeader("location");
+                                            String uploadAddress = location.getValue();
+                                            return uploadAddress;
+                                        } else {
+                                            HttpEntity entity = execute.getEntity();
+                                            String result =
+                                                    entity == null
+                                                            ? null
+                                                            : EntityUtils.toString(entity);
+                                            LOG.error(
+                                                    "Failed to get internalStage address, status {}, reason {}, response {}",
+                                                    statusCode,
+                                                    reason,
+                                                    result);
+                                            throw new CopyLoadException(
+                                                    "Failed get internalStage address");
+                                        }
+                                    }
+                                });
+                Preconditions.checkNotNull(address, "internalStage address is null");
+                return address.toString();
+            } catch (Exception e) {
+                LOG.error("Get internalStage address error,", e);
+                throw new CopyLoadException("Get internalStage address error, " + e.getMessage());
+            }
+        }
+    }
+
+    static class DefaultThreadFactory implements ThreadFactory {
+        private static final AtomicInteger poolNumber = new AtomicInteger(1);
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final String namePrefix;
+
+        DefaultThreadFactory(String name) {
+            namePrefix = "pool-" + poolNumber.getAndIncrement() + "-" + name + "-";
+        }
+
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(r, namePrefix + threadNumber.getAndIncrement());
+            t.setDaemon(false);
+            return t;
+        }
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
@@ -19,8 +19,6 @@ package org.apache.doris.flink.sink.copy;
 
 import org.apache.flink.util.Preconditions;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/CopyCommittableSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/CopyCommittableSerializer.java
@@ -37,14 +37,14 @@ public class CopyCommittableSerializer implements SimpleVersionedSerializer<Dori
     }
 
     @Override
-    public byte[] serialize(DorisCopyCommittable selectdbCommittable) throws IOException {
+    public byte[] serialize(DorisCopyCommittable copyCommittable) throws IOException {
         try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 final DataOutputStream out = new DataOutputStream(baos)) {
-            out.writeUTF(selectdbCommittable.getHostPort());
+            out.writeUTF(copyCommittable.getHostPort());
 
             // writeUTF has a length limit, but the copysql is sometimes very long
             final byte[] copySqlBytes =
-                    selectdbCommittable.getCopySQL().getBytes(StandardCharsets.UTF_8);
+                    copyCommittable.getCopySQL().getBytes(StandardCharsets.UTF_8);
             out.writeInt(copySqlBytes.length);
             out.write(copySqlBytes);
             out.flush();

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/CopyCommittableSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/CopyCommittableSerializer.java
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.copy;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/** define how to serialize DorisCopyCommittable. */
+public class CopyCommittableSerializer implements SimpleVersionedSerializer<DorisCopyCommittable> {
+
+    private static final int VERSION = 1;
+
+    @Override
+    public int getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public byte[] serialize(DorisCopyCommittable selectdbCommittable) throws IOException {
+        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                final DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeUTF(selectdbCommittable.getHostPort());
+
+            // writeUTF has a length limit, but the copysql is sometimes very long
+            final byte[] copySqlBytes =
+                    selectdbCommittable.getCopySQL().getBytes(StandardCharsets.UTF_8);
+            out.writeInt(copySqlBytes.length);
+            out.write(copySqlBytes);
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public DorisCopyCommittable deserialize(int version, byte[] serialized) throws IOException {
+        try (final ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                final DataInputStream in = new DataInputStream(bais)) {
+            final String hostPort = in.readUTF();
+
+            // read copySQL
+            final int len = in.readInt();
+            final byte[] bytes = new byte[len];
+            in.read(bytes);
+            String copySQL = new String(bytes, StandardCharsets.UTF_8);
+            return new DorisCopyCommittable(hostPort, copySQL);
+        }
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/CopySQLBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/CopySQLBuilder.java
@@ -81,7 +81,7 @@ public class CopySQLBuilder {
         return sb.toString();
     }
 
-    static List<String> PREFIX_LIST =
+    static final List<String> PREFIX_LIST =
             Arrays.asList(FIELD_DELIMITER_KEY, LINE_DELIMITER_KEY, STRIP_OUT_ARRAY);
 
     private String concatPropPrefix(String key) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/CopySQLBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/CopySQLBuilder.java
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.copy;
+
+import org.apache.doris.flink.cfg.DorisExecutionOptions;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringJoiner;
+
+import static org.apache.doris.flink.sink.writer.LoadConstants.COLUMNS_KEY;
+import static org.apache.doris.flink.sink.writer.LoadConstants.FIELD_DELIMITER_KEY;
+import static org.apache.doris.flink.sink.writer.LoadConstants.FORMAT_KEY;
+import static org.apache.doris.flink.sink.writer.LoadConstants.JSON;
+import static org.apache.doris.flink.sink.writer.LoadConstants.LINE_DELIMITER_KEY;
+import static org.apache.doris.flink.sink.writer.LoadConstants.READ_JSON_BY_LINE;
+
+public class CopySQLBuilder {
+    private static final String COPY_SYNC = "copy.async";
+    private static final String COPY_DELETE = "copy.use_delete_sign";
+    private static final String STRIP_OUT_ARRAY = "strip_outer_array";
+    private final DorisExecutionOptions executionOptions;
+    private final String tableIdentifier;
+    private final List<String> fileList;
+    private Properties properties;
+
+    public CopySQLBuilder(
+            String tableIdentifier, DorisExecutionOptions executionOptions, List<String> fileList) {
+        this.tableIdentifier = tableIdentifier;
+        this.executionOptions = executionOptions;
+        this.fileList = fileList;
+        this.properties = executionOptions.getStreamLoadProp();
+    }
+
+    public String buildCopySQL() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("COPY INTO ")
+                .append(tableIdentifier)
+                .append(" FROM @~('{")
+                .append(String.join(",", fileList))
+                .append("}') ")
+                .append("PROPERTIES (");
+
+        // copy into must be sync
+        properties.put(COPY_SYNC, false);
+        if (executionOptions.getDeletable()) {
+            properties.put(COPY_DELETE, true);
+        }
+
+        if (JSON.equals(properties.getProperty(FORMAT_KEY))) {
+            properties.put(STRIP_OUT_ARRAY, false);
+        }
+
+        properties.remove(READ_JSON_BY_LINE);
+        properties.remove(COLUMNS_KEY);
+        StringJoiner props = new StringJoiner(",");
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            String key = concatPropPrefix(String.valueOf(entry.getKey()));
+            String value = String.valueOf(entry.getValue());
+            String prop = String.format("'%s'='%s'", key, value);
+            props.add(prop);
+        }
+        sb.append(props).append(")");
+        return sb.toString();
+    }
+
+    static List<String> PREFIX_LIST =
+            Arrays.asList(FIELD_DELIMITER_KEY, LINE_DELIMITER_KEY, STRIP_OUT_ARRAY);
+
+    private String concatPropPrefix(String key) {
+        if (PREFIX_LIST.contains(key)) {
+            return "file." + key;
+        }
+        if (FORMAT_KEY.equals(key)) {
+            return "file.type";
+        }
+        return key;
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommittable.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommittable.java
@@ -15,32 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.flink.sink;
+package org.apache.doris.flink.sink.copy;
+
+import org.apache.doris.flink.sink.DorisAbstractCommittable;
 
 import java.util.Objects;
 
-/** DorisCommittable hold the info for Committer to commit. */
-public class DorisCommittable implements DorisAbstractCommittable {
+public class DorisCopyCommittable implements DorisAbstractCommittable {
     private final String hostPort;
-    private final String db;
-    private final long txnID;
+    private final String copySQL;
 
-    public DorisCommittable(String hostPort, String db, long txnID) {
+    public DorisCopyCommittable(String hostPort, String copySQL) {
         this.hostPort = hostPort;
-        this.db = db;
-        this.txnID = txnID;
+        this.copySQL = copySQL;
     }
 
     public String getHostPort() {
         return hostPort;
     }
 
-    public String getDb() {
-        return db;
-    }
-
-    public long getTxnID() {
-        return txnID;
+    public String getCopySQL() {
+        return copySQL;
     }
 
     @Override
@@ -51,28 +46,24 @@ public class DorisCommittable implements DorisAbstractCommittable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        DorisCommittable that = (DorisCommittable) o;
-        return txnID == that.txnID
-                && Objects.equals(hostPort, that.hostPort)
-                && Objects.equals(db, that.db);
+        DorisCopyCommittable that = (DorisCopyCommittable) o;
+        return Objects.equals(hostPort, that.hostPort) && Objects.equals(copySQL, that.copySQL);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(hostPort, db, txnID);
+        return Objects.hash(hostPort, copySQL);
     }
 
     @Override
     public String toString() {
-        return "DorisCommittable{"
+        return "SelectdbCommittable{"
                 + "hostPort='"
                 + hostPort
                 + '\''
-                + ", db='"
-                + db
+                + ", copySQL='"
+                + copySQL
                 + '\''
-                + ", txnID="
-                + txnID
                 + '}';
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommittable.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommittable.java
@@ -57,7 +57,7 @@ public class DorisCopyCommittable implements DorisAbstractCommittable {
 
     @Override
     public String toString() {
-        return "SelectdbCommittable{"
+        return "DorisCommittable{"
                 + "hostPort='"
                 + hostPort
                 + '\''

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommitter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommitter.java
@@ -1,0 +1,166 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.copy;
+
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.util.CollectionUtil;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.exception.CopyLoadException;
+import org.apache.doris.flink.sink.HttpUtil;
+import org.apache.doris.flink.sink.ResponseUtil;
+import org.apache.doris.flink.sink.copy.models.BaseResponse;
+import org.apache.doris.flink.sink.copy.models.CopyIntoResp;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DorisCopyCommitter implements Committer<DorisCopyCommittable>, Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(DorisCopyCommitter.class);
+    private static final String commitPattern = "http://%s/copy/query";
+    private static final int SUCCESS = 0;
+    private static final String FAIL = "1";
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private final CloseableHttpClient httpClient;
+    private final DorisOptions dorisOptions;
+    int maxRetry;
+
+    public DorisCopyCommitter(DorisOptions dorisOptions, int maxRetry) {
+        this(dorisOptions, maxRetry, new HttpUtil().getHttpClientWithTimeout());
+    }
+
+    public DorisCopyCommitter(DorisOptions dorisOptions, int maxRetry, CloseableHttpClient client) {
+        this.dorisOptions = dorisOptions;
+        this.maxRetry = maxRetry;
+        this.httpClient = client;
+    }
+
+    @Override
+    public void commit(Collection<CommitRequest<DorisCopyCommittable>> committableList)
+            throws IOException, InterruptedException {
+        for (CommitRequest<DorisCopyCommittable> committable : committableList) {
+            commitTransaction(committable.getCommittable());
+        }
+    }
+
+    private void commitTransaction(DorisCopyCommittable committable) throws IOException {
+        String hostPort = committable.getHostPort();
+        String copySQL = committable.getCopySQL();
+
+        int statusCode = -1;
+        String reasonPhrase = null;
+        int retry = 0;
+        Map<String, String> params = new HashMap<>();
+        params.put("sql", copySQL);
+        boolean success = false;
+        String loadResult = "";
+        long start = System.currentTimeMillis();
+        while (retry++ <= maxRetry) {
+            LOG.info("commit with copy sql: {}", copySQL);
+            HttpPostBuilder postBuilder = new HttpPostBuilder();
+            postBuilder
+                    .setUrl(String.format(commitPattern, hostPort))
+                    .baseAuth(dorisOptions.getUsername(), dorisOptions.getPassword())
+                    .setEntity(new StringEntity(objectMapper.writeValueAsString(params)));
+
+            try (CloseableHttpResponse response = httpClient.execute(postBuilder.build())) {
+                statusCode = response.getStatusLine().getStatusCode();
+                reasonPhrase = response.getStatusLine().getReasonPhrase();
+                if (statusCode != 200) {
+                    LOG.warn(
+                            "commit failed with status {} {}, reason {}",
+                            statusCode,
+                            hostPort,
+                            reasonPhrase);
+                } else if (response.getEntity() != null) {
+                    loadResult = EntityUtils.toString(response.getEntity());
+                    success = handleCommitResponse(loadResult);
+                    if (success) {
+                        LOG.info(
+                                "commit success cost {}ms, response is {}",
+                                System.currentTimeMillis() - start,
+                                loadResult);
+                        break;
+                    } else {
+                        LOG.warn("commit failed, retry again");
+                    }
+                }
+            } catch (IOException e) {
+                LOG.error("commit error : ", e);
+            }
+        }
+
+        if (!success) {
+            LOG.error(
+                    "commit error with status {}, reason {}, response {}",
+                    statusCode,
+                    reasonPhrase,
+                    loadResult);
+            String copyErrMsg =
+                    String.format(
+                            "commit error, status: %d, reason: %s, response: %s, copySQL: %s",
+                            statusCode, reasonPhrase, loadResult, committable.getCopySQL());
+            throw new CopyLoadException(copyErrMsg);
+        }
+    }
+
+    public boolean handleCommitResponse(String loadResult) throws IOException {
+        BaseResponse baseResponse =
+                objectMapper.readValue(loadResult, new TypeReference<BaseResponse>() {});
+        if (baseResponse.getCode() == SUCCESS && baseResponse.getData() instanceof Map) {
+            CopyIntoResp dataResp =
+                    objectMapper.convertValue(baseResponse.getData(), CopyIntoResp.class);
+            // Returning code means there is an exception, and returning result means success
+            if (FAIL.equals(dataResp.getDataCode())) {
+                LOG.error("copy into execute failed, reason:{}", loadResult);
+                return false;
+            } else {
+                Map<String, String> result = dataResp.getResult();
+                if (CollectionUtil.isNullOrEmpty(result)
+                        || (!result.get("state").equals("FINISHED")
+                                && !ResponseUtil.isCommitted(result.get("msg")))) {
+                    LOG.error("copy into load failed, reason:{}", loadResult);
+                    return false;
+                } else {
+                    return true;
+                }
+            }
+        } else {
+            LOG.error("commit failed, reason:{}", loadResult);
+            return false;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (httpClient != null) {
+            httpClient.close();
+        }
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommitter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommitter.java
@@ -144,7 +144,7 @@ public class DorisCopyCommitter implements Committer<DorisCopyCommittable>, Clos
                 Map<String, String> result = dataResp.getResult();
                 if (CollectionUtil.isNullOrEmpty(result)
                         || (!result.get("state").equals("FINISHED")
-                                && !ResponseUtil.isCommitted(result.get("msg")))) {
+                                && !ResponseUtil.isCopyCommitted(result.get("msg")))) {
                     LOG.error("copy into load failed, reason:{}", loadResult);
                     return false;
                 } else {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyWriter.java
@@ -1,0 +1,189 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.copy;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.sink.writer.DorisAbstractWriter;
+import org.apache.doris.flink.sink.writer.DorisWriterState;
+import org.apache.doris.flink.sink.writer.LabelGenerator;
+import org.apache.doris.flink.sink.writer.serializer.DorisRecord;
+import org.apache.doris.flink.sink.writer.serializer.DorisRecordSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class DorisCopyWriter<IN>
+        implements DorisAbstractWriter<IN, DorisWriterState, DorisCopyCommittable> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DorisCopyWriter.class);
+    private BatchStageLoad batchStageLoad;
+    private final DorisOptions dorisOptions;
+    private final DorisReadOptions dorisReadOptions;
+    private final DorisExecutionOptions executionOptions;
+    private final String labelPrefix;
+    private final LabelGenerator labelGenerator;
+    private final long flushIntervalMs;
+    private final DorisRecordSerializer<IN> serializer;
+    private final transient ScheduledExecutorService scheduledExecutorService;
+    private transient volatile Exception flushException = null;
+    private String database;
+    private String table;
+
+    public DorisCopyWriter(
+            Sink.InitContext initContext,
+            DorisRecordSerializer<IN> serializer,
+            DorisOptions dorisOptions,
+            DorisReadOptions dorisReadOptions,
+            DorisExecutionOptions executionOptions) {
+        if (!StringUtils.isNullOrWhitespaceOnly(dorisOptions.getTableIdentifier())) {
+            String[] tableInfo = dorisOptions.getTableIdentifier().split("\\.");
+            Preconditions.checkState(
+                    tableInfo.length == 2,
+                    "tableIdentifier input error, the format is database.table");
+            this.database = tableInfo[0];
+            this.table = tableInfo[1];
+        }
+        LOG.info("labelPrefix " + executionOptions.getLabelPrefix());
+        this.labelPrefix =
+                executionOptions.getLabelPrefix()
+                        + "_"
+                        + UUID.randomUUID().toString().replaceAll("-", "");
+        this.labelGenerator = new LabelGenerator(labelPrefix, false, initContext.getSubtaskId());
+        this.scheduledExecutorService =
+                new ScheduledThreadPoolExecutor(
+                        1, new ExecutorThreadFactory("copy-upload-interval"));
+        this.serializer = serializer;
+        this.dorisOptions = dorisOptions;
+        this.dorisReadOptions = dorisReadOptions;
+        this.executionOptions = executionOptions;
+        this.flushIntervalMs = executionOptions.getBufferFlushIntervalMs();
+        serializer.initial();
+        initializeLoad();
+    }
+
+    public void initializeLoad() {
+        this.batchStageLoad =
+                new BatchStageLoad(
+                        dorisOptions, dorisReadOptions, executionOptions, labelGenerator);
+        // when uploading data in streaming mode, we need to regularly detect whether there are
+        // exceptions.
+        scheduledExecutorService.scheduleWithFixedDelay(
+                this::intervalFlush, flushIntervalMs, flushIntervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    private void intervalFlush() {
+        try {
+            LOG.info("interval flush triggered.");
+            batchStageLoad.flush(null, false);
+        } catch (InterruptedException e) {
+            flushException = e;
+        }
+    }
+
+    @Override
+    public void write(IN in, Context context) throws IOException, InterruptedException {
+        checkFlushException();
+        writeOneDorisRecord(serializer.serialize(in));
+    }
+
+    public void writeOneDorisRecord(DorisRecord record) throws InterruptedException {
+        if (record == null || record.getRow() == null) {
+            // ddl or value is null
+            return;
+        }
+        String db = this.database;
+        String tbl = this.table;
+        // multi table load
+        if (record.getTableIdentifier() != null) {
+            db = record.getDatabase();
+            tbl = record.getTable();
+        }
+        batchStageLoad.writeRecord(db, tbl, record.getRow());
+    }
+
+    @Override
+    public void flush(boolean b) throws IOException, InterruptedException {
+        checkFlushException();
+        writeOneDorisRecord(serializer.flush());
+        LOG.info("checkpoint flush triggered.");
+        batchStageLoad.flush(null, true);
+    }
+
+    @Override
+    public Collection<DorisCopyCommittable> prepareCommit()
+            throws IOException, InterruptedException {
+        Preconditions.checkState(batchStageLoad != null);
+        LOG.info("checkpoint arrived, upload buffer to storage");
+        List<DorisCopyCommittable> committables = new ArrayList<>();
+        Map<String, List<String>> fileListMap = this.batchStageLoad.getFileListMap();
+        for (Map.Entry<String, List<String>> entry : fileListMap.entrySet()) {
+            String tableIdentifier = entry.getKey();
+            List<String> fileList = entry.getValue();
+            CopySQLBuilder copySQLBuilder =
+                    new CopySQLBuilder(tableIdentifier, executionOptions, fileList);
+            String copySql = copySQLBuilder.buildCopySQL();
+            committables.add(new DorisCopyCommittable(dorisOptions.getFenodes(), copySql));
+        }
+        return committables;
+    }
+
+    @Override
+    public List<DorisWriterState> snapshotState(long checkpointId) throws IOException {
+        Preconditions.checkState(batchStageLoad != null);
+        if (!batchStageLoad.getFileListMap().isEmpty()) {
+            LOG.info("clear the file list {}", batchStageLoad.getFileListMap());
+            this.batchStageLoad.clearFileListMap();
+        }
+
+        this.batchStageLoad.setCurrentCheckpointID(checkpointId + 1);
+        // Files will be automatically cleaned
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void close() throws Exception {
+        LOG.info("DorisBatchWriter Close");
+        if (scheduledExecutorService != null) {
+            scheduledExecutorService.shutdownNow();
+        }
+        batchStageLoad.close();
+    }
+
+    private void checkFlushException() {
+        if (flushException != null) {
+            throw new RuntimeException("Writing records to streamload failed.", flushException);
+        }
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/HttpPostBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/HttpPostBuilder.java
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.copy;
+
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpPost;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Builder for HttpPost. */
+public class HttpPostBuilder {
+    String url;
+    Map<String, String> header;
+    HttpEntity httpEntity;
+
+    public HttpPostBuilder() {
+        header = new HashMap<>();
+    }
+
+    public HttpPostBuilder setUrl(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public HttpPostBuilder addCommonHeader() {
+        header.put(HttpHeaders.EXPECT, "100-continue");
+        return this;
+    }
+
+    public HttpPostBuilder baseAuth(String user, String password) {
+        final String authInfo = user + ":" + password;
+        byte[] encoded = Base64.encodeBase64(authInfo.getBytes(StandardCharsets.UTF_8));
+        header.put(HttpHeaders.AUTHORIZATION, "Basic " + new String(encoded));
+        return this;
+    }
+
+    public HttpPostBuilder setEntity(HttpEntity httpEntity) {
+        this.httpEntity = httpEntity;
+        return this;
+    }
+
+    public HttpPost build() {
+        Preconditions.checkNotNull(url);
+        Preconditions.checkNotNull(httpEntity);
+        HttpPost put = new HttpPost(url);
+        header.forEach(put::setHeader);
+        put.setEntity(httpEntity);
+        return put;
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/models/BaseResponse.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/models/BaseResponse.java
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.copy.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BaseResponse<T> {
+    private int code;
+    private String msg;
+    private T data;
+    private int count;
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public T getData() {
+        return data;
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/models/CopyIntoResp.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/models/CopyIntoResp.java
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.copy.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CopyIntoResp extends BaseResponse {
+    private String code;
+    private String exception;
+
+    private Map<String, String> result;
+
+    public String getDataCode() {
+        return code;
+    }
+
+    public String getException() {
+        return exception;
+    }
+
+    public Map<String, String> getResult() {
+        return result;
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
@@ -41,6 +41,12 @@ public class LabelGenerator {
         this.subtaskId = subtaskId;
     }
 
+    public LabelGenerator(String labelPrefix, boolean enable2PC, int subtaskId) {
+        this.labelPrefix = labelPrefix;
+        this.enable2PC = enable2PC;
+        this.subtaskId = subtaskId;
+    }
+
     public String generateLabel(long chkId) {
         String label = String.format("%s_%s_%s", labelPrefix, subtaskId, chkId);
         return enable2PC ? label : label + "_" + UUID.randomUUID();
@@ -58,5 +64,9 @@ public class LabelGenerator {
 
     public String generateBatchLabel(String table) {
         return String.format("%s_%s_%s", labelPrefix, table, UUID.randomUUID());
+    }
+
+    public String generateCopyBatchLabel(String table, long chkId, int fileNum) {
+        return String.format("%s_%s_%s_%s_%s", labelPrefix, table, subtaskId, chkId, fileNum);
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -34,6 +34,7 @@ import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.DorisSink;
+import org.apache.doris.flink.sink.writer.WriteMode;
 import org.apache.doris.flink.sink.writer.serializer.JsonDebeziumSchemaSerializer;
 import org.apache.doris.flink.table.DorisConfigOptions;
 import org.slf4j.Logger;
@@ -276,6 +277,9 @@ public abstract class DatabaseSync {
         sinkConfig
                 .getOptional(DorisConfigOptions.SINK_USE_CACHE)
                 .ifPresent(executionBuilder::setUseCache);
+        sinkConfig
+                .getOptional(DorisConfigOptions.SINK_WRITE_MODE)
+                .ifPresent(v -> executionBuilder.setWriteMode(WriteMode.of(v)));
 
         DorisExecutionOptions executionOptions = executionBuilder.build();
         builder.setDorisReadOptions(DorisReadOptions.builder().build())

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/copy/TestDorisCopyCommitter.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/copy/TestDorisCopyCommitter.java
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.copy;
+
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.exception.CopyLoadException;
+import org.apache.doris.flink.sink.HttpEntityMock;
+import org.apache.doris.flink.sink.OptionUtils;
+import org.apache.doris.flink.sink.committer.MockCommitRequest;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Test for Doris Copy Committer. */
+public class TestDorisCopyCommitter {
+
+    DorisCopyCommitter copyCommitter;
+    DorisCopyCommittable copyCommittable;
+    HttpEntityMock entityMock;
+
+    @Before
+    public void setUp() throws Exception {
+        DorisOptions dorisOptions = OptionUtils.buildDorisOptions();
+        copyCommittable = new DorisCopyCommittable("127.0.0.1:8710", "copy into sql");
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        entityMock = new HttpEntityMock();
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        StatusLine normalLine = new BasicStatusLine(new ProtocolVersion("http", 1, 0), 200, "");
+        when(httpClient.execute(any())).thenReturn(httpResponse);
+        when(httpResponse.getStatusLine()).thenReturn(normalLine);
+        when(httpResponse.getEntity()).thenReturn(entityMock);
+        copyCommitter = new DorisCopyCommitter(dorisOptions, 1, httpClient);
+    }
+
+    @Test
+    public void testCommitted() throws Exception {
+        String response =
+                "{\"msg\":\"success\",\"code\":0,\"data\":{\"result\":{\"msg\":\"\",\"loadedRows\":\"2\",\"state\":\"FINISHED\",\"type\":\"\",\"filterRows\":\"0\",\"unselectRows\":\"0\",\"url\":null},\"time\":5230,\"type\":\"result_set\"},\"count\":0}";
+        this.entityMock.setValue(response);
+        final MockCommitRequest<DorisCopyCommittable> request =
+                new MockCommitRequest<>(copyCommittable);
+        copyCommitter.commit(Collections.singletonList(request));
+    }
+
+    @Test(expected = CopyLoadException.class)
+    public void testCommitedError() throws Exception {
+        String response =
+                "{\"msg\":\"success\",\"code\":0,\"data\":{\"result\":{\"msg\":\"errCode = 2, detailMessage = No source file in this table(table).\",\"loadedRows\":\"\",\"state\":\"CANCELLED\",\"type\":\"ETL_RUN_FAIL\",\"filterRows\":\"\",\"unselectRows\":\"\",\"url\":null},\"time\":5255,\"type\":\"result_set\"},\"count\":0}";
+        this.entityMock.setValue(response);
+        final MockCommitRequest<DorisCopyCommittable> request =
+                new MockCommitRequest<>(copyCommittable);
+        copyCommitter.commit(Collections.singletonList(request));
+    }
+
+    @Test
+    public void testHandleCommitResponse() throws Exception {
+        String loadResult =
+                "{\"msg\":\"Error\",\"code\":1,\"data\":\"Failed to execute sql: java.lang.ClassCastException:  java.util.LinkedHashMap$Entry cannot be cast to java.util.HashMap$TreeNode\",\"count\":0}";
+        Assert.assertFalse(copyCommitter.handleCommitResponse(loadResult));
+
+        loadResult =
+                "{\"msg\":\"success\",\"code\":0,\"data\":{\"result\":{\"msg\":\"errCode = 2, detailMessage = , host: 10.62.1.219\",\"loadedRows\":\"\",\"id\":\"88a895b14bf84184-9a061fd09f125b10\",\"state\":\"CANCELLED\",\"type\":\"LOAD_RUN_FAIL\",\"filterRows\":\"\",\"unselectRows\":\"\",\"url\":null},\"time\":6098,\"type\":\"result_set\"},\"count\":0} ";
+        Assert.assertFalse(copyCommitter.handleCommitResponse(loadResult));
+
+        loadResult =
+                "{\"msg\":\"success\","
+                        + "\"code\":0,\"data\":{\"result\":{\"msg\":\"errCode = 2, detailMessage = There is no scanNode Backend available.[2305966: not alive]\",\"loadedRows\":\"\",\"id\":\"c301fd3c88f946f1-98d05"
+                        + "4ddae4106ae\",\"state\":\"CANCELLED\",\"type\":\"LOAD_RUN_FAIL\",\"filterRows\":\"\",\"unselectRows\":\"\",\"url\":null},\"time\":10092,\"type\":\"result_set\"},\"count\":0} ";
+        Assert.assertFalse(copyCommitter.handleCommitResponse(loadResult));
+
+        loadResult =
+                "{\"msg\":\"Error\",\"code\":1,\"data\":\"Failed to execute sql: java.sql.SQLException: (conn=44217) Exception, msg: Node catalog is not ready, please wait for a while.\",\"count\":0}";
+        Assert.assertFalse(copyCommitter.handleCommitResponse(loadResult));
+
+        loadResult =
+                "{\"msg\":\"success\",\"code\":0,\"data\":{\"result\":{\"msg\":\"\",\"loadedRows\":\"2399\",\"id\":\"31734d4274964740-ac2c022b6dfbf658\",\"state\":\"FINISHED\",\"type\":\"\",\"filterRows\":\"0\",\"unselectRows\":\"0\",\"url\":null},\"time\":54974,\"type\":\"result_set\"},\"count\":0}";
+        Assert.assertTrue(copyCommitter.handleCommitResponse(loadResult));
+
+        loadResult =
+                "{\"msg\":\"success\",\"code\":0,\"data\":{\"result\":{\"msg\":\"errCode = 2, detailMessage = No files can be copied, matched 1 files, filtered 1 files because files may be loading or loaded\",\"loadedRows\":\"\",\"id\":\"b86cb31213014886-91bc97e8df01676f\",\"state\":\"CANCELLED\",\"type\":\"ETL_RUN_FAIL\",\"filterRows\":\"\",\"unselectRows\":\"\",\"url\":null},\"time\":5019,\"type\":\"result_set\"},\"count\":0}";
+        Assert.assertTrue(copyCommitter.handleCommitResponse(loadResult));
+    }
+}


### PR DESCRIPTION
# Proposed changes

Currently `sink.write-mode` supports `stream_load`, and `stream_load_batch` is used for streamload import.
Now the import method of `copy` load is added to adapt to the scenario of Doris storage and calculation separation.
The import is divided into two steps:
1. First upload the data to object storage.
2. Then load the data on the object storage into Doris.

This import method is usually used for synchronization across vpc scenarios (flink cluster and doris cluster).
## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
