### PR TITLE
[fix][mongodb-cdc]fix replace decimal type error when meeting non decimal type

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchema.java
@@ -22,14 +22,18 @@ import org.apache.flink.api.java.tuple.Tuple2;
 
 import org.apache.doris.flink.catalog.doris.DorisType;
 import org.apache.doris.flink.catalog.doris.FieldSchema;
+import org.apache.doris.flink.exception.DorisRuntimeException;
 import org.apache.doris.flink.tools.cdc.SourceSchema;
 import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class MongoDBSchema extends SourceSchema {
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBSchema.class);
 
     public MongoDBSchema(
             ArrayList<Document> sampleData,
@@ -73,17 +77,27 @@ public class MongoDBSchema extends SourceSchema {
             int existingPrecision = existingPrecisionAndScale.f0;
             int existingScale = existingPrecisionAndScale.f1;
 
-            Tuple2<Integer, Integer> currentPrecisionAndScale =
-                    MongoDBType.getDecimalPrecisionAndScale(newDorisType);
-            int currentPrecision = currentPrecisionAndScale.f0;
-            int currentScale = currentPrecisionAndScale.f1;
+            try {
+                Tuple2<Integer, Integer> currentPrecisionAndScale =
+                        MongoDBType.getDecimalPrecisionAndScale(newDorisType);
+                int currentPrecision = currentPrecisionAndScale.f0;
+                int currentScale = currentPrecisionAndScale.f1;
 
-            int newScale = Math.max(existingScale, currentScale);
-            int newIntegerPartSize =
-                    Math.max(existingPrecision - existingScale, currentPrecision - currentScale);
-            int newPrecision = newIntegerPartSize + newScale;
+                int newScale = Math.max(existingScale, currentScale);
+                int newIntegerPartSize =
+                        Math.max(
+                                existingPrecision - existingScale, currentPrecision - currentScale);
+                int newPrecision = newIntegerPartSize + newScale;
 
-            return DorisType.DECIMAL + "(" + newPrecision + "," + newScale + ")";
+                return DorisType.DECIMAL + "(" + newPrecision + "," + newScale + ")";
+            } catch (DorisRuntimeException e) {
+                LOG.warn(
+                        "Replace decimal type of field:{} failed, the newly type is:{}, rollback to existing type:{}",
+                        fieldName,
+                        newDorisType,
+                        existingField.getTypeString());
+                return existingField.getTypeString();
+            }
         }
         return newDorisType;
     }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchemaTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchemaTest.java
@@ -44,4 +44,15 @@ public class MongoDBSchemaTest {
         String d = mongoDBSchema.replaceDecimalTypeIfNeeded("fields1", "DECIMALV3(12,8)");
         assertEquals("DECIMAL(15,8)", d);
     }
+
+    @Test
+    public void replaceDecimalTypeIfNeededWhenContainsNonDecimalType() throws Exception {
+        ArrayList<Document> documents = new ArrayList<>();
+        documents.add(new Document("fields1", 1234567.666666));
+        documents.add(new Document("fields1", 1234567));
+        documents.add(new Document("fields1", 1234567.7777777));
+        MongoDBSchema mongoDBSchema = new MongoDBSchema(documents, "db_TEST", "test_table", "");
+        String d = mongoDBSchema.replaceDecimalTypeIfNeeded("fields1", "DECIMALV3(12,8)");
+        assertEquals("DECIMAL(15,8)", d);
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

If field's type is decimal type at first, then insert some non decimal type like int, it would cause `Get Decimal precision and Scale error !`.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
