### PR TITLE
[Improve] fix doris source duplicate splitid

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSource.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSource.java
@@ -17,9 +17,16 @@
 
 package org.apache.doris.flink.source;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
@@ -35,18 +42,12 @@ import org.apache.doris.flink.source.reader.DorisRecordEmitter;
 import org.apache.doris.flink.source.reader.DorisSourceReader;
 import org.apache.doris.flink.source.split.DorisSourceSplit;
 import org.apache.doris.flink.source.split.DorisSourceSplitSerializer;
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.connector.source.Boundedness;
-import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.api.connector.source.SourceReader;
-import org.apache.flink.api.connector.source.SourceReaderContext;
-import org.apache.flink.api.connector.source.SplitEnumerator;
-import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
-import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /** DorisSource based on FLIP-27 which is a BOUNDED stream. */
 @PublicEvolving
@@ -96,7 +97,7 @@ public class DorisSource<OUT>
         List<DorisSourceSplit> dorisSourceSplits = new ArrayList<>();
         List<PartitionDefinition> partitions =
                 RestService.findPartitions(options, readOptions, LOG);
-        for(int index = 0; index <partitions.size(); index++) {
+        for (int index = 0; index < partitions.size(); index++) {
             PartitionDefinition partitionDef = partitions.get(index);
             String splitId = partitionDef.getBeAddress() + "_" + index;
             dorisSourceSplits.add(new DorisSourceSplit(splitId, partitionDef));

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSource.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/DorisSource.java
@@ -17,16 +17,9 @@
 
 package org.apache.doris.flink.source;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.connector.source.Boundedness;
-import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.api.connector.source.SourceReader;
-import org.apache.flink.api.connector.source.SourceReaderContext;
-import org.apache.flink.api.connector.source.SplitEnumerator;
-import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
-import org.apache.flink.core.io.SimpleVersionedSerializer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
@@ -42,12 +35,18 @@ import org.apache.doris.flink.source.reader.DorisRecordEmitter;
 import org.apache.doris.flink.source.reader.DorisSourceReader;
 import org.apache.doris.flink.source.split.DorisSourceSplit;
 import org.apache.doris.flink.source.split.DorisSourceSplitSerializer;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 /** DorisSource based on FLIP-27 which is a BOUNDED stream. */
 @PublicEvolving
@@ -97,9 +96,12 @@ public class DorisSource<OUT>
         List<DorisSourceSplit> dorisSourceSplits = new ArrayList<>();
         List<PartitionDefinition> partitions =
                 RestService.findPartitions(options, readOptions, LOG);
-        partitions.forEach(m -> dorisSourceSplits.add(new DorisSourceSplit(m)));
+        for(int index = 0; index <partitions.size(); index++) {
+            PartitionDefinition partitionDef = partitions.get(index);
+            String splitId = partitionDef.getBeAddress() + "_" + index;
+            dorisSourceSplits.add(new DorisSourceSplit(splitId, partitionDef));
+        }
         DorisSplitAssigner splitAssigner = new SimpleSplitAssigner(dorisSourceSplits);
-
         return new DorisSourceEnumerator(context, splitAssigner);
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/assigners/SimpleSplitAssigner.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/assigners/SimpleSplitAssigner.java
@@ -17,18 +17,20 @@
 
 package org.apache.doris.flink.source.assigners;
 
-import org.apache.doris.flink.source.enumerator.PendingSplitsCheckpoint;
-import org.apache.doris.flink.source.split.DorisSourceSplit;
-
 import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.apache.doris.flink.source.enumerator.PendingSplitsCheckpoint;
+import org.apache.doris.flink.source.split.DorisSourceSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /** The {@code SimpleSplitAssigner} hands out splits in a random order. */
 public class SimpleSplitAssigner implements DorisSplitAssigner {
 
+    private static final Logger LOG = LoggerFactory.getLogger(SimpleSplitAssigner.class);
     private final ArrayList<DorisSourceSplit> splits;
 
     public SimpleSplitAssigner(Collection<DorisSourceSplit> splits) {
@@ -43,6 +45,7 @@ public class SimpleSplitAssigner implements DorisSplitAssigner {
 
     @Override
     public void addSplits(Collection<DorisSourceSplit> splits) {
+        LOG.info("Adding splits: {}", splits);
         splits.addAll(splits);
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/assigners/SimpleSplitAssigner.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/assigners/SimpleSplitAssigner.java
@@ -17,15 +17,16 @@
 
 package org.apache.doris.flink.source.assigners;
 
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Optional;
-
 import org.apache.doris.flink.source.enumerator.PendingSplitsCheckpoint;
 import org.apache.doris.flink.source.split.DorisSourceSplit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
 
 /** The {@code SimpleSplitAssigner} hands out splits in a random order. */
 public class SimpleSplitAssigner implements DorisSplitAssigner {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/enumerator/DorisSourceEnumerator.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/enumerator/DorisSourceEnumerator.java
@@ -17,19 +17,22 @@
 
 package org.apache.doris.flink.source.enumerator;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 
 import org.apache.doris.flink.source.DorisSource;
 import org.apache.doris.flink.source.assigners.DorisSplitAssigner;
 import org.apache.doris.flink.source.split.DorisSourceSplit;
-import org.apache.flink.api.connector.source.SplitEnumerator;
-import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A SplitEnumerator implementation for bounded / batch {@link DorisSource} input.

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/enumerator/DorisSourceEnumerator.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/enumerator/DorisSourceEnumerator.java
@@ -17,22 +17,19 @@
 
 package org.apache.doris.flink.source.enumerator;
 
-import org.apache.flink.api.connector.source.SplitEnumerator;
-import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-
-import org.apache.doris.flink.source.DorisSource;
-import org.apache.doris.flink.source.assigners.DorisSplitAssigner;
-import org.apache.doris.flink.source.split.DorisSourceSplit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.doris.flink.source.DorisSource;
+import org.apache.doris.flink.source.assigners.DorisSplitAssigner;
+import org.apache.doris.flink.source.split.DorisSourceSplit;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A SplitEnumerator implementation for bounded / batch {@link DorisSource} input.
@@ -79,7 +76,7 @@ public class DorisSourceEnumerator
 
     @Override
     public void addSplitsBack(List<DorisSourceSplit> splits, int subtaskId) {
-        LOG.debug("Doris Source Enumerator adds splits back: {}", splits);
+        LOG.info("Doris Source Enumerator adds splits back: {}", splits);
         splitAssigner.addSplits(splits);
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
@@ -17,20 +17,21 @@
 
 package org.apache.doris.flink.source.reader;
 
-import java.io.IOException;
-import java.util.ArrayDeque;
-import java.util.List;
-import java.util.Queue;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.source.split.DorisSourceSplit;
 import org.apache.doris.flink.source.split.DorisSplitRecords;
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
 
 /** The {@link SplitReader} implementation for the doris source. */
 public class DorisSourceSplitReader implements SplitReader<List, DorisSourceSplit> {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
@@ -17,21 +17,20 @@
 
 package org.apache.doris.flink.source.reader;
 
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
 
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.source.split.DorisSourceSplit;
 import org.apache.doris.flink.source.split.DorisSplitRecords;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.ArrayDeque;
-import java.util.List;
-import java.util.Queue;
 
 /** The {@link SplitReader} implementation for the doris source. */
 public class DorisSourceSplitReader implements SplitReader<List, DorisSourceSplit> {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/split/DorisSourceSplit.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/split/DorisSourceSplit.java
@@ -17,11 +17,13 @@
 
 package org.apache.doris.flink.source.split;
 
-import javax.annotation.Nullable;
-import java.util.Objects;
+import org.apache.flink.api.connector.source.SourceSplit;
 
 import org.apache.doris.flink.rest.PartitionDefinition;
-import org.apache.flink.api.connector.source.SourceSplit;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
 
 /** A {@link SourceSplit} that represents a {@link PartitionDefinition}. */
 public class DorisSourceSplit implements SourceSplit {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/split/DorisSourceSplit.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/split/DorisSourceSplit.java
@@ -17,17 +17,15 @@
 
 package org.apache.doris.flink.source.split;
 
-import org.apache.flink.api.connector.source.SourceSplit;
+import javax.annotation.Nullable;
+import java.util.Objects;
 
 import org.apache.doris.flink.rest.PartitionDefinition;
-
-import javax.annotation.Nullable;
-
-import java.util.Objects;
+import org.apache.flink.api.connector.source.SourceSplit;
 
 /** A {@link SourceSplit} that represents a {@link PartitionDefinition}. */
 public class DorisSourceSplit implements SourceSplit {
-
+    private String id;
     private final PartitionDefinition partitionDefinition;
 
     /**
@@ -36,13 +34,14 @@ public class DorisSourceSplit implements SourceSplit {
      */
     @Nullable transient byte[] serializedFormCache;
 
-    public DorisSourceSplit(PartitionDefinition partitionDefinition) {
+    public DorisSourceSplit(String id, PartitionDefinition partitionDefinition) {
+        this.id = id;
         this.partitionDefinition = partitionDefinition;
     }
 
     @Override
     public String splitId() {
-        return partitionDefinition.getBeAddress();
+        return id;
     }
 
     public PartitionDefinition getPartitionDefinition() {
@@ -52,9 +51,10 @@ public class DorisSourceSplit implements SourceSplit {
     @Override
     public String toString() {
         return String.format(
-                "DorisSourceSplit: %s.%s,be=%s,tablets=%s",
+                "DorisSourceSplit: %s.%s,id=%s,be=%s,tablets=%s",
                 partitionDefinition.getDatabase(),
                 partitionDefinition.getTable(),
+                id,
                 partitionDefinition.getBeAddress(),
                 partitionDefinition.getTabletIds());
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/split/DorisSourceSplitSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/split/DorisSourceSplitSerializer.java
@@ -17,19 +17,18 @@
 
 package org.apache.doris.flink.source.split;
 
-import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.core.memory.DataInputDeserializer;
-import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataOutputSerializer;
-import org.apache.flink.core.memory.DataOutputView;
-
-import org.apache.doris.flink.rest.PartitionDefinition;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.apache.doris.flink.rest.PartitionDefinition;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.memory.DataOutputView;
 
 /** A serializer for the {@link DorisSourceSplit}. */
 public class DorisSourceSplitSerializer implements SimpleVersionedSerializer<DorisSourceSplit> {
@@ -39,7 +38,7 @@ public class DorisSourceSplitSerializer implements SimpleVersionedSerializer<Dor
     private static final ThreadLocal<DataOutputSerializer> SERIALIZER_CACHE =
             ThreadLocal.withInitial(() -> new DataOutputSerializer(64));
 
-    private static final int VERSION = 1;
+    private static final int VERSION = 2;
 
     private static void writeLongArray(DataOutputView out, Long[] values) throws IOException {
         out.writeInt(values.length);
@@ -71,6 +70,8 @@ public class DorisSourceSplitSerializer implements SimpleVersionedSerializer<Dor
         }
 
         final DataOutputSerializer out = SERIALIZER_CACHE.get();
+
+
         PartitionDefinition partDef = split.getPartitionDefinition();
         out.writeUTF(partDef.getDatabase());
         out.writeUTF(partDef.getTable());
@@ -80,6 +81,8 @@ public class DorisSourceSplitSerializer implements SimpleVersionedSerializer<Dor
         final byte[] queryPlanBytes = partDef.getQueryPlan().getBytes(StandardCharsets.UTF_8);
         out.writeInt(queryPlanBytes.length);
         out.write(queryPlanBytes);
+
+        out.writeUTF(split.splitId());
 
         final byte[] result = out.getCopyOfBuffer();
         out.clear();
@@ -93,13 +96,16 @@ public class DorisSourceSplitSerializer implements SimpleVersionedSerializer<Dor
 
     @Override
     public DorisSourceSplit deserialize(int version, byte[] serialized) throws IOException {
-        if (version == 1) {
-            return deserialize(serialized);
+        switch (version){
+            case 1:
+            case 2:
+                return deserializeSplit(version, serialized);
+            default:
+                throw new IOException("Unknown version: " + version);
         }
-        throw new IOException("Unknown version: " + version);
     }
 
-    private DorisSourceSplit deserialize(byte[] serialized) throws IOException {
+    private DorisSourceSplit deserializeSplit(int version, byte[] serialized) throws IOException {
         final DataInputDeserializer in = new DataInputDeserializer(serialized);
         final String database = in.readUTF();
         final String table = in.readUTF();
@@ -112,8 +118,14 @@ public class DorisSourceSplitSerializer implements SimpleVersionedSerializer<Dor
         final byte[] bytes = new byte[len];
         in.read(bytes);
         final String queryPlan = new String(bytes, StandardCharsets.UTF_8);
+
+        // read split id
+        String splitId = "splitId";
+        if(version >= 2){
+            splitId = in.readUTF();
+        }
         PartitionDefinition partDef =
                 new PartitionDefinition(database, table, beAddress, tabletIds, queryPlan);
-        return new DorisSourceSplit(partDef);
+        return new DorisSourceSplit(splitId, partDef);
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/split/DorisSourceSplitSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/split/DorisSourceSplitSerializer.java
@@ -17,18 +17,19 @@
 
 package org.apache.doris.flink.source.split;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.apache.doris.flink.rest.PartitionDefinition;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.memory.DataOutputView;
+
+import org.apache.doris.flink.rest.PartitionDefinition;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /** A serializer for the {@link DorisSourceSplit}. */
 public class DorisSourceSplitSerializer implements SimpleVersionedSerializer<DorisSourceSplit> {
@@ -71,7 +72,6 @@ public class DorisSourceSplitSerializer implements SimpleVersionedSerializer<Dor
 
         final DataOutputSerializer out = SERIALIZER_CACHE.get();
 
-
         PartitionDefinition partDef = split.getPartitionDefinition();
         out.writeUTF(partDef.getDatabase());
         out.writeUTF(partDef.getTable());
@@ -96,7 +96,7 @@ public class DorisSourceSplitSerializer implements SimpleVersionedSerializer<Dor
 
     @Override
     public DorisSourceSplit deserialize(int version, byte[] serialized) throws IOException {
-        switch (version){
+        switch (version) {
             case 1:
             case 2:
                 return deserializeSplit(version, serialized);
@@ -121,7 +121,7 @@ public class DorisSourceSplitSerializer implements SimpleVersionedSerializer<Dor
 
         // read split id
         String splitId = "splitId";
-        if(version >= 2){
+        if (version >= 2) {
             splitId = in.readUTF();
         }
         PartitionDefinition partDef =

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/enumerator/PendingSplitsCheckpointSerializerTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/enumerator/PendingSplitsCheckpointSerializerTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.doris.flink.source.enumerator;
 
+import java.util.Arrays;
+
 import org.apache.doris.flink.sink.OptionUtils;
 import org.apache.doris.flink.source.split.DorisSourceSplit;
 import org.apache.doris.flink.source.split.DorisSourceSplitSerializer;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Arrays;
 
 /** Unit tests for the {@link PendingSplitsCheckpointSerializer}. */
 public class PendingSplitsCheckpointSerializerTest {
@@ -35,7 +35,7 @@ public class PendingSplitsCheckpointSerializerTest {
 
     @Test
     public void serializeSplit() throws Exception {
-        final DorisSourceSplit split = new DorisSourceSplit(OptionUtils.buildPartitionDef());
+        final DorisSourceSplit split = new DorisSourceSplit("splitId", OptionUtils.buildPartitionDef());
         PendingSplitsCheckpoint checkpoint = new PendingSplitsCheckpoint(Arrays.asList(split));
 
         final PendingSplitsCheckpointSerializer splitSerializer =

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/enumerator/PendingSplitsCheckpointSerializerTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/enumerator/PendingSplitsCheckpointSerializerTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.doris.flink.source.enumerator;
 
-import java.util.Arrays;
-
 import org.apache.doris.flink.sink.OptionUtils;
 import org.apache.doris.flink.source.split.DorisSourceSplit;
 import org.apache.doris.flink.source.split.DorisSourceSplitSerializer;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 /** Unit tests for the {@link PendingSplitsCheckpointSerializer}. */
 public class PendingSplitsCheckpointSerializerTest {
@@ -35,7 +35,8 @@ public class PendingSplitsCheckpointSerializerTest {
 
     @Test
     public void serializeSplit() throws Exception {
-        final DorisSourceSplit split = new DorisSourceSplit("splitId", OptionUtils.buildPartitionDef());
+        final DorisSourceSplit split =
+                new DorisSourceSplit("splitId", OptionUtils.buildPartitionDef());
         PendingSplitsCheckpoint checkpoint = new PendingSplitsCheckpoint(Arrays.asList(split));
 
         final PendingSplitsCheckpointSerializer splitSerializer =

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/reader/DorisSourceReaderTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/reader/DorisSourceReaderTest.java
@@ -17,15 +17,14 @@
 
 package org.apache.doris.flink.source.reader;
 
-import org.apache.doris.flink.deserialization.SimpleListDeserializationSchema;
-import org.apache.doris.flink.sink.OptionUtils;
-import org.apache.doris.flink.source.split.DorisSourceSplit;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.Collections;
 
+import org.apache.doris.flink.deserialization.SimpleListDeserializationSchema;
+import org.apache.doris.flink.sink.OptionUtils;
+import org.apache.doris.flink.source.split.DorisSourceSplit;
 import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 /** Unit tests for the {@link DorisSourceReader}. */
 public class DorisSourceReaderTest {
@@ -40,7 +39,7 @@ public class DorisSourceReaderTest {
     }
 
     private static DorisSourceSplit createTestDorisSplit() throws IOException {
-        return new DorisSourceSplit(OptionUtils.buildPartitionDef());
+        return new DorisSourceSplit("splitId", OptionUtils.buildPartitionDef());
     }
 
     @Test

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/reader/DorisSourceReaderTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/reader/DorisSourceReaderTest.java
@@ -17,14 +17,15 @@
 
 package org.apache.doris.flink.source.reader;
 
-import java.io.IOException;
-import java.util.Collections;
-
 import org.apache.doris.flink.deserialization.SimpleListDeserializationSchema;
 import org.apache.doris.flink.sink.OptionUtils;
 import org.apache.doris.flink.source.split.DorisSourceSplit;
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
 
 /** Unit tests for the {@link DorisSourceReader}. */
 public class DorisSourceReaderTest {

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/split/DorisSourceSplitSerializerTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/split/DorisSourceSplitSerializerTest.java
@@ -27,7 +27,8 @@ public class DorisSourceSplitSerializerTest {
 
     @Test
     public void serializeSplit() throws Exception {
-        final DorisSourceSplit split = new DorisSourceSplit("splitId", OptionUtils.buildPartitionDef());
+        final DorisSourceSplit split =
+                new DorisSourceSplit("splitId", OptionUtils.buildPartitionDef());
 
         DorisSourceSplit deSerialized = serializeAndDeserializeSplit(split);
         assertEquals(split, deSerialized);

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/split/DorisSourceSplitSerializerTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/split/DorisSourceSplitSerializerTest.java
@@ -27,7 +27,7 @@ public class DorisSourceSplitSerializerTest {
 
     @Test
     public void serializeSplit() throws Exception {
-        final DorisSourceSplit split = new DorisSourceSplit(OptionUtils.buildPartitionDef());
+        final DorisSourceSplit split = new DorisSourceSplit("splitId", OptionUtils.buildPartitionDef());
 
         DorisSourceSplit deSerialized = serializeAndDeserializeSplit(split);
         assertEquals(split, deSerialized);

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/split/DorisSourceSplitTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/split/DorisSourceSplitTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.doris.flink.source.split;
 
-import java.util.HashSet;
-
 import org.apache.doris.flink.rest.PartitionDefinition;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.HashSet;
 
 public class DorisSourceSplitTest {
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/split/DorisSourceSplitTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/split/DorisSourceSplitTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.doris.flink.source.split;
 
+import java.util.HashSet;
+
 import org.apache.doris.flink.rest.PartitionDefinition;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.HashSet;
 
 public class DorisSourceSplitTest {
 
@@ -31,8 +31,8 @@ public class DorisSourceSplitTest {
                 new PartitionDefinition("db", "tbl", "be", new HashSet<>(), "queryplan1");
         PartitionDefinition pd2 =
                 new PartitionDefinition("db", "tbl", "be", new HashSet<>(), "queryplan1");
-        DorisSourceSplit split1 = new DorisSourceSplit(pd1);
-        DorisSourceSplit split2 = new DorisSourceSplit(pd2);
+        DorisSourceSplit split1 = new DorisSourceSplit("be_1", pd1);
+        DorisSourceSplit split2 = new DorisSourceSplit("be_2", pd2);
         Assert.assertEquals(split1, split2);
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When using DorisSource, currently SplitId is the IP address of BE. If it is divided into partitions across BE, duplicate splitIds will appear.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
