### PR TITLE
[feature](cdc)  Support merging multiple databases with the same schema into a single Doris table during synchronization

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -82,7 +82,7 @@ public abstract class DatabaseSync {
     protected String tablePrefix;
     protected String tableSuffix;
     protected boolean singleSink;
-    protected boolean mergeSameSchema;
+    protected boolean mergeSameSchema = true;
     private final Map<String, String> tableMapping = new HashMap<>();
 
     public abstract void registerDriver() throws SQLException;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -540,7 +540,7 @@ public abstract class DatabaseSync {
         private final boolean mergeSameSchema;
 
         TableNameConverter() {
-            this("", "", false);
+            this("", "", true);
         }
 
         TableNameConverter(String prefix, String suffix, boolean mergeSameSchema) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSync.java
@@ -230,8 +230,7 @@ public class MysqlDatabaseSync extends DatabaseSync {
 
     @Override
     public String getTableListPrefix() {
-        String databaseName = config.get(MySqlSourceOptions.DATABASE_NAME);
-        return databaseName;
+        return config.get(MySqlSourceOptions.DATABASE_NAME);
     }
 
     /**

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleType.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleType.java
@@ -17,12 +17,9 @@
 
 package org.apache.doris.flink.tools.cdc.oracle;
 
-import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.doris.flink.catalog.doris.DorisType;
-
-import static org.apache.doris.flink.catalog.DorisTypeMapper.MAX_SUPPORTED_DATE_TIME_PRECISION;
 
 public class OracleType {
     private static final String VARCHAR2 = "VARCHAR2";
@@ -52,16 +49,7 @@ public class OracleType {
         if (oracleType.startsWith(INTERVAL)) {
             oracleType = oracleType.substring(0, 8);
         } else if (oracleType.startsWith(TIMESTAMP)) {
-            // In Debezium Json data,the length of timestamp range 0 to 9.
-            if (scale == 0 && precision <= TimestampType.MAX_PRECISION) {
-                return String.format(
-                        "%s(%s)",
-                        DorisType.DATETIME_V2,
-                        Math.min(precision, MAX_SUPPORTED_DATE_TIME_PRECISION));
-            }
-            return String.format(
-                    "%s(%s)",
-                    DorisType.DATETIME_V2, Math.min(scale, MAX_SUPPORTED_DATE_TIME_PRECISION));
+            return String.format("%s(%s)", DorisType.DATETIME_V2, Math.min(scale, 6));
         }
         switch (oracleType) {
             case NUMBER:

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleType.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleType.java
@@ -17,9 +17,12 @@
 
 package org.apache.doris.flink.tools.cdc.oracle;
 
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.doris.flink.catalog.doris.DorisType;
+
+import static org.apache.doris.flink.catalog.DorisTypeMapper.MAX_SUPPORTED_DATE_TIME_PRECISION;
 
 public class OracleType {
     private static final String VARCHAR2 = "VARCHAR2";
@@ -49,7 +52,16 @@ public class OracleType {
         if (oracleType.startsWith(INTERVAL)) {
             oracleType = oracleType.substring(0, 8);
         } else if (oracleType.startsWith(TIMESTAMP)) {
-            return String.format("%s(%s)", DorisType.DATETIME_V2, Math.min(scale, 6));
+            // In Debezium Json data,the length of timestamp range 0 to 9.
+            if (scale == 0 && precision <= TimestampType.MAX_PRECISION) {
+                return String.format(
+                        "%s(%s)",
+                        DorisType.DATETIME_V2,
+                        Math.min(precision, MAX_SUPPORTED_DATE_TIME_PRECISION));
+            }
+            return String.format(
+                    "%s(%s)",
+                    DorisType.DATETIME_V2, Math.min(scale, MAX_SUPPORTED_DATE_TIME_PRECISION));
         }
         switch (oracleType) {
             case NUMBER:

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcMysqlSyncDatabaseCase.java
@@ -73,6 +73,7 @@ public class CdcMysqlSyncDatabaseCase {
         boolean ignoreDefaultValue = false;
         boolean useNewSchemaChange = false;
         boolean singleSink = false;
+        boolean mergeSameSchema = false;
         DatabaseSync databaseSync = new MysqlDatabaseSync();
         databaseSync
                 .setEnv(env)
@@ -90,6 +91,7 @@ public class CdcMysqlSyncDatabaseCase {
                 .setCreateTableOnly(false)
                 .setNewSchemaChange(useNewSchemaChange)
                 .setSingleSink(singleSink)
+                .setMergeSameSchema(mergeSameSchema)
                 .create();
         databaseSync.build();
         env.execute(String.format("MySQL-Doris Database Sync: %s", database));


### PR DESCRIPTION
# Proposed changes
if some tables in different databases have the same name, their schemas will be merged and their records will be synchronized into one Doris table. Otherwise, each table's records will be synchronized to a corresponding Doris table, and the Doris table will be named to 'databaseName_tableName' to avoid potential name conflict.
Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
