### PR TITLE
doris illegal label fix

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
@@ -49,12 +49,16 @@ public class LabelGenerator {
 
     public String generateTableLabel(long chkId) {
         Preconditions.checkState(tableIdentifier != null);
+        // The label of stream load can not contain `-` , replace all "-" by "_"
         String label = String.format("%s_%s_%s_%s", labelPrefix, tableIdentifier, subtaskId, chkId);
-        return enable2PC ? label : label + "_" + UUID.randomUUID();
+        String uuid = UUID.randomUUID().toString().replace("-", "_");
+        return enable2PC ? label : label + "_" + uuid;
     }
 
     public String generateBatchLabel(String table) {
-        return String.format("%s_%s_%s", labelPrefix, table, UUID.randomUUID());
+        // The label of stream load can not contain `-` , replace all "-" by "_"
+        String uuid = UUID.randomUUID().toString().replace("-", "_");
+        return String.format("%s_%s_%s", labelPrefix, table, uuid);
     }
 
     public String generateCopyBatchLabel(String table, long chkId, int fileNum) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #420 
## Problem Summary:

Backgroud（why）：
When flink cdc uses doris-flink-connector for data synchronization, it generates random labels to complete streamload. Currently, the generated labels contain illegal "-" hyphens, which makes the labels unable to be cleaned.

Describe the overview of changes.
Replace the "-" in label with "_" to ensure the generation of a legal random label.
## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)
