### PR TITLE
[fix] Fix the bug that the `DorisTypeMapper` datetime type will lose precision when converted to flink type

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisTypeMapper.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisTypeMapper.java
@@ -125,7 +125,7 @@ public class DorisTypeMapper {
                 return DataTypes.DATE();
             case DATETIME:
             case DATETIME_V2:
-                return DataTypes.TIMESTAMP(0);
+                return DataTypes.TIMESTAMP(scale);
             default:
                 throw new UnsupportedOperationException(
                         String.format(


### PR DESCRIPTION
# Proposed changes

Issue Number: close #378

## Problem Summary:

#378

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
