### PR TITLE
[fix] Support converting type BINARY of Flink to Doris type (#397)

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisTypeMapper.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisTypeMapper.java
@@ -21,6 +21,7 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DateType;
@@ -237,6 +238,11 @@ public class DorisTypeMapper {
 
         @Override
         public String visit(RowType rowType) {
+            return STRING;
+        }
+
+        @Override
+        public String visit(BinaryType binaryType) {
             return STRING;
         }
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/catalog/DorisTypeMapperTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/catalog/DorisTypeMapperTest.java
@@ -176,4 +176,10 @@ public class DorisTypeMapperTest {
                         DataTypes.ROW(DataTypes.FIELD("field", DataTypes.INT())));
         assertEquals("STRING", dorisType);
     }
+
+    @Test
+    public void testBinaryType() {
+        String dorisType = DorisTypeMapper.toDorisType(DataTypes.BINARY(1));
+        assertEquals("STRING", dorisType);
+    }
 }


### PR DESCRIPTION
# Proposed changes
fix the bug of 'Flink doesn't support converting type BINARY(1) to Doris type yet'.
Issue Number: close #397 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
