### PR TITLE
[fix]Fix github workflow Run ITCases 2.0 failure

### DIFF
--- a/.github/workflows/run-e2ecase-12.yml
+++ b/.github/workflows/run-e2ecase-12.yml
@@ -40,5 +40,5 @@ jobs:
 
     - name: Run E2ECases
       run: |
-        cd flink-doris-connector && mvn test -Dtest="*E2ECase" -Dimage="adamlee489/doris:1.2.7.1_x86"
+        cd flink-doris-connector && mvn test -T 1C -Dtest="*E2ECase" -Dimage="adamlee489/doris:1.2.7.1_x86"
 

--- a/.github/workflows/run-e2ecase-20.yml
+++ b/.github/workflows/run-e2ecase-20.yml
@@ -40,5 +40,5 @@ jobs:
 
     - name: Run E2ECases
       run: |
-        cd flink-doris-connector && mvn test -Dtest="*E2ECase" -Dimage="adamlee489/doris:2.0.3"
+        cd flink-doris-connector && mvn test -T 1C -Dtest="*E2ECase" -Dimage="adamlee489/doris:2.0.3"
 

--- a/.github/workflows/run-itcase-12.yml
+++ b/.github/workflows/run-itcase-12.yml
@@ -40,5 +40,5 @@ jobs:
 
     - name: Run ITCases
       run: |
-        cd flink-doris-connector && mvn test -Dtest="*ITCase" -Dimage="adamlee489/doris:1.2.7.1_x86"
+        cd flink-doris-connector && mvn test -T 1C -Dtest="*ITCase" -Dimage="adamlee489/doris:1.2.7.1_x86"
 

--- a/.github/workflows/run-itcase-20.yml
+++ b/.github/workflows/run-itcase-20.yml
@@ -40,5 +40,5 @@ jobs:
 
     - name: Run ITCases
       run: |
-        cd flink-doris-connector && mvn test -Dtest="*ITCase" -Dimage="adamlee489/doris:2.0.3"
+        cd flink-doris-connector && mvn test -T 1C -Dtest="*ITCase" -Dimage="adamlee489/doris:2.0.3"
 

--- a/flink-doris-connector/pom.xml
+++ b/flink-doris-connector/pom.xml
@@ -90,8 +90,8 @@ under the License.
         <slf4j.version>1.7.25</slf4j.version>
         <mockito.version>4.2.0</mockito.version>
         <testcontainers.version>1.17.6</testcontainers.version>
-        <junit-jupiter.version>5.10.1</junit-jupiter.version>
-        <junit.version>4.11</junit.version>
+        <junit5.version>5.10.1</junit5.version>
+        <junit4.version>4.11</junit4.version>
         <hamcrest.version>1.3</hamcrest.version>
     </properties>
 
@@ -314,13 +314,20 @@ under the License.
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>${junit4.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit-jupiter.version}</version>
+            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
@@ -18,8 +18,8 @@
 package org.apache.doris.flink;
 
 import com.google.common.collect.Lists;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -66,23 +66,23 @@ public abstract class DorisTestBase {
         return DORIS_CONTAINER.getHost() + ":8030";
     }
 
-    @BeforeClass
-    public static void startContainers() {
-        LOG.info("Starting containers...");
+    @BeforeEach
+    public void startContainers() {
+        LOG.info("Starting doris containers...");
         Startables.deepStart(Stream.of(DORIS_CONTAINER)).join();
         given().ignoreExceptions()
                 .await()
                 .atMost(300, TimeUnit.SECONDS)
                 .pollInterval(ONE_SECOND)
                 .untilAsserted(DorisTestBase::initializeJdbcConnection);
-        LOG.info("Containers are started.");
+        LOG.info("Containers doris are started.");
     }
 
-    @AfterClass
-    public static void stopContainers() {
-        LOG.info("Stopping containers...");
+    @AfterEach
+    public void stopContainers() {
+        LOG.info("Stopping doris containers...");
         DORIS_CONTAINER.stop();
-        LOG.info("Containers are stopped.");
+        LOG.info("Containers doris are stopped.");
     }
 
     public static GenericContainer createDorisContainer() {

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
@@ -27,8 +27,12 @@ import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.writer.serializer.SimpleStringSerializer;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -44,11 +48,22 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /** DorisSink ITCase with csv and arrow format. */
+@Execution(ExecutionMode.SAME_THREAD)
 public class DorisSinkITCase extends DorisTestBase {
     static final String DATABASE = "test";
     static final String TABLE_CSV = "tbl_csv";
     static final String TABLE_JSON = "tbl_json";
     static final String TABLE_JSON_TBL = "tbl_json_tbl";
+
+    @BeforeEach
+    public void startContainers() {
+        super.startContainers();
+    }
+
+    @AfterEach
+    public void stopContainers() {
+        super.stopContainers();
+    }
 
     @Test
     public void testSinkCsvFormat() throws Exception {

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
@@ -29,8 +29,12 @@ import org.apache.doris.flink.DorisTestBase;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.deserialization.SimpleListDeserializationSchema;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -38,10 +42,21 @@ import java.util.Arrays;
 import java.util.List;
 
 /** DorisSource ITCase. */
+@Execution(ExecutionMode.SAME_THREAD)
 public class DorisSourceITCase extends DorisTestBase {
     static final String DATABASE = "test";
     static final String TABLE_READ = "tbl_read";
     static final String TABLE_READ_TBL = "tbl_read_tbl";
+
+    @BeforeEach
+    public void startContainers() {
+        super.startContainers();
+    }
+
+    @AfterEach
+    public void stopContainers() {
+        super.stopContainers();
+    }
 
     @Test
     public void testSource() throws Exception {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
Due to the concurrent execution of multiple threads in github workflow, after the previous thread finishes executing, the container will be closed early.

<img width="1419" alt="image" src="https://github.com/apache/doris-flink-connector/assets/46414265/c5cb3244-1a9c-4c88-be0a-7672f1bb7004">
<img width="1045" alt="image" src="https://github.com/apache/doris-flink-connector/assets/46414265/7871c91c-ebf0-4e26-8edb-4a1169f22d80">




## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
