### PR TITLE
[Fix] fix projection pushdown

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSource.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSource.java
@@ -94,6 +94,15 @@ public final class DorisDynamicTableSource
             String filterQuery = resolvedFilterQuery.stream().collect(Collectors.joining(" AND "));
             readOptions.setFilterQuery(filterQuery);
         }
+        if (StringUtils.isNullOrWhitespaceOnly(readOptions.getReadFields())) {
+            String[] selectFields =
+                    DataType.getFieldNames(physicalRowDataType).toArray(new String[0]);
+            readOptions.setReadFields(
+                    Arrays.stream(selectFields)
+                            .map(item -> String.format("`%s`", item.trim().replace("`", "")))
+                            .collect(Collectors.joining(", ")));
+        }
+
         if (readOptions.getUseOldApi()) {
             List<PartitionDefinition> dorisPartitions;
             try {
@@ -199,14 +208,11 @@ public final class DorisDynamicTableSource
     @Override
     public void applyProjection(int[][] projectedFields, DataType producedDataType) {
         this.physicalRowDataType = Projection.of(projectedFields).project(physicalRowDataType);
-        if (StringUtils.isNullOrWhitespaceOnly(readOptions.getReadFields())) {
-            String[] selectFields =
-                    DataType.getFieldNames(physicalRowDataType).toArray(new String[0]);
-            this.readOptions.setReadFields(
-                    Arrays.stream(selectFields)
-                            .map(item -> String.format("`%s`", item.trim().replace("`", "")))
-                            .collect(Collectors.joining(", ")));
-        }
+        String[] selectFields = DataType.getFieldNames(physicalRowDataType).toArray(new String[0]);
+        this.readOptions.setReadFields(
+                Arrays.stream(selectFields)
+                        .map(item -> String.format("`%s`", item.trim().replace("`", "")))
+                        .collect(Collectors.joining(", ")));
     }
 
     @VisibleForTesting

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
@@ -49,6 +49,7 @@ public class DorisSourceITCase extends DorisTestBase {
     static final String TABLE_READ_TBL = "tbl_read_tbl";
     static final String TABLE_READ_TBL_OLD_API = "tbl_read_tbl_old_api";
     static final String TABLE_READ_TBL_ALL_OPTIONS = "tbl_read_tbl_all_options";
+    static final String TABLE_READ_TBL_PUSH_DOWN = "tbl_read_tbl_push_down";
 
     @Test
     public void testSource() throws Exception {
@@ -228,6 +229,41 @@ public class DorisSourceITCase extends DorisTestBase {
             }
         }
         String[] expected = new String[] {"+I[doris, 18]", "+I[flink, 10]"};
+        Assert.assertArrayEquals(expected, actual.toArray());
+    }
+
+    @Test
+    public void testTableSourceFilterAndProjectionPushDown() throws Exception {
+        initializeTable(TABLE_READ_TBL_PUSH_DOWN);
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        String sourceDDL =
+                String.format(
+                        "CREATE TABLE doris_source ("
+                                + " age INT"
+                                + ") WITH ("
+                                + " 'connector' = 'doris',"
+                                + " 'fenodes' = '%s',"
+                                + " 'table.identifier' = '%s',"
+                                + " 'username' = '%s',"
+                                + " 'password' = '%s'"
+                                + ")",
+                        getFenodes(),
+                        DATABASE + "." + TABLE_READ_TBL_PUSH_DOWN,
+                        USERNAME,
+                        PASSWORD);
+        tEnv.executeSql(sourceDDL);
+        TableResult tableResult = tEnv.executeSql("SELECT age FROM doris_source");
+
+        List<String> actual = new ArrayList<>();
+        try (CloseableIterator<Row> iterator = tableResult.collect()) {
+            while (iterator.hasNext()) {
+                actual.add(iterator.next().toString());
+            }
+        }
+        String[] expected = new String[] {"+I[18]", "+I[10]"};
         Assert.assertArrayEquals(expected, actual.toArray());
     }
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
@@ -255,8 +255,7 @@ public class DorisSourceITCase extends DorisTestBase {
                         USERNAME,
                         PASSWORD);
         tEnv.executeSql(sourceDDL);
-        TableResult tableResult =
-                tEnv.executeSql("SELECT age FROM doris_source where age = '18'");
+        TableResult tableResult = tEnv.executeSql("SELECT age FROM doris_source where age = '18'");
 
         List<String> actual = new ArrayList<>();
         try (CloseableIterator<Row> iterator = tableResult.collect()) {

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
@@ -256,7 +256,7 @@ public class DorisSourceITCase extends DorisTestBase {
                         PASSWORD);
         tEnv.executeSql(sourceDDL);
         TableResult tableResult =
-                tEnv.executeSql("SELECT age FROM doris_source where name = 'doris'");
+                tEnv.executeSql("SELECT age FROM doris_source where age = '18'");
 
         List<String> actual = new ArrayList<>();
         try (CloseableIterator<Row> iterator = tableResult.collect()) {

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
@@ -255,7 +255,8 @@ public class DorisSourceITCase extends DorisTestBase {
                         USERNAME,
                         PASSWORD);
         tEnv.executeSql(sourceDDL);
-        TableResult tableResult = tEnv.executeSql("SELECT age FROM doris_source");
+        TableResult tableResult =
+                tEnv.executeSql("SELECT age FROM doris_source where name = 'doris'");
 
         List<String> actual = new ArrayList<>();
         try (CloseableIterator<Row> iterator = tableResult.collect()) {
@@ -263,7 +264,7 @@ public class DorisSourceITCase extends DorisTestBase {
                 actual.add(iterator.next().toString());
             }
         }
-        String[] expected = new String[] {"+I[18]", "+I[10]"};
+        String[] expected = new String[] {"+I[18]"};
         Assert.assertArrayEquals(expected, actual.toArray());
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

If Doris's table is
```sql
 CREATE TABLE `test_flink` (
  `name` VARCHAR(200) NULL,
  `age` INT NULL
) ENGINE=OLAP
UNIQUE KEY(`name`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`name`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1"
)
```

and FlinkSQL is
```sql
        tEnv.executeSql(
                "CREATE TABLE doris_source ("
                        + "age INT"
                        + ") "
                        + "WITH (\n"
                        + "  'connector' = 'doris',\n"
                        + "  'fenodes' = 'xxxx:8030',\n"
                        + "  'table.identifier' = 'test.test_flink',\n"
                        + "  'username' = 'root',\n"
                        + "  'password' = ''\n"
                        + ")");
final Table result = tEnv.sqlQuery("SELECT age from doris_source ");
```
The execution plan currently sent is still select * from table, which results in the query data having 2 columns, but the flink schema has only 1 column, and the serialization will report an error



## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
