### PR TITLE
[Improvement] SupportsFilterPushDown and ProjectionPushDown in DorisSource

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalogFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalogFactory.java
@@ -33,8 +33,6 @@ import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_BATCH_SIZE;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_ARROW_ASYNC;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_QUEUE_SIZE;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_EXEC_MEM_LIMIT;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_FILTER_QUERY;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_READ_FIELD;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_QUERY_TIMEOUT_S;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_READ_TIMEOUT_MS;
@@ -86,8 +84,6 @@ public class DorisCatalogFactory implements CatalogFactory {
         options.add(USERNAME);
         options.add(PASSWORD);
 
-        options.add(DORIS_READ_FIELD);
-        options.add(DORIS_FILTER_QUERY);
         options.add(DORIS_TABLET_SIZE);
         options.add(DORIS_REQUEST_CONNECT_TIMEOUT_MS);
         options.add(DORIS_REQUEST_READ_TIMEOUT_MS);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -605,7 +605,7 @@ public class RestService implements Serializable {
         if (!StringUtils.isEmpty(readOptions.getFilterQuery())) {
             sql += " where " + readOptions.getFilterQuery();
         }
-        logger.debug("Query SQL Sending to Doris FE is: '{}'.", sql);
+        logger.info("Query SQL Sending to Doris FE is: '{}'.", sql);
 
         HttpPost httpPost = new HttpPost(getUriStr(options, logger) + QUERY_PLAN);
         String entity = "{\"sql\": \"" + sql + "\"}";

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -80,18 +80,6 @@ public class DorisConfigOptions {
                             "Use automatic redirection of fe without explicitly obtaining the be list");
 
     // source config options
-    public static final ConfigOption<String> DORIS_READ_FIELD =
-            ConfigOptions.key("doris.read.field")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "List of column names in the Doris table, separated by commas");
-    public static final ConfigOption<String> DORIS_FILTER_QUERY =
-            ConfigOptions.key("doris.filter.query")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "Filter expression of the query, which is transparently transmitted to Doris. Doris uses this expression to complete source-side data filtering");
     public static final ConfigOption<Integer> DORIS_TABLET_SIZE =
             ConfigOptions.key("doris.request.tablet.size")
                     .intType()

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
@@ -181,7 +181,8 @@ public final class DorisDynamicTableFactory
                 getDorisOptions(helper.getOptions()),
                 getDorisReadOptions(helper.getOptions()),
                 getDorisLookupOptions(helper.getOptions()),
-                physicalSchema);
+                physicalSchema,
+                context.getPhysicalRowDataType());
     }
 
     private DorisOptions getDorisOptions(ReadableConfig readableConfig) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
@@ -45,8 +45,6 @@ import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_BATCH_SIZE;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_ARROW_ASYNC;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_QUEUE_SIZE;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_EXEC_MEM_LIMIT;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_FILTER_QUERY;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_READ_FIELD;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_QUERY_TIMEOUT_S;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_READ_TIMEOUT_MS;
@@ -118,8 +116,6 @@ public final class DorisDynamicTableFactory
         options.add(JDBC_URL);
         options.add(AUTO_REDIRECT);
 
-        options.add(DORIS_READ_FIELD);
-        options.add(DORIS_FILTER_QUERY);
         options.add(DORIS_TABLET_SIZE);
         options.add(DORIS_REQUEST_CONNECT_TIMEOUT_MS);
         options.add(DORIS_REQUEST_READ_TIMEOUT_MS);
@@ -206,8 +202,6 @@ public final class DorisDynamicTableFactory
         builder.setDeserializeArrowAsync(readableConfig.get(DORIS_DESERIALIZE_ARROW_ASYNC))
                 .setDeserializeQueueSize(readableConfig.get(DORIS_DESERIALIZE_QUEUE_SIZE))
                 .setExecMemLimit(readableConfig.get(DORIS_EXEC_MEM_LIMIT).getBytes())
-                .setFilterQuery(readableConfig.get(DORIS_FILTER_QUERY))
-                .setReadFields(readableConfig.get(DORIS_READ_FIELD))
                 .setRequestQueryTimeoutS(
                         (int) readableConfig.get(DORIS_REQUEST_QUERY_TIMEOUT_S).getSeconds())
                 .setRequestBatchSize(readableConfig.get(DORIS_BATCH_SIZE))

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisExpressionVisitor.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisExpressionVisitor.java
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.table;
+
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.ExpressionVisitor;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.TypeLiteralExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import java.util.List;
+
+public class DorisExpressionVisitor implements ExpressionVisitor<String> {
+
+    @Override
+    public String visit(CallExpression call) {
+        if (BuiltInFunctionDefinitions.EQUALS.equals(call.getFunctionDefinition())) {
+            return combineExpression("=", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.LESS_THAN.equals(call.getFunctionDefinition())) {
+            return combineExpression("<", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL.equals(call.getFunctionDefinition())) {
+            return combineExpression("<=", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.GREATER_THAN.equals(call.getFunctionDefinition())) {
+            return combineExpression(">", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL.equals(call.getFunctionDefinition())) {
+            return combineExpression(">=", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.NOT_EQUALS.equals(call.getFunctionDefinition())) {
+            return combineExpression("<>", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.OR.equals(call.getFunctionDefinition())) {
+            return combineExpression("OR", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.AND.equals(call.getFunctionDefinition())) {
+            return combineExpression("AND", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.LIKE.equals(call.getFunctionDefinition())) {
+            return combineExpression("LIKE", call.getResolvedChildren());
+        }
+        if (BuiltInFunctionDefinitions.IS_NULL.equals(call.getFunctionDefinition())) {
+            return combineLeftExpression("IS NULL", call.getResolvedChildren().get(0));
+        }
+        if (BuiltInFunctionDefinitions.IS_NOT_NULL.equals(call.getFunctionDefinition())) {
+            return combineLeftExpression("IS NOT NULL", call.getResolvedChildren().get(0));
+        }
+        return null;
+    }
+
+    private String combineExpression(String operator, List<ResolvedExpression> operand) {
+        String left = operand.get(0).accept(this);
+        String right = operand.get(1).accept(this);
+        return String.format("(%s %s %s)", left, operator, right);
+    }
+
+    private String combineLeftExpression(String operator, ResolvedExpression operand) {
+        String left = operand.accept(this);
+        return String.format("(%s %s)", left, operator);
+    }
+
+    @Override
+    public String visit(ValueLiteralExpression valueLiteral) {
+        LogicalTypeRoot typeRoot = valueLiteral.getOutputDataType().getLogicalType().getTypeRoot();
+        if (typeRoot.equals(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)
+                || typeRoot.equals(LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                || typeRoot.equals(LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE)
+                || typeRoot.equals(LogicalTypeRoot.DATE)) {
+            return "'" + valueLiteral + "'";
+        }
+        return valueLiteral.toString();
+    }
+
+    @Override
+    public String visit(FieldReferenceExpression fieldReference) {
+        return fieldReference.getName();
+    }
+
+    @Override
+    public String visit(TypeLiteralExpression typeLiteral) {
+        return typeLiteral.getOutputDataType().toString();
+    }
+
+    @Override
+    public String visit(Expression expression) {
+        return null;
+    }
+}

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableSourceTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableSourceTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.connector.source.SourceProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 
+import org.apache.doris.flink.cfg.DorisLookupOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.OptionUtils;
 import org.apache.doris.flink.source.DorisSource;
@@ -48,7 +49,9 @@ public class DorisDynamicTableSourceTest {
                 new DorisDynamicTableSource(
                         OptionUtils.buildDorisOptions(),
                         builder.build(),
-                        TableSchema.fromResolvedSchema(FactoryMocks.SCHEMA));
+                        DorisLookupOptions.builder().build(),
+                        TableSchema.fromResolvedSchema(FactoryMocks.SCHEMA),
+                        FactoryMocks.PHYSICAL_DATA_TYPE);
         ScanTableSource.ScanRuntimeProvider provider =
                 actualDorisSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
         assertDorisSource(provider);
@@ -60,7 +63,9 @@ public class DorisDynamicTableSourceTest {
                 new DorisDynamicTableSource(
                         OptionUtils.buildDorisOptions(),
                         OptionUtils.buildDorisReadOptions(),
-                        TableSchema.fromResolvedSchema(FactoryMocks.SCHEMA));
+                        DorisLookupOptions.builder().build(),
+                        TableSchema.fromResolvedSchema(FactoryMocks.SCHEMA),
+                        FactoryMocks.PHYSICAL_DATA_TYPE);
         ScanTableSource.ScanRuntimeProvider provider =
                 actualDorisSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
         assertDorisSource(provider);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Background: Currently, DorisSource can only implement FilterPushDown and ProjectionPushDown through read.fields and filter.query, but cannot implement pushdown for the where that comes with FlinkSQL.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
