### PR TITLE
[fix](cdc) add Oracle table name validation

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/TableSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/TableSchema.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 public class TableSchema {
+    public static final String DORIS_TABLE_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]*$";
     private String database;
     private String table;
     private String tableComment;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/sqlserver/SqlServerDatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/sqlserver/SqlServerDatabaseSync.java
@@ -125,7 +125,7 @@ public class SqlServerDatabaseSync extends DatabaseSync {
         String databaseName = config.get(JdbcSourceOptions.DATABASE_NAME);
         String schemaName = config.get(JdbcSourceOptions.SCHEMA_NAME);
         Preconditions.checkNotNull(databaseName, "database-name in sqlserver is required");
-        Preconditions.checkNotNull(databaseName, "schema-name in sqlserver is required");
+        Preconditions.checkNotNull(schemaName, "schema-name in sqlserver is required");
 
         String tableName = config.get(JdbcSourceOptions.TABLE_NAME);
         String hostname = config.get(JdbcSourceOptions.HOSTNAME);


### PR DESCRIPTION
# Proposed changes
In Oracle , the table names to contain special characters such as /, #, $, etc.. However, Doris does not support tables with these characters.
Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
