### PR TITLE
[improve](cdc) support changing column names using the 'CHANGE' statement

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/CdcDataChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/CdcDataChange.java
@@ -31,10 +31,19 @@ import java.util.Map;
  */
 public abstract class CdcDataChange implements ChangeEvent {
 
-    protected abstract DorisRecord serialize(String record, JsonNode recordRoot, String op)
-            throws IOException;
+    protected DorisRecord serialize(String record, JsonNode recordRoot, String op)
+            throws IOException {
+        System.out.println(record);
+        return null;
+    }
 
-    protected abstract Map<String, Object> extractBeforeRow(JsonNode record);
+    protected Map<String, Object> extractBeforeRow(JsonNode record) {
+        System.out.println(record);
+        return null;
+    }
 
-    protected abstract Map<String, Object> extractAfterRow(JsonNode record);
+    protected Map<String, Object> extractAfterRow(JsonNode record) {
+        System.out.println(record);
+        return null;
+    }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/CdcDataChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/CdcDataChange.java
@@ -31,19 +31,10 @@ import java.util.Map;
  */
 public abstract class CdcDataChange implements ChangeEvent {
 
-    protected DorisRecord serialize(String record, JsonNode recordRoot, String op)
-            throws IOException {
-        System.out.println(record);
-        return null;
-    }
+    protected abstract DorisRecord serialize(String record, JsonNode recordRoot, String op)
+            throws IOException;
 
-    protected Map<String, Object> extractBeforeRow(JsonNode record) {
-        System.out.println(record);
-        return null;
-    }
+    protected abstract Map<String, Object> extractBeforeRow(JsonNode record);
 
-    protected Map<String, Object> extractAfterRow(JsonNode record) {
-        System.out.println(record);
-        return null;
-    }
+    protected abstract Map<String, Object> extractAfterRow(JsonNode record);
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
@@ -339,6 +339,45 @@ public class TestJsonDebeziumSchemaChangeImplV2 extends TestJsonDebeziumChangeBa
     }
 
     @Test
+    public void testExtractDDlListChangeNameWithColumn() throws IOException {
+        String columnInfo =
+                "{\n"
+                        + "  \"source\": {\n"
+                        + "    \"version\": \"1.9.7.Final\",\n"
+                        + "    \"connector\": \"mysql\",\n"
+                        + "    \"name\": \"mysql_binlog_source\",\n"
+                        + "    \"ts_ms\": 1711082679841,\n"
+                        + "    \"snapshot\": \"false\",\n"
+                        + "    \"db\": \"doris_test\",\n"
+                        + "    \"sequence\": null,\n"
+                        + "    \"table\": \"test_key_word\",\n"
+                        + "    \"server_id\": 1,\n"
+                        + "    \"gtid\": null,\n"
+                        + "    \"file\": \"mysql-bin.000292\",\n"
+                        + "    \"pos\": 5496,\n"
+                        + "    \"row\": 0,\n"
+                        + "    \"thread\": null,\n"
+                        + "    \"query\": null\n"
+                        + "  },\n"
+                        + "  \"historyRecord\": \"{\\\"source\\\":{\\\"file\\\":\\\"mysql-bin.000292\\\",\\\"pos\\\":5496,\\\"server_id\\\":1},\\\"position\\\":{\\\"transaction_id\\\":null,\\\"ts_sec\\\":1711082679,\\\"file\\\":\\\"mysql-bin.000292\\\",\\\"pos\\\":5714,\\\"server_id\\\":1},\\\"databaseName\\\":\\\"test\\\",\\\"ddl\\\":\\\"alter table t1\\\\n    change column \\\\n        `key` `key_word` int default 1 not null\\\",\\\"tableChanges\\\":[{\\\"type\\\":\\\"ALTER\\\",\\\"id\\\":\\\"\\\\\\\"doris_test\\\\\\\".\\\\\\\"test_key_word\\\\\\\"\\\",\\\"table\\\":{\\\"defaultCharsetName\\\":\\\"utf8\\\",\\\"primaryKeyColumnNames\\\":[\\\"id\\\"],\\\"columns\\\":[{\\\"name\\\":\\\"id\\\",\\\"jdbcType\\\":4,\\\"typeName\\\":\\\"INT\\\",\\\"typeExpression\\\":\\\"INT\\\",\\\"charsetName\\\":null,\\\"length\\\":11,\\\"position\\\":1,\\\"optional\\\":false,\\\"autoIncremented\\\":false,\\\"generated\\\":false,\\\"comment\\\":null,\\\"hasDefaultValue\\\":false,\\\"enumValues\\\":[]},{\\\"name\\\":\\\"key_word\\\",\\\"jdbcType\\\":4,\\\"typeName\\\":\\\"INT\\\",\\\"typeExpression\\\":\\\"INT\\\",\\\"charsetName\\\":null,\\\"length\\\":11,\\\"position\\\":2,\\\"optional\\\":false,\\\"autoIncremented\\\":false,\\\"generated\\\":false,\\\"comment\\\":null,\\\"hasDefaultValue\\\":true,\\\"defaultValueExpression\\\":\\\"1\\\",\\\"enumValues\\\":[]}]},\\\"comment\\\":null}]}\"\n"
+                        + "}";
+        Map<String, Map<String, FieldSchema>> originFieldSchemaHashMap = new LinkedHashMap<>();
+        Map<String, FieldSchema> fieldSchemaHashMap = Maps.newHashMap();
+        JsonNode record = objectMapper.readTree(columnInfo);
+        schemaChange.setSourceConnector("mysql");
+
+        fieldSchemaHashMap.put("id", new FieldSchema("id", "int", "", ""));
+        fieldSchemaHashMap.put("key", new FieldSchema("key", "int", "", ""));
+        originFieldSchemaHashMap.put("test.t1", fieldSchemaHashMap);
+        schemaChange.setOriginFieldSchemaMap(originFieldSchemaHashMap);
+        List<String> changeNameList = schemaChange.extractDDLList(record);
+        System.out.println(changeNameList.get(0));
+        //        Assert.assertEquals(
+        //                "ALTER TABLE `test`.`t1` RENAME COLUMN `age` `age1`",
+        // changeNameList.get(0));
+    }
+
+    @Test
     public void testGetCdcTableIdentifier() throws Exception {
         String insert =
                 "{\"before\":{\"id\":1,\"name\":\"doris-update\",\"dt\":\"2022-01-01\",\"dtime\":\"2022-01-01 10:01:02\",\"ts\":\"2022-01-01 10:01:03\"},\"after\":null,\"source\":{\"version\":\"1.5.4.Final\",\"connector\":\"mysql\",\"name\":\"mysql_binlog_source\",\"ts_ms\":1663924328000,\"snapshot\":\"false\",\"db\":\"test\",\"sequence\":null,\"table\":\"t1\",\"server_id\":1,\"gtid\":null,\"file\":\"binlog.000006\",\"pos\":12500,\"row\":0,\"thread\":null,\"query\":null},\"op\":\"d\",\"ts_ms\":1663924328869,\"transaction\":null}";

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
@@ -323,7 +323,7 @@ public class TestJsonDebeziumSchemaChangeImplV2 extends TestJsonDebeziumChangeBa
     @Test
     public void testExtractDDlListChangeName() throws IOException {
         String columnInfo =
-                "{\"source\":{\"version\":\"1.9.7.Final\",\"connector\":\"mysql\",\"name\":\"mysql_binlog_source\",\"ts_ms\":1710925209991,\"snapshot\":\"false\",\"db\":\"testdb\",\"sequence\":null,\"table\":\"tbl1\",\"server_id\":1,\"gtid\":null,\"file\":\"mysql-bin.000288\",\"pos\":81654,\"row\":0,\"thread\":null,\"query\":null},\"historyRecord\":\"{\\\"source\\\":{\\\"file\\\":\\\"mysql-bin.000288\\\",\\\"pos\\\":81654,\\\"server_id\\\":1},\\\"position\\\":{\\\"transaction_id\\\":null,\\\"ts_sec\\\":1710925209,\\\"file\\\":\\\"mysql-bin.000288\\\",\\\"pos\\\":81808,\\\"server_id\\\":1},\\\"databaseName\\\":\\\"testdb\\\",\\\"ddl\\\":\\\"alter table tbl1 change age age1 int\\\",\\\"tableChanges\\\":[{\\\"type\\\":\\\"ALTER\\\",\\\"id\\\":\\\"\\\\\\\"test\\\\\\\".\\\\\\\"t1\\\\\\\"\\\",\\\"table\\\":{\\\"defaultCharsetName\\\":\\\"utf8\\\",\\\"primaryKeyColumnNames\\\":[\\\"name\\\"],\\\"columns\\\":[{\\\"name\\\":\\\"name\\\",\\\"jdbcType\\\":12,\\\"typeName\\\":\\\"VARCHAR\\\",\\\"typeExpression\\\":\\\"VARCHAR\\\",\\\"charsetName\\\":\\\"utf8\\\",\\\"length\\\":256,\\\"position\\\":1,\\\"optional\\\":false,\\\"autoIncremented\\\":false,\\\"generated\\\":false,\\\"comment\\\":null,\\\"hasDefaultValue\\\":false,\\\"enumValues\\\":[]},{\\\"name\\\":\\\"age1\\\",\\\"jdbcType\\\":4,\\\"typeName\\\":\\\"INT\\\",\\\"typeExpression\\\":\\\"INT\\\",\\\"charsetName\\\":null,\\\"length\\\":11,\\\"position\\\":2,\\\"optional\\\":true,\\\"autoIncremented\\\":false,\\\"generated\\\":false,\\\"comment\\\":null,\\\"hasDefaultValue\\\":true,\\\"enumValues\\\":[]}]},\\\"comment\\\":null}]}\"}";
+                "{\"source\":{\"version\":\"1.9.7.Final\",\"connector\":\"mysql\",\"name\":\"mysql_binlog_source\",\"ts_ms\":1710925209991,\"snapshot\":\"false\",\"db\":\"test\",\"sequence\":null,\"table\":\"t1\",\"server_id\":1,\"gtid\":null,\"file\":\"mysql-bin.000288\",\"pos\":81654,\"row\":0,\"thread\":null,\"query\":null},\"historyRecord\":\"{\\\"source\\\":{\\\"file\\\":\\\"mysql-bin.000288\\\",\\\"pos\\\":81654,\\\"server_id\\\":1},\\\"position\\\":{\\\"transaction_id\\\":null,\\\"ts_sec\\\":1710925209,\\\"file\\\":\\\"mysql-bin.000288\\\",\\\"pos\\\":81808,\\\"server_id\\\":1},\\\"databaseName\\\":\\\"test\\\",\\\"ddl\\\":\\\"alter table t1 change age age1 int\\\",\\\"tableChanges\\\":[{\\\"type\\\":\\\"ALTER\\\",\\\"id\\\":\\\"\\\\\\\"test\\\\\\\".\\\\\\\"t1\\\\\\\"\\\",\\\"table\\\":{\\\"defaultCharsetName\\\":\\\"utf8\\\",\\\"primaryKeyColumnNames\\\":[\\\"name\\\"],\\\"columns\\\":[{\\\"name\\\":\\\"name\\\",\\\"jdbcType\\\":12,\\\"typeName\\\":\\\"VARCHAR\\\",\\\"typeExpression\\\":\\\"VARCHAR\\\",\\\"charsetName\\\":\\\"utf8\\\",\\\"length\\\":256,\\\"position\\\":1,\\\"optional\\\":false,\\\"autoIncremented\\\":false,\\\"generated\\\":false,\\\"comment\\\":null,\\\"hasDefaultValue\\\":false,\\\"enumValues\\\":[]},{\\\"name\\\":\\\"age1\\\",\\\"jdbcType\\\":4,\\\"typeName\\\":\\\"INT\\\",\\\"typeExpression\\\":\\\"INT\\\",\\\"charsetName\\\":null,\\\"length\\\":11,\\\"position\\\":2,\\\"optional\\\":true,\\\"autoIncremented\\\":false,\\\"generated\\\":false,\\\"comment\\\":null,\\\"hasDefaultValue\\\":true,\\\"enumValues\\\":[]}]},\\\"comment\\\":null}]}\"}";
         Map<String, Map<String, FieldSchema>> originFieldSchemaHashMap = new LinkedHashMap<>();
         Map<String, FieldSchema> fieldSchemaHashMap = Maps.newHashMap();
         JsonNode record = objectMapper.readTree(columnInfo);
@@ -341,26 +341,7 @@ public class TestJsonDebeziumSchemaChangeImplV2 extends TestJsonDebeziumChangeBa
     @Test
     public void testExtractDDlListChangeNameWithColumn() throws IOException {
         String columnInfo =
-                "{\n"
-                        + "  \"source\": {\n"
-                        + "    \"version\": \"1.9.7.Final\",\n"
-                        + "    \"connector\": \"mysql\",\n"
-                        + "    \"name\": \"mysql_binlog_source\",\n"
-                        + "    \"ts_ms\": 1711082679841,\n"
-                        + "    \"snapshot\": \"false\",\n"
-                        + "    \"db\": \"doris_test\",\n"
-                        + "    \"sequence\": null,\n"
-                        + "    \"table\": \"test_key_word\",\n"
-                        + "    \"server_id\": 1,\n"
-                        + "    \"gtid\": null,\n"
-                        + "    \"file\": \"mysql-bin.000292\",\n"
-                        + "    \"pos\": 5496,\n"
-                        + "    \"row\": 0,\n"
-                        + "    \"thread\": null,\n"
-                        + "    \"query\": null\n"
-                        + "  },\n"
-                        + "  \"historyRecord\": \"{\\\"source\\\":{\\\"file\\\":\\\"mysql-bin.000292\\\",\\\"pos\\\":5496,\\\"server_id\\\":1},\\\"position\\\":{\\\"transaction_id\\\":null,\\\"ts_sec\\\":1711082679,\\\"file\\\":\\\"mysql-bin.000292\\\",\\\"pos\\\":5714,\\\"server_id\\\":1},\\\"databaseName\\\":\\\"test\\\",\\\"ddl\\\":\\\"alter table t1\\\\n    change column \\\\n        `key` `key_word` int default 1 not null\\\",\\\"tableChanges\\\":[{\\\"type\\\":\\\"ALTER\\\",\\\"id\\\":\\\"\\\\\\\"doris_test\\\\\\\".\\\\\\\"test_key_word\\\\\\\"\\\",\\\"table\\\":{\\\"defaultCharsetName\\\":\\\"utf8\\\",\\\"primaryKeyColumnNames\\\":[\\\"id\\\"],\\\"columns\\\":[{\\\"name\\\":\\\"id\\\",\\\"jdbcType\\\":4,\\\"typeName\\\":\\\"INT\\\",\\\"typeExpression\\\":\\\"INT\\\",\\\"charsetName\\\":null,\\\"length\\\":11,\\\"position\\\":1,\\\"optional\\\":false,\\\"autoIncremented\\\":false,\\\"generated\\\":false,\\\"comment\\\":null,\\\"hasDefaultValue\\\":false,\\\"enumValues\\\":[]},{\\\"name\\\":\\\"key_word\\\",\\\"jdbcType\\\":4,\\\"typeName\\\":\\\"INT\\\",\\\"typeExpression\\\":\\\"INT\\\",\\\"charsetName\\\":null,\\\"length\\\":11,\\\"position\\\":2,\\\"optional\\\":false,\\\"autoIncremented\\\":false,\\\"generated\\\":false,\\\"comment\\\":null,\\\"hasDefaultValue\\\":true,\\\"defaultValueExpression\\\":\\\"1\\\",\\\"enumValues\\\":[]}]},\\\"comment\\\":null}]}\"\n"
-                        + "}";
+                "{\"source\":{\"version\":\"1.9.7.Final\",\"connector\":\"mysql\",\"name\":\"mysql_binlog_source\",\"ts_ms\":1711088321412,\"snapshot\":\"false\",\"db\":\"doris_test\",\"sequence\":null,\"table\":\"t1\",\"server_id\":1,\"gtid\":null,\"file\":\"mysql-bin.000292\",\"pos\":55695,\"row\":0,\"thread\":null,\"query\":null},\"historyRecord\":\"{\\\"source\\\":{\\\"file\\\":\\\"mysql-bin.000292\\\",\\\"pos\\\":55695,\\\"server_id\\\":1},\\\"position\\\":{\\\"transaction_id\\\":null,\\\"ts_sec\\\":1711088321,\\\"file\\\":\\\"mysql-bin.000292\\\",\\\"pos\\\":55891,\\\"server_id\\\":1},\\\"databaseName\\\":\\\"test\\\",\\\"ddl\\\":\\\"alter table t1\\\\n    change column `key` key_word int default 1 not null\\\",\\\"tableChanges\\\":[{\\\"type\\\":\\\"ALTER\\\",\\\"id\\\":\\\"\\\\\\\"test\\\\\\\".\\\\\\\"t1\\\\\\\"\\\",\\\"table\\\":{\\\"defaultCharsetName\\\":\\\"utf8\\\",\\\"primaryKeyColumnNames\\\":[\\\"id\\\"],\\\"columns\\\":[{\\\"name\\\":\\\"id\\\",\\\"jdbcType\\\":4,\\\"typeName\\\":\\\"INT\\\",\\\"typeExpression\\\":\\\"INT\\\",\\\"charsetName\\\":null,\\\"length\\\":11,\\\"position\\\":1,\\\"optional\\\":false,\\\"autoIncremented\\\":false,\\\"generated\\\":false,\\\"comment\\\":null,\\\"hasDefaultValue\\\":false,\\\"enumValues\\\":[]},{\\\"name\\\":\\\"key_word\\\",\\\"jdbcType\\\":4,\\\"typeName\\\":\\\"INT\\\",\\\"typeExpression\\\":\\\"INT\\\",\\\"charsetName\\\":null,\\\"length\\\":11,\\\"position\\\":2,\\\"optional\\\":false,\\\"autoIncremented\\\":false,\\\"generated\\\":false,\\\"comment\\\":null,\\\"hasDefaultValue\\\":true,\\\"defaultValueExpression\\\":\\\"1\\\",\\\"enumValues\\\":[]}]},\\\"comment\\\":null}]}\"}";
         Map<String, Map<String, FieldSchema>> originFieldSchemaHashMap = new LinkedHashMap<>();
         Map<String, FieldSchema> fieldSchemaHashMap = Maps.newHashMap();
         JsonNode record = objectMapper.readTree(columnInfo);
@@ -371,10 +352,8 @@ public class TestJsonDebeziumSchemaChangeImplV2 extends TestJsonDebeziumChangeBa
         originFieldSchemaHashMap.put("test.t1", fieldSchemaHashMap);
         schemaChange.setOriginFieldSchemaMap(originFieldSchemaHashMap);
         List<String> changeNameList = schemaChange.extractDDLList(record);
-        System.out.println(changeNameList.get(0));
-        //        Assert.assertEquals(
-        //                "ALTER TABLE `test`.`t1` RENAME COLUMN `age` `age1`",
-        // changeNameList.get(0));
+        Assert.assertEquals(
+                "ALTER TABLE `test`.`t1` RENAME COLUMN `key` `key_word`", changeNameList.get(0));
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes
In MySQL 5.7.x, renaming a column using the syntax `RENAME COLUMN old_column_name TO new_column_name` is not supported. However, you can change the column name using the syntax `CHANGE COLUMN old_column new_column datatype`. Therefore, we can resolve this issue by adding compatibility for the 'CHANGE old_column new_column' syntax in MySQL.
Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
