### PR TITLE
[optimize](sink) Optimize the BE load balancing logic during concurrent imports.

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
@@ -84,9 +84,9 @@ public class BackendUtil {
         while (pos < tmp) {
             BackendV2.BackendRowV2 backend =
                     backends.get((int) ((pos + subtaskId) % backends.size()));
+            pos++;
             String res = backend.toBackendString();
             if (tryHttpConnection(res)) {
-                pos++;
                 return res;
             }
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
@@ -76,11 +76,17 @@ public class BackendUtil {
     }
 
     public String getAvailableBackend() {
+        return getAvailableBackend(0);
+    }
+
+    public String getAvailableBackend(int subtaskId) {
         long tmp = pos + backends.size();
         while (pos < tmp) {
-            BackendV2.BackendRowV2 backend = backends.get((int) (pos++ % backends.size()));
+            BackendV2.BackendRowV2 backend =
+                    backends.get((int) ((pos + subtaskId) % backends.size()));
             String res = backend.toBackendString();
             if (tryHttpConnection(res)) {
+                pos++;
                 return res;
             }
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -312,7 +312,7 @@ public class DorisWriter<IN>
         List<DorisWriterState> writerStates = new ArrayList<>();
         for (DorisStreamLoad dorisStreamLoad : dorisStreamLoadMap.values()) {
             // Dynamic refresh backend
-            dorisStreamLoad.setHostPort(backendUtil.getAvailableBackend());
+            dorisStreamLoad.setHostPort(backendUtil.getAvailableBackend(subtaskId));
             DorisWriterState writerState =
                     new DorisWriterState(
                             labelPrefix,
@@ -340,7 +340,7 @@ public class DorisWriter<IN>
                 tableKey,
                 v ->
                         new DorisStreamLoad(
-                                backendUtil.getAvailableBackend(),
+                                backendUtil.getAvailableBackend(subtaskId),
                                 dorisOptions,
                                 executionOptions,
                                 labelGenerator,
@@ -373,7 +373,7 @@ public class DorisWriter<IN>
                 // use send cached data to new txn, then notify to restart the stream
                 if (executionOptions.isUseCache()) {
                     try {
-                        dorisStreamLoad.setHostPort(backendUtil.getAvailableBackend());
+                        dorisStreamLoad.setHostPort(backendUtil.getAvailableBackend(subtaskId));
                         if (executionOptions.enabled2PC()) {
                             dorisStreamLoad.abortPreCommit(labelPrefix, curCheckpointId);
                         }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/TestBackendUtil.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/TestBackendUtil.java
@@ -22,7 +22,6 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -45,8 +44,7 @@ public class TestBackendUtil {
 
     @Test
     public void testTryHttpConnection() {
-        BackendUtil backendUtil = new BackendUtil(new ArrayList<>());
-        boolean flag = backendUtil.tryHttpConnection("127.0.0.1:8040");
+        boolean flag = BackendUtil.tryHttpConnection("127.0.0.1:8040");
         Assert.assertFalse(flag);
     }
 


### PR DESCRIPTION
# Proposed changes
For example, consider multiple BEs in Apache Doris. The load is not balanced during concurrent imports. At the same checkpoint, multiple stream load tasks are directed to the same BE, causing server pressure on the backends because the `Pos` variables are the same within the checkpoint. To address this, we can calculate the destination BE using both the `subTaskId` and `Pos` variables.

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
