### PR TITLE
[improvement] fix some successfully precommitted cannot be aborted lead to LabelAlreadyExists

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/LabelAlreadyExistsException.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/LabelAlreadyExistsException.java
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.exception;
+
+public class LabelAlreadyExistsException extends RuntimeException {
+    public LabelAlreadyExistsException() {
+        super();
+    }
+
+    public LabelAlreadyExistsException(String message) {
+        super(message);
+    }
+
+    public LabelAlreadyExistsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LabelAlreadyExistsException(Throwable cause) {
+        super(cause);
+    }
+
+    protected LabelAlreadyExistsException(
+            String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/RespContent.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/RespContent.java
@@ -143,6 +143,10 @@ public class RespContent {
         return commitAndPublishTimeMs;
     }
 
+    public String getLabel() {
+        return label;
+    }
+
     @Override
     public String toString() {
         ObjectMapper mapper = new ObjectMapper();

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/ResponseUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/ResponseUtil.java
@@ -27,8 +27,16 @@ public class ResponseUtil {
             Pattern.compile(
                     "transaction \\[(\\d+)\\] is already \\b(COMMITTED|committed|VISIBLE|visible)\\b, not pre-committed.");
 
+    public static final Pattern ABORTTED_PATTERN =
+            Pattern.compile(
+                    "transaction \\[(\\d+)\\] is already|transaction \\[(\\d+)\\] not found");
+
     public static boolean isCommitted(String msg) {
         return COMMITTED_PATTERN.matcher(msg).find();
+    }
+
+    public static boolean isAborted(String msg) {
+        return ABORTTED_PATTERN.matcher(msg).find();
     }
 
     static final Pattern COPY_COMMITTED_PATTERN =

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/RecordWithMeta.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/RecordWithMeta.java
@@ -57,4 +57,19 @@ public class RecordWithMeta {
     public String getTableIdentifier() {
         return this.database + "." + this.table;
     }
+
+    @Override
+    public String toString() {
+        return "RecordWithMeta{"
+                + "database='"
+                + database
+                + '\''
+                + ", table='"
+                + table
+                + '\''
+                + ", record='"
+                + record
+                + '\''
+                + '}';
+    }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -323,8 +323,7 @@ public class DorisStreamLoad implements Serializable {
             String msg = res.get("msg");
             if (msg != null && ResponseUtil.isCommitted(msg)) {
                 throw new DorisException(
-                        "try abort committed transaction, "
-                                + "do you recover from old savepoint?");
+                        "try abort committed transaction, " + "do you recover from old savepoint?");
             }
 
             LOG.error("Fail to abort transaction. txnId: {}, error: {}", txnID, msg);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -169,6 +169,7 @@ public class DorisStreamLoad implements Serializable {
                 //  Currently, it can only be aborted based on txnid, so we must
                 //  first request a streamload based on the label to get the txnid.
                 String label = labelGenerator.generateTableLabel(startChkID);
+                LOG.info("start a check label {} to load.", label);
                 HttpPutBuilder builder = new HttpPutBuilder();
                 builder.setUrl(loadUrlStr)
                         .baseAuth(user, passwd)

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -19,6 +19,7 @@ package org.apache.doris.flink.sink.writer;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -336,6 +337,9 @@ public class DorisStreamLoad implements Serializable {
     }
 
     public void abortTransactionByLabel(String label) throws Exception {
+        if (StringUtils.isNullOrWhitespaceOnly(label)) {
+            return;
+        }
         HttpPutBuilder builder = new HttpPutBuilder();
         builder.setUrl(abortUrlStr)
                 .baseAuth(user, passwd)
@@ -371,7 +375,7 @@ public class DorisStreamLoad implements Serializable {
     }
 
     public void abortLabelExistTransaction(RespContent respContent) {
-        if (respContent == null && respContent.getMessage() != null) {
+        if (respContent == null || respContent.getMessage() == null) {
             return;
         }
         try {
@@ -380,7 +384,7 @@ public class DorisStreamLoad implements Serializable {
                 long txnId = Long.parseLong(matcher.group(2));
                 abortTransaction(txnId);
                 LOG.info(
-                        "abort transaction {} for label already exist {}",
+                        "Finish to abort transaction {} for label already exist {}",
                         txnId,
                         respContent.getLabel());
             }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -301,37 +301,42 @@ public class DorisStreamLoad implements Serializable {
         }
     }
 
-    public void abortTransaction(long txnID) throws Exception {
-        HttpPutBuilder builder = new HttpPutBuilder();
-        builder.setUrl(abortUrlStr)
-                .baseAuth(user, passwd)
-                .addCommonHeader()
-                .addTxnId(txnID)
-                .setEmptyEntity()
-                .abort();
-        CloseableHttpResponse response = httpClient.execute(builder.build());
+    public void abortTransaction(long txnID) {
+        try {
+            HttpPutBuilder builder = new HttpPutBuilder();
+            builder.setUrl(abortUrlStr)
+                    .baseAuth(user, passwd)
+                    .addCommonHeader()
+                    .addTxnId(txnID)
+                    .setEmptyEntity()
+                    .abort();
+            CloseableHttpResponse response = httpClient.execute(builder.build());
 
-        int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode != 200 || response.getEntity() == null) {
-            LOG.warn("abort transaction response: " + response.getStatusLine().toString());
-            throw new DorisRuntimeException(
-                    "Fail to abort transaction " + txnID + " with url " + abortUrlStr);
-        }
-
-        ObjectMapper mapper = new ObjectMapper();
-        String loadResult = EntityUtils.toString(response.getEntity());
-        LOG.info("abort Result {}", loadResult);
-        Map<String, String> res =
-                mapper.readValue(loadResult, new TypeReference<HashMap<String, String>>() {});
-        if (!SUCCESS.equals(res.get("status"))) {
-            String msg = res.get("msg");
-            if (msg != null && ResponseUtil.isCommitted(msg)) {
-                throw new DorisException(
-                        "try abort committed transaction, " + "do you recover from old savepoint?");
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200 || response.getEntity() == null) {
+                LOG.warn("abort transaction response: " + response.getStatusLine().toString());
+                throw new DorisRuntimeException(
+                        "Fail to abort transaction " + txnID + " with url " + abortUrlStr);
             }
 
-            LOG.error("Fail to abort transaction. txnId: {}, error: {}", txnID, msg);
-            throw new DorisException("Fail to abort transaction, " + loadResult);
+            ObjectMapper mapper = new ObjectMapper();
+            String loadResult = EntityUtils.toString(response.getEntity());
+            LOG.info("abort Result {}", loadResult);
+            Map<String, String> res =
+                    mapper.readValue(loadResult, new TypeReference<HashMap<String, String>>() {});
+            if (!SUCCESS.equals(res.get("status"))) {
+                String msg = res.get("msg");
+                if (msg != null && ResponseUtil.isAborted(msg)) {
+                    LOG.warn("Failed to abort transaction, {}", msg);
+                    return;
+                }
+
+                LOG.error("Fail to abort transaction. txnId: {}, error: {}", txnID, msg);
+                throw new DorisException("Fail to abort transaction, " + loadResult);
+            }
+        } catch (Exception ex) {
+            LOG.error("abort transaction {} error, ", txnID, ex);
+            throw new DorisRuntimeException(ex);
         }
     }
 
@@ -367,6 +372,21 @@ public class DorisStreamLoad implements Serializable {
 
             LOG.error("Fail to abort transaction by label. label: {}, error: {}", label, msg);
             throw new DorisException("Fail to abort transaction by label, " + loadResult);
+        }
+    }
+
+    public void abortLabelExistTransaction(RespContent respContent) {
+        if (respContent == null && respContent.getMessage() != null) {
+            return;
+        }
+        Matcher matcher = LABEL_EXIST_PATTERN.matcher(respContent.getMessage());
+        if (matcher.find()) {
+            long txnId = Long.parseLong(matcher.group(2));
+            abortTransaction(txnId);
+            LOG.info(
+                    "abort transaction {} for label already exist {}",
+                    txnId,
+                    respContent.getLabel());
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -297,43 +297,38 @@ public class DorisStreamLoad implements Serializable {
         }
     }
 
-    public void abortTransaction(long txnID) {
-        try {
-            HttpPutBuilder builder = new HttpPutBuilder();
-            builder.setUrl(abortUrlStr)
-                    .baseAuth(user, passwd)
-                    .addCommonHeader()
-                    .addTxnId(txnID)
-                    .setEmptyEntity()
-                    .abort();
-            CloseableHttpResponse response = httpClient.execute(builder.build());
+    public void abortTransaction(long txnID) throws Exception {
+        HttpPutBuilder builder = new HttpPutBuilder();
+        builder.setUrl(abortUrlStr)
+                .baseAuth(user, passwd)
+                .addCommonHeader()
+                .addTxnId(txnID)
+                .setEmptyEntity()
+                .abort();
+        CloseableHttpResponse response = httpClient.execute(builder.build());
 
-            int statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode != 200 || response.getEntity() == null) {
-                LOG.warn("abort transaction response: " + response.getStatusLine().toString());
-                throw new DorisRuntimeException(
-                        "Fail to abort transaction " + txnID + " with url " + abortUrlStr);
+        int statusCode = response.getStatusLine().getStatusCode();
+        if (statusCode != 200 || response.getEntity() == null) {
+            LOG.warn("abort transaction response: " + response.getStatusLine().toString());
+            throw new DorisRuntimeException(
+                    "Fail to abort transaction " + txnID + " with url " + abortUrlStr);
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        String loadResult = EntityUtils.toString(response.getEntity());
+        LOG.info("abort Result {}", loadResult);
+        Map<String, String> res =
+                mapper.readValue(loadResult, new TypeReference<HashMap<String, String>>() {});
+        if (!SUCCESS.equals(res.get("status"))) {
+            String msg = res.get("msg");
+            if (msg != null && ResponseUtil.isCommitted(msg)) {
+                throw new DorisException(
+                        "try abort committed transaction, "
+                                + "do you recover from old savepoint?");
             }
 
-            ObjectMapper mapper = new ObjectMapper();
-            String loadResult = EntityUtils.toString(response.getEntity());
-            LOG.info("abort Result {}", loadResult);
-            Map<String, String> res =
-                    mapper.readValue(loadResult, new TypeReference<HashMap<String, String>>() {});
-            if (!SUCCESS.equals(res.get("status"))) {
-                String msg = res.get("msg");
-                if (msg != null && ResponseUtil.isCommitted(msg)) {
-                    throw new DorisException(
-                            "try abort committed transaction, "
-                                    + "do you recover from old savepoint?");
-                }
-
-                LOG.error("Fail to abort transaction. txnId: {}, error: {}", txnID, msg);
-                throw new DorisException("Fail to abort transaction, " + loadResult);
-            }
-        } catch (Exception ex) {
-            LOG.error("Error to abort transaction, ", ex);
-            throw new DorisRuntimeException(ex);
+            LOG.error("Fail to abort transaction. txnId: {}, error: {}", txnID, msg);
+            throw new DorisException("Fail to abort transaction, " + loadResult);
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -65,7 +65,7 @@ import static org.apache.doris.flink.sink.writer.LoadConstants.LINE_DELIMITER_KE
 public class DorisStreamLoad implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(DorisStreamLoad.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private LabelGenerator labelGenerator;
+    private final LabelGenerator labelGenerator;
     private final byte[] lineDelimiter;
     private static final String LOAD_URL_PATTERN = "http://%s/api/%s/%s/_stream_load";
     private static final String ABORT_URL_PATTERN = "http://%s/api/%s/_stream_load_2pc";
@@ -392,10 +392,6 @@ public class DorisStreamLoad implements Serializable {
             LOG.error(
                     "Failed abort transaction {} for label already exist", respContent.getLabel());
         }
-    }
-
-    public void setLabelGenerator(LabelGenerator labelGenerator) {
-        this.labelGenerator = labelGenerator;
     }
 
     public String getCurrentLabel() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -297,37 +297,43 @@ public class DorisStreamLoad implements Serializable {
         }
     }
 
-    public void abortTransaction(long txnID) throws Exception {
-        HttpPutBuilder builder = new HttpPutBuilder();
-        builder.setUrl(abortUrlStr)
-                .baseAuth(user, passwd)
-                .addCommonHeader()
-                .addTxnId(txnID)
-                .setEmptyEntity()
-                .abort();
-        CloseableHttpResponse response = httpClient.execute(builder.build());
+    public void abortTransaction(long txnID) {
+        try {
+            HttpPutBuilder builder = new HttpPutBuilder();
+            builder.setUrl(abortUrlStr)
+                    .baseAuth(user, passwd)
+                    .addCommonHeader()
+                    .addTxnId(txnID)
+                    .setEmptyEntity()
+                    .abort();
+            CloseableHttpResponse response = httpClient.execute(builder.build());
 
-        int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode != 200 || response.getEntity() == null) {
-            LOG.warn("abort transaction response: " + response.getStatusLine().toString());
-            throw new DorisRuntimeException(
-                    "Fail to abort transaction " + txnID + " with url " + abortUrlStr);
-        }
-
-        ObjectMapper mapper = new ObjectMapper();
-        String loadResult = EntityUtils.toString(response.getEntity());
-        LOG.info("abort Result {}", loadResult);
-        Map<String, String> res =
-                mapper.readValue(loadResult, new TypeReference<HashMap<String, String>>() {});
-        if (!SUCCESS.equals(res.get("status"))) {
-            String msg = res.get("msg");
-            if (msg != null && ResponseUtil.isCommitted(msg)) {
-                throw new DorisException(
-                        "try abort committed transaction, " + "do you recover from old savepoint?");
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200 || response.getEntity() == null) {
+                LOG.warn("abort transaction response: " + response.getStatusLine().toString());
+                throw new DorisRuntimeException(
+                        "Fail to abort transaction " + txnID + " with url " + abortUrlStr);
             }
 
-            LOG.error("Fail to abort transaction. txnId: {}, error: {}", txnID, msg);
-            throw new DorisException("Fail to abort transaction, " + loadResult);
+            ObjectMapper mapper = new ObjectMapper();
+            String loadResult = EntityUtils.toString(response.getEntity());
+            LOG.info("abort Result {}", loadResult);
+            Map<String, String> res =
+                    mapper.readValue(loadResult, new TypeReference<HashMap<String, String>>() {});
+            if (!SUCCESS.equals(res.get("status"))) {
+                String msg = res.get("msg");
+                if (msg != null && ResponseUtil.isCommitted(msg)) {
+                    throw new DorisException(
+                            "try abort committed transaction, "
+                                    + "do you recover from old savepoint?");
+                }
+
+                LOG.error("Fail to abort transaction. txnId: {}, error: {}", txnID, msg);
+                throw new DorisException("Fail to abort transaction, " + loadResult);
+            }
+        } catch (Exception ex) {
+            LOG.error("Error to abort transaction, ", ex);
+            throw new DorisRuntimeException(ex);
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -64,7 +64,7 @@ import static org.apache.doris.flink.sink.writer.LoadConstants.LINE_DELIMITER_KE
 public class DorisStreamLoad implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(DorisStreamLoad.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private final LabelGenerator labelGenerator;
+    private LabelGenerator labelGenerator;
     private final byte[] lineDelimiter;
     private static final String LOAD_URL_PATTERN = "http://%s/api/%s/%s/_stream_load";
     private static final String ABORT_URL_PATTERN = "http://%s/api/%s/_stream_load_2pc";
@@ -162,7 +162,11 @@ public class DorisStreamLoad implements Serializable {
      */
     public void abortPreCommit(String labelPrefix, long chkID) throws Exception {
         long startChkID = chkID;
-        LOG.info("abort for labelPrefix {}. start chkId {}.", labelPrefix, chkID);
+        LOG.info(
+                "abort for labelPrefix {}, concat labelPrefix {},  start chkId {}.",
+                labelPrefix,
+                labelGenerator.getConcatLabelPrefix(),
+                chkID);
         while (true) {
             try {
                 // TODO: According to label abort txn.
@@ -329,6 +333,10 @@ public class DorisStreamLoad implements Serializable {
             LOG.error("Fail to abort transaction. txnId: {}, error: {}", txnID, msg);
             throw new DorisException("Fail to abort transaction, " + loadResult);
         }
+    }
+
+    public void setLabelGenerator(LabelGenerator labelGenerator) {
+        this.labelGenerator = labelGenerator;
     }
 
     public void close() throws IOException {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -187,7 +187,7 @@ public class DorisWriter<IN>
             Set<String> diff = new HashSet<>(dorisStreamLoadMap.keySet());
             diff.removeAll(alreadyAbortTables);
             LOG.warn(
-                    "there are some tables in dorisStreamLoadMap, but they are not aborted: {}",
+                    "There are some tables in dorisStreamLoadMap, but they are not aborted: {}",
                     diff);
         }
 
@@ -197,9 +197,7 @@ public class DorisWriter<IN>
             // an error reported by thread A may cause thread B to be unable to abort in time.
             // In this case, labelPrefix needs to be modified.
             labelPrefix = labelPrefix + "_" + attemptNumber;
-            LOG.info(
-                    "In the multi-table writing state, modify the label prefix to {}.",
-                    labelPrefix);
+            LOG.info("In the multi-table writing, change the labelPrefix to {}.", labelPrefix);
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -253,6 +253,7 @@ public class DorisWriter<IN>
             if (!DORIS_SUCCESS_STATUS.contains(respContent.getStatus())) {
                 if (executionOptions.enabled2PC()
                         && LoadStatus.LABEL_ALREADY_EXIST.equals(respContent.getStatus())) {
+                    LOG.info("try to abort {} cause Label Already Exists", respContent.getLabel());
                     dorisStreamLoad.abortLabelExistTransaction(respContent);
                 } else {
                     String errMsg =
@@ -387,6 +388,9 @@ public class DorisWriter<IN>
                                         dorisStreamLoad.getPendingLoadFuture().get());
                         if (executionOptions.enabled2PC()
                                 && LoadStatus.LABEL_ALREADY_EXIST.equals(content.getStatus())) {
+                            LOG.info(
+                                    "try to abort {} cause Label Already Exists",
+                                    content.getLabel());
                             dorisStreamLoad.abortLabelExistTransaction(content);
                             return;
                         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -338,8 +338,12 @@ public class DorisWriter<IN>
 
     /** Check the streamload http request regularly. */
     private void checkDone() {
-        for (Map.Entry<String, DorisStreamLoad> streamLoadMap : dorisStreamLoadMap.entrySet()) {
-            checkAllDone(streamLoadMap.getKey(), streamLoadMap.getValue());
+        // todo: When writing to multiple tables,
+        //  the checkdone thread may cause problems. Disable it first.
+        if (!multiTableLoad || dorisStreamLoadMap.size() > 1) {
+            for (Map.Entry<String, DorisStreamLoad> streamLoadMap : dorisStreamLoadMap.entrySet()) {
+                checkAllDone(streamLoadMap.getKey(), streamLoadMap.getValue());
+            }
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -390,7 +390,8 @@ public class DorisWriter<IN>
                                     content.getLabel());
                             dorisStreamLoad.abortLabelExistTransaction(content);
                             errorMsg = "Exist label abort finished, retry";
-                            loadException = new LabelAlreadyExistsException(errorMsg);
+                            LOG.info(errorMsg);
+                            return;
                         } else {
                             errorMsg = content.getMessage();
                             loadException = new StreamLoadException(errorMsg);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -98,7 +98,7 @@ public class DorisWriter<IN>
                         .getRestoredCheckpointId()
                         .orElse(CheckpointIDCounter.INITIAL_CHECKPOINT_ID - 1);
         this.curCheckpointId = lastCheckpointId + 1;
-        LOG.info("restore checkpointId from {}", lastCheckpointId);
+        LOG.info("restore from checkpointId {}", lastCheckpointId);
         LOG.info("labelPrefix {}", executionOptions.getLabelPrefix());
         this.labelPrefix = executionOptions.getLabelPrefix();
         this.subtaskId = initContext.getSubtaskId();

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -340,7 +340,7 @@ public class DorisWriter<IN>
     private void checkDone() {
         // todo: When writing to multiple tables,
         //  the checkdone thread may cause problems. Disable it first.
-        if (!multiTableLoad || dorisStreamLoadMap.size() > 1) {
+        if (!multiTableLoad) {
             for (Map.Entry<String, DorisStreamLoad> streamLoadMap : dorisStreamLoadMap.entrySet()) {
                 checkAllDone(streamLoadMap.getKey(), streamLoadMap.getValue());
             }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -251,7 +251,8 @@ public class DorisWriter<IN>
                 dorisWriteMetrics.flush(respContent);
             }
             if (!DORIS_SUCCESS_STATUS.contains(respContent.getStatus())) {
-                if (LoadStatus.LABEL_ALREADY_EXIST.equals(respContent.getStatus())) {
+                if (executionOptions.enabled2PC()
+                        && LoadStatus.LABEL_ALREADY_EXIST.equals(respContent.getStatus())) {
                     dorisStreamLoad.abortLabelExistTransaction(respContent);
                 } else {
                     String errMsg =
@@ -384,7 +385,8 @@ public class DorisWriter<IN>
                         RespContent content =
                                 dorisStreamLoad.handlePreCommitResponse(
                                         dorisStreamLoad.getPendingLoadFuture().get());
-                        if (LoadStatus.LABEL_ALREADY_EXIST.equals(content.getStatus())) {
+                        if (executionOptions.enabled2PC()
+                                && LoadStatus.LABEL_ALREADY_EXIST.equals(content.getStatus())) {
                             dorisStreamLoad.abortLabelExistTransaction(content);
                             return;
                         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
@@ -69,4 +69,9 @@ public class LabelGenerator {
     public String generateCopyBatchLabel(String table, long chkId, int fileNum) {
         return String.format("%s_%s_%s_%s_%s", labelPrefix, table, subtaskId, chkId, fileNum);
     }
+
+    public String getConcatLabelPrefix() {
+        String concatPrefix = String.format("%s_%s_%s", labelPrefix, tableIdentifier, subtaskId);
+        return concatPrefix;
+    }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/TestResponseUtil.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/TestResponseUtil.java
@@ -44,4 +44,25 @@ public class TestResponseUtil {
         Assert.assertFalse(ResponseUtil.isCommitted(commitMsg));
         Assert.assertFalse(ResponseUtil.isCommitted(abortedMsg));
     }
+
+    @Test
+    public void testIsAborted() {
+        String notFoundMsg = "errCode = 2, detailMessage = transaction [2] not found";
+        String alreadyAbort =
+                "errCode = 2, detailMessage = transaction [2] is already aborted. abort reason: User Abort";
+        String systemAlreadAbort =
+                "errCode = 2, detailMessage = transaction [2] is already aborted. abort reason: timeout by txn manager";
+        String alreadCommit =
+                "errCode = 2, detailMessage = transaction [2] is already COMMITTED, could not abort.";
+        String alreadVISIBLE =
+                "errCode = 2, detailMessage = transaction [2] is already VISIBLE, could not abort.";
+        String errormsg =
+                "tCouldn't open transport for :0 (Could not resolve host for client socket.";
+        Assert.assertTrue(ResponseUtil.isAborted(notFoundMsg));
+        Assert.assertTrue(ResponseUtil.isAborted(alreadyAbort));
+        Assert.assertTrue(ResponseUtil.isAborted(systemAlreadAbort));
+        Assert.assertTrue(ResponseUtil.isAborted(alreadCommit));
+        Assert.assertTrue(ResponseUtil.isAborted(alreadVISIBLE));
+        Assert.assertFalse(ResponseUtil.isAborted(errormsg));
+    }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestDorisStreamLoad.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestDorisStreamLoad.java
@@ -20,7 +20,6 @@ package org.apache.doris.flink.sink.writer;
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
-import org.apache.doris.flink.exception.DorisException;
 import org.apache.doris.flink.sink.HttpTestUtil;
 import org.apache.doris.flink.sink.OptionUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -89,7 +88,7 @@ public class TestDorisStreamLoad {
         dorisStreamLoad.abortTransaction(anyLong());
     }
 
-    @Test(expected = DorisException.class)
+    @Test(expected = Exception.class)
     public void testAbortTransactionFailed() throws Exception {
         CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
         CloseableHttpResponse abortFailedResponse =


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1. In the case of writing to multiple tables, such as tables A, B, and C, if tables D and E are added during the period (there is no streamloader for this table in the previous Checkpoint), in the precommit phase, if table D succeeds but table E fails, this will retry from the last Checkpoint, but there is no streamloader of table D in the last checkpoint, so the txn of table D that has been successfully precommitted cannot be aborted, and the error **LabelAlreadyExists** will be reported next time

2. In the scenario of writing to multiple tables, if the sink is multi-concurrent,
At this time, the A thread reports an error, and the B thread Http request has ended, and the txnid of successful precommit has not been obtained. However, when jobmanager tries to cancel thread B, the txnid of thread B may not be aborted in time, and an error labelAlreadExist will be reported next time.

Therefore, when the thread exits, it must be aborted according to the label (only available on doris 2.1+)

3. The simultaneous asynchronous check thread is closed in the case of multiple tables.
4. During abort, it is currently based on txnidabort, so a pre-request with the same label will be initiated first. So if this pre-request abort fails, the label will already exist during the next write.
For example：
restore from ck-106
label107 alread exist，abort label107
label108 not use,abort fail
restore from ck-106
label107 not use,exit abort
label108 write，label already exists

At this time, you need to actively abort the label and let flink restart

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
