### PR TITLE
[improve] Improve Httpclient Connection

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
@@ -35,6 +35,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +85,7 @@ public class BatchStageLoad implements Serializable {
     private final AtomicBoolean started;
     private volatile boolean loadThreadAlive = false;
     private AtomicReference<Throwable> exception = new AtomicReference<>(null);
-    private CloseableHttpClient httpClient = new HttpUtil().getHttpClientWithTimeout();
+    private HttpClientBuilder httpClientBuilder = new HttpUtil().getHttpClientBuilderForBatch();
 
     public BatchStageLoad(
             DorisOptions dorisOptions,
@@ -290,33 +291,38 @@ public class BatchStageLoad implements Serializable {
                         BackoffAndRetryUtils.backoffAndRetry(
                                 BackoffAndRetryUtils.LoadOperation.UPLOAD_FILE,
                                 () -> {
-                                    try (CloseableHttpResponse response =
-                                            httpClient.execute(httpPut)) {
-                                        final int statusCode =
-                                                response.getStatusLine().getStatusCode();
-                                        String requestId = getRequestId(response.getAllHeaders());
-                                        if (statusCode == 200 && response.getEntity() != null) {
-                                            String loadResult =
-                                                    EntityUtils.toString(response.getEntity());
-                                            if (loadResult == null || loadResult.isEmpty()) {
-                                                // upload finished
-                                                return requestId;
+                                    try (CloseableHttpClient httpClient =
+                                            httpClientBuilder.build()) {
+                                        try (CloseableHttpResponse response =
+                                                httpClient.execute(httpPut)) {
+                                            final int statusCode =
+                                                    response.getStatusLine().getStatusCode();
+                                            String requestId =
+                                                    getRequestId(response.getAllHeaders());
+                                            if (statusCode == 200 && response.getEntity() != null) {
+                                                String loadResult =
+                                                        EntityUtils.toString(response.getEntity());
+                                                if (loadResult == null || loadResult.isEmpty()) {
+                                                    // upload finished
+                                                    return requestId;
+                                                }
+                                                LOG.error(
+                                                        "upload file failed, requestId is {}, response result: {}",
+                                                        requestId,
+                                                        loadResult);
+                                                throw new CopyLoadException(
+                                                        "upload file failed: "
+                                                                + response.getStatusLine()
+                                                                        .toString()
+                                                                + ", with requestId "
+                                                                + requestId);
                                             }
-                                            LOG.error(
-                                                    "upload file failed, requestId is {}, response result: {}",
-                                                    requestId,
-                                                    loadResult);
                                             throw new CopyLoadException(
-                                                    "upload file failed: "
+                                                    "upload file error: "
                                                             + response.getStatusLine().toString()
                                                             + ", with requestId "
                                                             + requestId);
                                         }
-                                        throw new CopyLoadException(
-                                                "upload file error: "
-                                                        + response.getStatusLine().toString()
-                                                        + ", with requestId "
-                                                        + requestId);
                                     }
                                 });
                 return String.valueOf(result);
@@ -361,27 +367,33 @@ public class BatchStageLoad implements Serializable {
                         BackoffAndRetryUtils.backoffAndRetry(
                                 BackoffAndRetryUtils.LoadOperation.GET_INTERNAL_STAGE_ADDRESS,
                                 () -> {
-                                    try (CloseableHttpResponse execute =
-                                            httpClient.execute(putBuilder.build())) {
-                                        int statusCode = execute.getStatusLine().getStatusCode();
-                                        String reason = execute.getStatusLine().getReasonPhrase();
-                                        if (statusCode == 307) {
-                                            Header location = execute.getFirstHeader("location");
-                                            String uploadAddress = location.getValue();
-                                            return uploadAddress;
-                                        } else {
-                                            HttpEntity entity = execute.getEntity();
-                                            String result =
-                                                    entity == null
-                                                            ? null
-                                                            : EntityUtils.toString(entity);
-                                            LOG.error(
-                                                    "Failed to get internalStage address, status {}, reason {}, response {}",
-                                                    statusCode,
-                                                    reason,
-                                                    result);
-                                            throw new CopyLoadException(
-                                                    "Failed get internalStage address");
+                                    try (CloseableHttpClient httpClient =
+                                            httpClientBuilder.build()) {
+                                        try (CloseableHttpResponse execute =
+                                                httpClient.execute(putBuilder.build())) {
+                                            int statusCode =
+                                                    execute.getStatusLine().getStatusCode();
+                                            String reason =
+                                                    execute.getStatusLine().getReasonPhrase();
+                                            if (statusCode == 307) {
+                                                Header location =
+                                                        execute.getFirstHeader("location");
+                                                String uploadAddress = location.getValue();
+                                                return uploadAddress;
+                                            } else {
+                                                HttpEntity entity = execute.getEntity();
+                                                String result =
+                                                        entity == null
+                                                                ? null
+                                                                : EntityUtils.toString(entity);
+                                                LOG.error(
+                                                        "Failed to get internalStage address, status {}, reason {}, response {}",
+                                                        statusCode,
+                                                        reason,
+                                                        result);
+                                                throw new CopyLoadException(
+                                                        "Failed get internalStage address");
+                                            }
                                         }
                                     }
                                 });

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommitter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommitter.java
@@ -31,6 +31,7 @@ import org.apache.doris.flink.sink.copy.models.CopyIntoResp;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,18 +48,20 @@ public class DorisCopyCommitter implements Committer<DorisCopyCommittable>, Clos
     private static final int SUCCESS = 0;
     private static final String FAIL = "1";
     private ObjectMapper objectMapper = new ObjectMapper();
-    private final CloseableHttpClient httpClient;
     private final DorisOptions dorisOptions;
+    private HttpClientBuilder httpClientBuilder = new HttpUtil().getHttpClientBuilderForBatch();
     int maxRetry;
 
     public DorisCopyCommitter(DorisOptions dorisOptions, int maxRetry) {
-        this(dorisOptions, maxRetry, new HttpUtil().getHttpClientWithTimeout());
-    }
-
-    public DorisCopyCommitter(DorisOptions dorisOptions, int maxRetry, CloseableHttpClient client) {
         this.dorisOptions = dorisOptions;
         this.maxRetry = maxRetry;
-        this.httpClient = client;
+    }
+
+    public DorisCopyCommitter(
+            DorisOptions dorisOptions, int maxRetry, HttpClientBuilder httpClientBuilder) {
+        this.dorisOptions = dorisOptions;
+        this.maxRetry = maxRetry;
+        this.httpClientBuilder = httpClientBuilder;
     }
 
     @Override
@@ -88,31 +91,32 @@ public class DorisCopyCommitter implements Committer<DorisCopyCommittable>, Clos
                     .setUrl(String.format(commitPattern, hostPort))
                     .baseAuth(dorisOptions.getUsername(), dorisOptions.getPassword())
                     .setEntity(new StringEntity(objectMapper.writeValueAsString(params)));
-
-            try (CloseableHttpResponse response = httpClient.execute(postBuilder.build())) {
-                statusCode = response.getStatusLine().getStatusCode();
-                reasonPhrase = response.getStatusLine().getReasonPhrase();
-                if (statusCode != 200) {
-                    LOG.warn(
-                            "commit failed with status {} {}, reason {}",
-                            statusCode,
-                            hostPort,
-                            reasonPhrase);
-                } else if (response.getEntity() != null) {
-                    loadResult = EntityUtils.toString(response.getEntity());
-                    success = handleCommitResponse(loadResult);
-                    if (success) {
-                        LOG.info(
-                                "commit success cost {}ms, response is {}",
-                                System.currentTimeMillis() - start,
-                                loadResult);
-                        break;
-                    } else {
-                        LOG.warn("commit failed, retry again");
+            try (CloseableHttpClient httpClient = httpClientBuilder.build()) {
+                try (CloseableHttpResponse response = httpClient.execute(postBuilder.build())) {
+                    statusCode = response.getStatusLine().getStatusCode();
+                    reasonPhrase = response.getStatusLine().getReasonPhrase();
+                    if (statusCode != 200) {
+                        LOG.warn(
+                                "commit failed with status {} {}, reason {}",
+                                statusCode,
+                                hostPort,
+                                reasonPhrase);
+                    } else if (response.getEntity() != null) {
+                        loadResult = EntityUtils.toString(response.getEntity());
+                        success = handleCommitResponse(loadResult);
+                        if (success) {
+                            LOG.info(
+                                    "commit success cost {}ms, response is {}",
+                                    System.currentTimeMillis() - start,
+                                    loadResult);
+                            break;
+                        } else {
+                            LOG.warn("commit failed, retry again");
+                        }
                     }
+                } catch (IOException e) {
+                    LOG.error("commit error : ", e);
                 }
-            } catch (IOException e) {
-                LOG.error("commit error : ", e);
             }
         }
 
@@ -158,9 +162,5 @@ public class DorisCopyCommitter implements Committer<DorisCopyCommittable>, Clos
     }
 
     @Override
-    public void close() throws IOException {
-        if (httpClient != null) {
-            httpClient.close();
-        }
-    }
+    public void close() throws IOException {}
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/copy/TestDorisCopyCommitter.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/copy/TestDorisCopyCommitter.java
@@ -26,6 +26,7 @@ import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,14 +49,16 @@ public class TestDorisCopyCommitter {
     public void setUp() throws Exception {
         DorisOptions dorisOptions = OptionUtils.buildDorisOptions();
         copyCommittable = new DorisCopyCommittable("127.0.0.1:8710", "copy into sql");
+        HttpClientBuilder httpClientBuilder = mock(HttpClientBuilder.class);
         CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        when(httpClientBuilder.build()).thenReturn(httpClient);
         entityMock = new HttpEntityMock();
         CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
         StatusLine normalLine = new BasicStatusLine(new ProtocolVersion("http", 1, 0), 200, "");
         when(httpClient.execute(any())).thenReturn(httpResponse);
         when(httpResponse.getStatusLine()).thenReturn(normalLine);
         when(httpResponse.getEntity()).thenReturn(entityMock);
-        copyCommitter = new DorisCopyCommitter(dorisOptions, 1, httpClient);
+        copyCommitter = new DorisCopyCommitter(dorisOptions, 1, httpClientBuilder);
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Connector uses HttpClient to send requests
When the FIN packet sent by the server is lost, subsequent HttpClient requests will reuse the last link, causing the request to report a Connection Reset error.
So here are two optimizations:
1. For stream mode, add evictIdleConnections setting, which will regularly clean up expired connection.
2. For batch mode, do not reuse the httpclient connection

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
