### PR TITLE
[improve] make doris container singleton

### DIFF
--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
@@ -72,7 +72,10 @@ public abstract class DorisTestBase {
         return DORIS_CONTAINER.getHost() + ":8030";
     }
 
-    @BeforeClass
+    static {
+        startContainers();
+    }
+
     public static void startContainers() {
         LOG.info("Starting doris containers...");
         Startables.deepStart(Stream.of(DORIS_CONTAINER)).join();
@@ -84,7 +87,6 @@ public abstract class DorisTestBase {
         LOG.info("Containers doris are started.");
     }
 
-    @AfterClass
     public static void stopContainers() {
         LOG.info("Stopping doris containers...");
         DORIS_CONTAINER.stop();
@@ -92,6 +94,7 @@ public abstract class DorisTestBase {
     }
 
     public static GenericContainer createDorisContainer() {
+        LOG.info("Create doris containers...");
         GenericContainer container =
                 new GenericContainer<>(DORIS_DOCKER_IMAGE)
                         .withNetwork(Network.newNetwork())
@@ -99,8 +102,7 @@ public abstract class DorisTestBase {
                         .withPrivilegedMode(true)
                         .withLogConsumer(
                                 new Slf4jLogConsumer(
-                                        DockerLoggerFactory.getLogger(DORIS_DOCKER_IMAGE)))
-                        .withReuse(true);
+                                        DockerLoggerFactory.getLogger(DORIS_DOCKER_IMAGE)));
 
         container.setPortBindings(
                 Lists.newArrayList(


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
The current case will start multiple doris container images, which can be optimized to a single instance image to make it run faster.
refer to [manual_lifecycle_control](https://java.testcontainers.org/test_framework_integration/manual_lifecycle_control/)

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
