### PR TITLE
[Improve](sink) add options to commit tolerance

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -19,6 +19,7 @@ package org.apache.doris.flink.cfg;
 
 import org.apache.flink.util.Preconditions;
 
+import org.apache.doris.flink.sink.committer.CommitTolerance;
 import org.apache.doris.flink.sink.writer.WriteMode;
 
 import java.io.Serializable;
@@ -63,6 +64,7 @@ public class DorisExecutionOptions implements Serializable {
     private final boolean enableBatchMode;
     private final boolean ignoreUpdateBefore;
     private final WriteMode writeMode;
+    private final CommitTolerance commitTolerance;
 
     public DorisExecutionOptions(
             int checkInterval,
@@ -81,7 +83,8 @@ public class DorisExecutionOptions implements Serializable {
             long bufferFlushIntervalMs,
             boolean ignoreUpdateBefore,
             boolean force2PC,
-            WriteMode writeMode) {
+            WriteMode writeMode,
+            CommitTolerance commitTolerance) {
         Preconditions.checkArgument(maxRetries >= 0);
         this.checkInterval = checkInterval;
         this.maxRetries = maxRetries;
@@ -102,6 +105,7 @@ public class DorisExecutionOptions implements Serializable {
 
         this.ignoreUpdateBefore = ignoreUpdateBefore;
         this.writeMode = writeMode;
+        this.commitTolerance = commitTolerance;
     }
 
     public static Builder builder() {
@@ -205,6 +209,10 @@ public class DorisExecutionOptions implements Serializable {
         return writeMode;
     }
 
+    public CommitTolerance getCommitTolerance() {
+        return commitTolerance;
+    }
+
     /** Builder of {@link DorisExecutionOptions}. */
     public static class Builder {
         private int checkInterval = DEFAULT_CHECK_INTERVAL;
@@ -229,6 +237,7 @@ public class DorisExecutionOptions implements Serializable {
 
         private boolean ignoreUpdateBefore = true;
         private WriteMode writeMode = WriteMode.STREAM_LOAD;
+        private CommitTolerance commitTolerance = CommitTolerance.NEVER;
 
         public Builder setCheckInterval(Integer checkInterval) {
             this.checkInterval = checkInterval;
@@ -320,6 +329,10 @@ public class DorisExecutionOptions implements Serializable {
             return this;
         }
 
+        public void setCommitTolerance(CommitTolerance commitTolerance) {
+            this.commitTolerance = commitTolerance;
+        }
+
         public DorisExecutionOptions build() {
             // If format=json is set but read_json_by_line is not set, record may not be written.
             if (streamLoadProp != null
@@ -344,7 +357,8 @@ public class DorisExecutionOptions implements Serializable {
                     bufferFlushIntervalMs,
                     ignoreUpdateBefore,
                     force2PC,
-                    writeMode);
+                    writeMode,
+                    commitTolerance);
         }
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -329,8 +329,9 @@ public class DorisExecutionOptions implements Serializable {
             return this;
         }
 
-        public void setCommitTolerance(CommitTolerance commitTolerance) {
+        public Builder setCommitTolerance(CommitTolerance commitTolerance) {
             this.commitTolerance = commitTolerance;
+            return this;
         }
 
         public DorisExecutionOptions build() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/DorisCommittable.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/DorisCommittable.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.flink.sink;
 
+import org.apache.doris.flink.sink.committer.CommitTolerance;
+
 import java.util.Objects;
 
 /** DorisCommittable hold the info for Committer to commit. */
@@ -24,6 +26,7 @@ public class DorisCommittable implements DorisAbstractCommittable {
     private final String hostPort;
     private final String db;
     private final long txnID;
+    private CommitTolerance commitTolerance;
 
     public DorisCommittable(String hostPort, String db, long txnID) {
         this.hostPort = hostPort;
@@ -41,6 +44,14 @@ public class DorisCommittable implements DorisAbstractCommittable {
 
     public long getTxnID() {
         return txnID;
+    }
+
+    public void setCommitTolerance(CommitTolerance commitTolerance) {
+        this.commitTolerance = commitTolerance;
+    }
+
+    public CommitTolerance getCommitTolerance() {
+        return commitTolerance;
     }
 
     @Override
@@ -73,6 +84,8 @@ public class DorisCommittable implements DorisAbstractCommittable {
                 + '\''
                 + ", txnID="
                 + txnID
+                + ", commitTolerance="
+                + commitTolerance
                 + '}';
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/DorisSink.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/DorisSink.java
@@ -89,8 +89,7 @@ public class DorisSink<IN>
     public Committer createCommitter() throws IOException {
         if (WriteMode.STREAM_LOAD.equals(dorisExecutionOptions.getWriteMode())
                 || WriteMode.STREAM_LOAD_BATCH.equals(dorisExecutionOptions.getWriteMode())) {
-            return new DorisCommitter(
-                    dorisOptions, dorisReadOptions, dorisExecutionOptions.getMaxRetries());
+            return new DorisCommitter(dorisOptions, dorisReadOptions, dorisExecutionOptions);
         } else if (WriteMode.COPY.equals(dorisExecutionOptions.getWriteMode())) {
             return new DorisCopyCommitter(dorisOptions, dorisExecutionOptions.getMaxRetries());
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/committer/CommitTolerance.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/committer/CommitTolerance.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.committer;
+
+import java.io.Serializable;
+
+/**
+ * The strategy for Commit transaction failure, the default is NEVER. NEVER: Do not ignore Commit
+ * transaction failure; ONCE: When resuming the task for the first time, ignore the Txn that failed
+ * the first Commit, For example, the Txn has expired; ALWAYS: Ignore Commit transaction failure
+ */
+public enum CommitTolerance implements Serializable {
+    NEVER,
+    ONCE,
+    ALWAYS;
+
+    public static CommitTolerance of(String name) {
+        try {
+            return CommitTolerance.valueOf(name.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unsupported commit tolerance: " + name);
+        }
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
@@ -119,7 +119,7 @@ public class DorisCommitter implements Committer<DorisCommittable>, Closeable {
                 "commit txn {} to host {}, tolerance is {}",
                 committable.getTxnID(),
                 hostPort,
-                committable.getCommitTolerance());
+                commitTolerance);
         int retry = 0;
         while (retry <= maxRetry) {
             // get latest-url

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -21,6 +21,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.table.factories.FactoryUtil;
 
+import org.apache.doris.flink.sink.committer.CommitTolerance;
 import org.apache.doris.flink.sink.writer.WriteMode;
 
 import java.time.Duration;
@@ -234,6 +235,12 @@ public class DorisConfigOptions {
                     .stringType()
                     .defaultValue(WriteMode.STREAM_LOAD.name())
                     .withDescription("Write mode, supports stream_load, stream_load_batch");
+
+    public static final ConfigOption<String> SINK_COMMIT_TOLERANCE =
+            ConfigOptions.key("sink.commit-tolerance")
+                    .stringType()
+                    .defaultValue(CommitTolerance.NEVER.name())
+                    .withDescription("Commit tolerance, supports never, once, always");
 
     public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
@@ -32,6 +32,7 @@ import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisLookupOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.sink.committer.CommitTolerance;
 import org.apache.doris.flink.sink.writer.WriteMode;
 
 import java.util.HashSet;
@@ -69,6 +70,7 @@ import static org.apache.doris.flink.table.DorisConfigOptions.SINK_BUFFER_FLUSH_
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_BUFFER_SIZE;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_CHECK_INTERVAL;
+import static org.apache.doris.flink.table.DorisConfigOptions.SINK_COMMIT_TOLERANCE;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_ENABLE_2PC;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_ENABLE_BATCH_MODE;
 import static org.apache.doris.flink.table.DorisConfigOptions.SINK_ENABLE_DELETE;
@@ -156,6 +158,7 @@ public final class DorisDynamicTableFactory
 
         options.add(SOURCE_USE_OLD_API);
         options.add(SINK_WRITE_MODE);
+        options.add(SINK_COMMIT_TOLERANCE);
         return options;
     }
 
@@ -235,6 +238,7 @@ public final class DorisDynamicTableFactory
         }
 
         builder.setWriteMode(WriteMode.of(readableConfig.get(SINK_WRITE_MODE)));
+        builder.setCommitTolerance(CommitTolerance.of(readableConfig.get(SINK_COMMIT_TOLERANCE)));
         builder.setBatchMode(readableConfig.get(SINK_ENABLE_BATCH_MODE));
         // Compatible with previous versions
         if (readableConfig.get(SINK_ENABLE_BATCH_MODE)) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -34,6 +34,7 @@ import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.DorisSink;
+import org.apache.doris.flink.sink.committer.CommitTolerance;
 import org.apache.doris.flink.sink.writer.WriteMode;
 import org.apache.doris.flink.sink.writer.serializer.DorisRecordSerializer;
 import org.apache.doris.flink.sink.writer.serializer.JsonDebeziumSchemaSerializer;
@@ -291,6 +292,9 @@ public abstract class DatabaseSync {
         sinkConfig
                 .getOptional(DorisConfigOptions.SINK_WRITE_MODE)
                 .ifPresent(v -> executionBuilder.setWriteMode(WriteMode.of(v)));
+        sinkConfig
+                .getOptional(DorisConfigOptions.SINK_COMMIT_TOLERANCE)
+                .ifPresent(v -> executionBuilder.setCommitTolerance(CommitTolerance.of(v)));
 
         DorisExecutionOptions executionOptions = executionBuilder.build();
         builder.setDorisReadOptions(DorisReadOptions.builder().build())

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/committer/TestDorisCommitter.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/committer/TestDorisCommitter.java
@@ -97,7 +97,7 @@ public class TestDorisCommitter {
     @Test
     public void testCommitAbort() throws Exception {
         thrown.expect(DorisRuntimeException.class);
-        thrown.expectMessage("commit transaction error");
+        thrown.expectMessage("Commit transaction error");
 
         String response =
                 "{\n"


### PR DESCRIPTION
# Proposed changes

Normally, in 2pc, commit cannot fail, otherwise it will cause data loss.
But sometimes, when resuming a task from checkpoint, the txnid recorded in the checkpoint may have expired. At this time, an error txn not found will be reported, including some other unexpected errors.
At this time, the offset of the source saved by ckpt cannot be used. If the txn is submitted successfully, the first commit failure can be tolerated.

Therefore, the parameter `sink.commit-tolerance` is added. It supports three configurations: NEVER, ONCE, and ALWAYS. The default is NEVER.
NEVER means never ignore Commit errors.
ONCE means ignore it only once, usually on first startup. At this time, you need to ensure that txn is successful, otherwise data may be lost.
ALWAYS means it has been ignored.


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
