### PR TITLE
[improve] make doris container singleton

### DIFF
--- a/.github/workflows/run-e2ecase.yml
+++ b/.github/workflows/run-e2ecase.yml
@@ -40,5 +40,5 @@ jobs:
 
     - name: Run E2ECases
       run: |
-        cd flink-doris-connector && mvn test -Dtest="*E2ECase" -Dimage="adamlee489/doris:2.0.3"
+        cd flink-doris-connector && mvn test -Dtest="*E2ECase" -Dimage="apache/doris:doris-all-in-one-2.1.0"
 

--- a/.github/workflows/run-itcase.yml
+++ b/.github/workflows/run-itcase.yml
@@ -40,5 +40,5 @@ jobs:
 
     - name: Run ITCases
       run: |
-        cd flink-doris-connector && mvn test -Dtest="*ITCase" -Dimage="adamlee489/doris:2.0.3"
+        cd flink-doris-connector && mvn test -Dtest="*ITCase" -Dimage="apache/doris:doris-all-in-one-2.1.0"
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
@@ -46,7 +46,7 @@ import java.util.concurrent.locks.LockSupport;
 
 public abstract class DorisTestBase {
     protected static final Logger LOG = LoggerFactory.getLogger(DorisTestBase.class);
-    private static final String DEFAULT_DOCKER_IMAGE = "adamlee489/doris:2.0.3";
+    private static final String DEFAULT_DOCKER_IMAGE = "apache/doris:doris-all-in-one-2.1.0";
     protected static final String DORIS_DOCKER_IMAGE =
             System.getProperty("image") == null
                     ? DEFAULT_DOCKER_IMAGE

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
@@ -18,8 +18,6 @@
 package org.apache.doris.flink;
 
 import com.google.common.collect.Lists;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerLoggerFactory;
 
 import java.io.BufferedReader;
@@ -90,8 +89,7 @@ public abstract class DorisTestBase {
                         .withLogConsumer(
                                 new Slf4jLogConsumer(
                                         DockerLoggerFactory.getLogger(DORIS_DOCKER_IMAGE)))
-                        .withExposedPorts(8030, 9030, 8040, 9060)
-                        .waitingFor(Wait.forLogMessage(".*register be exec success.*\\n", 1));
+                        .withExposedPorts(8030, 9030, 8040, 9060);
 
         container.setPortBindings(
                 Lists.newArrayList(

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/DorisTestBase.java
@@ -72,7 +72,10 @@ public abstract class DorisTestBase {
         return DORIS_CONTAINER.getHost() + ":8030";
     }
 
-    @BeforeClass
+    static {
+        startContainers();
+    }
+
     public static void startContainers() {
         LOG.info("Starting doris containers...");
         Startables.deepStart(Stream.of(DORIS_CONTAINER)).join();
@@ -84,7 +87,6 @@ public abstract class DorisTestBase {
         LOG.info("Containers doris are started.");
     }
 
-    @AfterClass
     public static void stopContainers() {
         LOG.info("Stopping doris containers...");
         DORIS_CONTAINER.stop();
@@ -92,6 +94,7 @@ public abstract class DorisTestBase {
     }
 
     public static GenericContainer createDorisContainer() {
+        LOG.info("Create doris containers...");
         GenericContainer container =
                 new GenericContainer<>(DORIS_DOCKER_IMAGE)
                         .withNetwork(Network.newNetwork())
@@ -99,8 +102,7 @@ public abstract class DorisTestBase {
                         .withPrivilegedMode(true)
                         .withLogConsumer(
                                 new Slf4jLogConsumer(
-                                        DockerLoggerFactory.getLogger(DORIS_DOCKER_IMAGE)))
-                        .withReuse(true);
+                                        DockerLoggerFactory.getLogger(DORIS_DOCKER_IMAGE)));
 
         container.setPortBindings(
                 Lists.newArrayList(

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/MySQLDorisE2ECase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/MySQLDorisE2ECase.java
@@ -280,6 +280,7 @@ public class MySQLDorisE2ECase extends DorisTestBase {
                         DriverManager.getConnection(
                                 String.format(URL, DORIS_CONTAINER.getHost()), USERNAME, PASSWORD);
                 Statement statement = connection.createStatement()) {
+            statement.execute(String.format("CREATE DATABASE IF NOT EXISTS %s", DATABASE));
             statement.execute(String.format("DROP TABLE IF EXISTS %s.%s", DATABASE, TABLE_1));
             statement.execute(String.format("DROP TABLE IF EXISTS %s.%s", DATABASE, TABLE_2));
             statement.execute(String.format("DROP TABLE IF EXISTS %s.%s", DATABASE, TABLE_3));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The current case will start multiple doris container images, which can be optimized to a single instance image to make it run faster.
refer to [manual_lifecycle_control](https://java.testcontainers.org/test_framework_integration/manual_lifecycle_control/)

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
