### PR TITLE
[fix]Fix NPE that occurs when schemaChangeMode is not specified

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -36,6 +36,7 @@ import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisSystemException;
 import org.apache.doris.flink.sink.DorisSink;
+import org.apache.doris.flink.sink.schema.SchemaChangeMode;
 import org.apache.doris.flink.sink.writer.WriteMode;
 import org.apache.doris.flink.sink.writer.serializer.DorisRecordSerializer;
 import org.apache.doris.flink.sink.writer.serializer.JsonDebeziumSchemaSerializer;
@@ -563,6 +564,10 @@ public abstract class DatabaseSync {
     }
 
     public DatabaseSync setSchemaChangeMode(String schemaChangeMode) {
+        if (org.apache.commons.lang3.StringUtils.isEmpty(schemaChangeMode)) {
+            this.schemaChangeMode = SchemaChangeMode.DEBEZIUM_STRUCTURE.getName();
+            return this;
+        }
         this.schemaChangeMode = schemaChangeMode.trim();
         return this;
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
When `--schema-change-mode` is not specified, a null pointer problem occurs
<img width="831" alt="image" src="https://github.com/user-attachments/assets/b7382661-0d54-4497-871f-23380b5b1907">

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
