### PR TITLE
[Fix] fix arrow  read timestamp bug

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/serialization/RowBatch.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/serialization/RowBatch.java
@@ -348,9 +348,9 @@ public class RowBatch {
                     addValueToRow(rowIndex, dateTime);
                 } else {
                     logger.error(
-                            "Unsupported type for DATETIME, minorType {}, vector {}",
+                            "Unsupported type for DATETIME, minorType {}, class is {}",
                             minorType.name(),
-                            fieldVector);
+                            fieldVector == null ? null : fieldVector.getClass());
                     return false;
                 }
                 break;
@@ -370,9 +370,9 @@ public class RowBatch {
                     addValueToRow(rowIndex, dateTime);
                 } else {
                     logger.error(
-                            "Unsupported type for DATETIMEV2, minorType {}, vector {}",
+                            "Unsupported type for DATETIMEV2, minorType {}, class is {}",
                             minorType.name(),
-                            fieldVector);
+                            fieldVector == null ? null : fieldVector.getClass());
                     return false;
                 }
                 break;

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/serialization/TestRowBatch.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/serialization/TestRowBatch.java
@@ -1333,10 +1333,21 @@ public class TestRowBatch {
         flag = rowBatch.doConvert(1, 1, Types.MinorType.INT, "DATETIME", null);
         Assert.assertFalse(flag);
 
+        flag = rowBatch.doConvert(1, 1, Types.MinorType.TIMESTAMPSEC, "DATETIME", null);
+        Assert.assertFalse(flag);
+
+        IntVector intVector1 = new IntVector("test", new RootAllocator(Integer.MAX_VALUE));
+        intVector1.setNull(0);
+        flag = rowBatch.doConvert(1, 1, Types.MinorType.TIMESTAMPSEC, "DATETIME", intVector1);
+        Assert.assertFalse(flag);
+
         flag = rowBatch.doConvert(1, 1, Types.MinorType.INT, "DATETIMEV2", null);
         Assert.assertFalse(flag);
 
         flag = rowBatch.doConvert(1, 1, Types.MinorType.TIMESTAMPSEC, "DATETIMEV2", null);
+        Assert.assertFalse(flag);
+
+        flag = rowBatch.doConvert(1, 1, Types.MinorType.TIMESTAMPSEC, "DATETIMEV2", intVector1);
         Assert.assertFalse(flag);
 
         flag = rowBatch.doConvert(1, 1, Types.MinorType.INT, "LARGEINT", null);

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/serialization/TestRowBatch.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/serialization/TestRowBatch.java
@@ -34,6 +34,8 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampSecVector;
 import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.UInt4Vector;
 import org.apache.arrow.vector.VarBinaryVector;
@@ -1334,6 +1336,9 @@ public class TestRowBatch {
         flag = rowBatch.doConvert(1, 1, Types.MinorType.INT, "DATETIMEV2", null);
         Assert.assertFalse(flag);
 
+        flag = rowBatch.doConvert(1, 1, Types.MinorType.TIMESTAMPSEC, "DATETIMEV2", null);
+        Assert.assertFalse(flag);
+
         flag = rowBatch.doConvert(1, 1, Types.MinorType.INT, "LARGEINT", null);
         Assert.assertFalse(flag);
 
@@ -1657,5 +1662,98 @@ public class TestRowBatch {
         long[] resultArray = {result1, result2, result3};
 
         Assert.assertArrayEquals(expectArray, resultArray);
+    }
+
+    @Test
+    public void timestampVector() throws IOException, DorisException {
+        List<Field> childrenBuilder = new ArrayList<>();
+        childrenBuilder.add(
+                new Field(
+                        "k0",
+                        FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MICROSECOND, null)),
+                        null));
+        childrenBuilder.add(
+                new Field(
+                        "k1",
+                        FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)),
+                        null));
+        childrenBuilder.add(
+                new Field(
+                        "k2",
+                        FieldType.nullable(new ArrowType.Timestamp(TimeUnit.SECOND, null)),
+                        null));
+
+        VectorSchemaRoot root =
+                VectorSchemaRoot.create(
+                        new org.apache.arrow.vector.types.pojo.Schema(childrenBuilder, null),
+                        new RootAllocator(Integer.MAX_VALUE));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ArrowStreamWriter arrowStreamWriter =
+                new ArrowStreamWriter(
+                        root, new DictionaryProvider.MapDictionaryProvider(), outputStream);
+
+        arrowStreamWriter.start();
+        root.setRowCount(1);
+
+        FieldVector vector = root.getVector("k0");
+        TimeStampMicroVector mircoVec = (TimeStampMicroVector) vector;
+        mircoVec.allocateNew(1);
+        mircoVec.setIndexDefined(0);
+        mircoVec.setSafe(0, 1721892143586123L);
+        vector.setValueCount(1);
+
+        vector = root.getVector("k1");
+        TimeStampMilliVector milliVector = (TimeStampMilliVector) vector;
+        milliVector.allocateNew(1);
+        milliVector.setIndexDefined(0);
+        milliVector.setSafe(0, 1721892143586L);
+        vector.setValueCount(1);
+
+        vector = root.getVector("k2");
+        TimeStampSecVector secVector = (TimeStampSecVector) vector;
+        secVector.allocateNew(1);
+        secVector.setIndexDefined(0);
+        secVector.setSafe(0, 1721892143L);
+        vector.setValueCount(1);
+
+        arrowStreamWriter.writeBatch();
+
+        arrowStreamWriter.end();
+        arrowStreamWriter.close();
+
+        TStatus status = new TStatus();
+        status.setStatusCode(TStatusCode.OK);
+        TScanBatchResult scanBatchResult = new TScanBatchResult();
+        scanBatchResult.setStatus(status);
+        scanBatchResult.setEos(false);
+        scanBatchResult.setRows(outputStream.toByteArray());
+
+        String schemaStr =
+                "{\"properties\":[{\"type\":\"DATETIME\",\"name\":\"k0\",\"comment\":\"\"}, {\"type\":\"DATETIME\",\"name\":\"k1\",\"comment\":\"\"}, {\"type\":\"DATETIME\",\"name\":\"k2\",\"comment\":\"\"}],"
+                        + "\"status\":200}";
+
+        Schema schema = RestService.parseSchema(schemaStr, logger);
+
+        RowBatch rowBatch = new RowBatch(scanBatchResult, schema).readArrow();
+        List<Object> next = rowBatch.next();
+        Assert.assertEquals(next.size(), 3);
+        Assert.assertEquals(
+                next.get(0),
+                LocalDateTime.of(2024, 7, 25, 15, 22, 23, 586123000)
+                        .atZone(ZoneId.of("UTC+8"))
+                        .withZoneSameInstant(ZoneId.systemDefault())
+                        .toLocalDateTime());
+        Assert.assertEquals(
+                next.get(1),
+                LocalDateTime.of(2024, 7, 25, 15, 22, 23, 586000000)
+                        .atZone(ZoneId.of("UTC+8"))
+                        .withZoneSameInstant(ZoneId.systemDefault())
+                        .toLocalDateTime());
+        Assert.assertEquals(
+                next.get(2),
+                LocalDateTime.of(2024, 7, 25, 15, 22, 23, 0)
+                        .atZone(ZoneId.of("UTC+8"))
+                        .withZoneSameInstant(ZoneId.systemDefault())
+                        .toLocalDateTime());
     }
 }


### PR DESCRIPTION
# Proposed changes

Currently, when reading arrow, since the be layer hard-codes all datetimev2 scales to 6, arrow returns TimeStampMicroVector, which results in scale parsing errors when arrow is displayed. Refer to https://github.com/apache/doris/issues/38174

This PR removes the strong consistency restriction of the type and is compatible with the logic of the scale repaired above

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
