### PR TITLE
(Fix)[case] Fix unstable cases

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
@@ -427,4 +427,9 @@ public class BatchStageLoad implements Serializable {
     public void setHttpClientBuilder(HttpClientBuilder httpClientBuilder) {
         this.httpClientBuilder = httpClientBuilder;
     }
+
+    @VisibleForTesting
+    public boolean isLoadThreadAlive() {
+        return loadThreadAlive;
+    }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyWriter.java
@@ -197,7 +197,7 @@ public class DorisCopyWriter<IN>
     }
 
     @VisibleForTesting
-    public void setBatchStageLoad(BatchStageLoad batchStageLoad) {
-        this.batchStageLoad = batchStageLoad;
+    public BatchStageLoad getBatchStageLoad() {
+        return batchStageLoad;
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/TestUtil.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/TestUtil.java
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.util.function.SupplierWithException;
+
+import java.util.concurrent.TimeoutException;
+
+public class TestUtil {
+
+    public static void waitUntilCondition(
+            SupplierWithException<Boolean, Exception> condition,
+            Deadline timeout,
+            long retryIntervalMillis,
+            String errorMsg)
+            throws Exception {
+        while (timeout.hasTimeLeft() && !(Boolean) condition.get()) {
+            long timeLeft = Math.max(0L, timeout.timeLeft().toMillis());
+            Thread.sleep(Math.min(retryIntervalMillis, timeLeft));
+        }
+
+        if (!timeout.hasTimeLeft()) {
+            throw new TimeoutException(errorMsg);
+        }
+    }
+}

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
@@ -18,23 +18,18 @@
 package org.apache.doris.flink.sink.batch;
 
 import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.util.function.SupplierWithException;
 
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.BackendUtil;
 import org.apache.doris.flink.sink.HttpTestUtil;
+import org.apache.doris.flink.sink.TestUtil;
 import org.apache.doris.flink.sink.writer.LabelGenerator;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.junit.runners.MethodSorters;
 import org.mockito.MockedStatic;
@@ -42,13 +37,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestDorisBatchStreamLoad {
@@ -97,7 +89,7 @@ public class TestDorisBatchStreamLoad {
         DorisBatchStreamLoad loader =
                 new DorisBatchStreamLoad(
                         options, readOptions, executionOptions, new LabelGenerator("label", false));
-        waitUntilCondition(
+        TestUtil.waitUntilCondition(
                 () -> loader.isLoadThreadAlive(),
                 Deadline.fromNow(Duration.ofSeconds(10)),
                 100L,
@@ -137,7 +129,7 @@ public class TestDorisBatchStreamLoad {
                 new DorisBatchStreamLoad(
                         options, readOptions, executionOptions, new LabelGenerator("label", false));
 
-        waitUntilCondition(
+        TestUtil.waitUntilCondition(
                 () -> loader.isLoadThreadAlive(),
                 Deadline.fromNow(Duration.ofSeconds(10)),
                 100L,
@@ -166,22 +158,6 @@ public class TestDorisBatchStreamLoad {
     public void after() {
         if (backendUtilMockedStatic != null) {
             backendUtilMockedStatic.close();
-        }
-    }
-
-    public static void waitUntilCondition(
-            SupplierWithException<Boolean, Exception> condition,
-            Deadline timeout,
-            long retryIntervalMillis,
-            String errorMsg)
-            throws Exception {
-        while (timeout.hasTimeLeft() && !(Boolean) condition.get()) {
-            long timeLeft = Math.max(0L, timeout.timeLeft().toMillis());
-            Thread.sleep(Math.min(retryIntervalMillis, timeLeft));
-        }
-
-        if (!timeout.hasTimeLeft()) {
-            throw new TimeoutException(errorMsg);
         }
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
@@ -29,7 +29,12 @@ import org.apache.doris.flink.sink.writer.LabelGenerator;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runners.MethodSorters;
 import org.mockito.MockedStatic;
@@ -40,7 +45,9 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestDorisBatchStreamLoad {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

```
[INFO] Running org.apache.doris.flink.sink.copy.TestDorisCopyWriter
02:12:37,489 INFO  org.apache.doris.flink.sink.copy.DorisCopyWriter             [main]  - restore checkpointId 0
02:12:37,490 INFO  org.apache.doris.flink.sink.copy.DorisCopyWriter             [main]  - labelPrefix doris
02:12:37,492 INFO  org.apache.doris.flink.sink.copy.BatchStageLoad              [pool-2-copy-executor-1]  - StageLoadAsyncExecutor start
02:12:37,493 INFO  org.apache.doris.flink.sink.copy.DorisCopyWriter             [main]  - checkpoint arrived, upload buffer to storage
02:12:37,494 INFO  org.apache.doris.flink.sink.copy.DorisCopyWriter             [main]  - checkpoint flush triggered.
02:12:37,497 INFO  org.apache.doris.flink.sink.copy.BatchStageLoad              [pool-1-copy-executor-1]  - StageLoadAsyncExecutor start
02:12:37,501 INFO  org.apache.doris.flink.sink.copy.DorisCopyWriter             [main]  - restore checkpointId 0
02:12:37,501 INFO  org.apache.doris.flink.sink.copy.DorisCopyWriter             [main]  - labelPrefix doris
02:12:37,503 INFO  org.apache.doris.flink.sink.copy.BatchStageLoad              [pool-3-copy-executor-1]  - StageLoadAsyncExecutor start
02:12:37,503 INFO  org.apache.doris.flink.sink.copy.DorisCopyWriter             [main]  - DorisBatchWriter Close
02:12:37,503 INFO  org.apache.doris.flink.sink.copy.BatchStageLoad              [pool-4-copy-executor-1]  - StageLoadAsyncExecutor start
Error:  Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.018 s <<< FAILURE! - in org.apache.doris.flink.sink.copy.TestDorisCopyWriter
Error:  testPrepareCommit  Time elapsed: 0.015 s  <<< ERROR!
java.lang.RuntimeException: load thread already exit, write was interrupted
	at org.apache.doris.flink.sink.copy.TestDorisCopyWriter.testPrepareCommit(TestDorisCopyWriter.java:93)

02:12:37,504 INFO  org.apache.doris.flink.sink.copy.BatchStageLoad              [pool-4-copy-executor-1]  - StageLoadAsyncExecutor stop
[INFO] Running org.apache.doris.flink.sink.copy.TestCopyCommittableSerializer
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
