### PR TITLE
[improve] support  read ipv4 in Doris 2.1.0

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/serialization/RowBatch.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/serialization/RowBatch.java
@@ -20,6 +20,7 @@ package org.apache.doris.flink.serialization;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BaseIntVector;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -228,10 +229,17 @@ public class RowBatch {
                 addValueToRow(rowIndex, fieldValue);
                 break;
             case "IPV4":
-                if (!minorType.equals(Types.MinorType.UINT4)) {
+                if (!minorType.equals(Types.MinorType.UINT4)
+                        && !minorType.equals(Types.MinorType.INT)) {
                     return false;
                 }
-                UInt4Vector ipv4Vector = (UInt4Vector) fieldVector;
+                BaseIntVector ipv4Vector;
+                if (minorType.equals(Types.MinorType.INT)) {
+                    ipv4Vector = (IntVector) fieldVector;
+
+                } else {
+                    ipv4Vector = (UInt4Vector) fieldVector;
+                }
                 fieldValue =
                         ipv4Vector.isNull(rowIndex)
                                 ? null


### PR DESCRIPTION
# Proposed changes
In the previous PR (https://github.com/apache/doris-flink-connector/pull/365), we added support for reading both IPv4 and IPv6 addresses starting from Doris 2.1.1. In this PR, we further enhance the functionality to support reading IPv4 addresses since version 2.1.0.
Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
