### PR TITLE
[improve] oracle cdc regex improve

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public abstract class DatabaseSync {
     private static final Logger LOG = LoggerFactory.getLogger(DatabaseSync.class);
@@ -327,9 +326,7 @@ public abstract class DatabaseSync {
 
     protected String getSyncTableList(List<String> syncTables) {
         if (!singleSink) {
-            return syncTables.stream()
-                    .map(v -> getTableListPrefix() + "\\." + v)
-                    .collect(Collectors.joining("|"));
+            return String.format("(%s)\\.(%s)", getTableListPrefix(), String.join("|", syncTables));
         } else {
             // includingTablePattern and ^excludingPattern
             if (includingTables == null) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleDatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleDatabaseSync.java
@@ -154,10 +154,8 @@ public class OracleDatabaseSync extends DatabaseSync {
         // When debezium incrementally reads, it will be judged based on regexp_like.
         // When the regular length exceeds 512, an error will be reported,
         // like ORA-12733: regular expression too long
-        if (tableName.length() > 384) {
-            // max database name length 128
-            tableName =
-                    StringUtils.isNullOrWhitespaceOnly(includingTables) ? ".*" : includingTables;
+        if (tableName.length() > 512) {
+            tableName = StringUtils.isNullOrWhitespaceOnly(includingTables) ? ".*" : tableName;
         }
 
         String url = config.get(OracleSourceOptions.URL);

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/DatabaseSyncTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/DatabaseSyncTest.java
@@ -62,7 +62,7 @@ public class DatabaseSyncTest {
         config.setString("table-name", "tbl.*");
         databaseSync.setConfig(config);
         String syncTableList = databaseSync.getSyncTableList(Arrays.asList("tbl_1", "tbl_2"));
-        assertEquals("db\\.tbl_1|db\\.tbl_2", syncTableList);
+        assertEquals("(db)\\.(tbl_1|tbl_2)", syncTableList);
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

Convert the value of table.include.list from `db.tbl_1|db.tbl2 to (db).(tbl_1|tbl_2)`
This is very useful during Oracle synchronization, because debezium is limited by regex_like function characters when reading from Oracle.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
