### PR TITLE
[fix][DorisBatchStreamLoad] waitAsyncLoadFinish should wait AsyncLoad finish ranthen than AsyncLoad start load

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -237,13 +237,15 @@ public class DorisBatchStreamLoad implements Serializable {
             while (started.get()) {
                 BatchRecordBuffer buffer = null;
                 try {
-                    buffer = flushQueue.poll(2000L, TimeUnit.MILLISECONDS);
+                    buffer = flushQueue.peek();
                     if (buffer == null) {
                         continue;
                     }
                     if (buffer.getLabelName() != null) {
                         load(buffer.getLabelName(), buffer);
                     }
+                    //load end, remove from queue
+                    flushQueue.take();
                 } catch (Exception e) {
                     LOG.error("worker running error", e);
                     exception.set(e);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
