### PR TITLE
[improve]Improve the hardcode of tableConfig

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalog.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/DorisCatalog.java
@@ -56,6 +56,7 @@ import org.apache.doris.flink.catalog.doris.FieldSchema;
 import org.apache.doris.flink.catalog.doris.TableSchema;
 import org.apache.doris.flink.cfg.DorisConnectionOptions;
 import org.apache.doris.flink.table.DorisDynamicTableFactory;
+import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -359,7 +360,7 @@ public class DorisCatalog extends AbstractCatalog {
                         tablePath.getObjectName(),
                         getCreateDorisColumns(table.getSchema()),
                         primaryKeys,
-                        getCreateTableProps(options),
+                        new DorisTableConfig(getCreateTableProps(options)),
                         table.getComment());
 
         dorisSystem.createTable(schema);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSchemaFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSchemaFactory.java
@@ -20,6 +20,7 @@ package org.apache.doris.flink.catalog.doris;
 import org.apache.flink.annotation.VisibleForTesting;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 
 import java.util.ArrayList;
@@ -87,7 +88,7 @@ public class DorisSchemaFactory {
     @VisibleForTesting
     public static Integer parseTableSchemaBuckets(
             Map<String, Integer> tableBucketsMap, String tableName) {
-        if (tableBucketsMap != null) {
+        if (MapUtils.isNotEmpty(tableBucketsMap)) {
             // Firstly, if the table name is in the table-buckets map, set the buckets of the table.
             if (tableBucketsMap.containsKey(tableName)) {
                 return tableBucketsMap.get(tableName);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSystem.java
@@ -50,7 +50,6 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class DorisSystem implements Serializable {
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(DorisSystem.class);
-    private static final String TABLE_BUCKETS = "table-buckets";
     private final JdbcConnectionProvider jdbcConnectionProvider;
     private static final List<String> builtinDatabases =
             Collections.singletonList("information_schema");
@@ -200,13 +199,7 @@ public class DorisSystem implements Serializable {
         }
         // append properties
         int index = 0;
-        int skipProNum = 0;
         for (Map.Entry<String, String> entry : properties.entrySet()) {
-            // skip table-buckets
-            if (entry.getKey().equals(TABLE_BUCKETS)) {
-                skipProNum++;
-                continue;
-            }
             if (index == 0) {
                 sb.append(" PROPERTIES (");
             }
@@ -218,7 +211,7 @@ public class DorisSystem implements Serializable {
                     .append(quoteProperties(entry.getValue()));
             index++;
 
-            if (index == (schema.getProperties().size() - skipProNum)) {
+            if (index == (schema.getProperties().size())) {
                 sb.append(")");
             }
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManager.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManager.java
@@ -35,6 +35,7 @@ import org.apache.doris.flink.catalog.doris.DorisSchemaFactory;
 import org.apache.doris.flink.catalog.doris.FieldSchema;
 import org.apache.doris.flink.catalog.doris.TableSchema;
 import org.apache.doris.flink.sink.writer.serializer.jsondebezium.JsonDebeziumChangeUtils;
+import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 import org.apache.doris.flink.tools.cdc.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,7 +111,7 @@ public class SQLParserSchemaManager implements Serializable {
             SourceConnector sourceConnector,
             String ddl,
             String dorisTable,
-            Map<String, String> tableProperties) {
+            DorisTableConfig dorisTableConfig) {
         try {
             Statement statement = CCJSqlParserUtil.parse(ddl);
             if (statement instanceof CreateTable) {
@@ -144,7 +145,7 @@ public class SQLParserSchemaManager implements Serializable {
                         dbTable[1],
                         columnFields,
                         pkKeys,
-                        tableProperties,
+                        dorisTableConfig,
                         extractTableComment(createTable.getTableOptionsStrings()));
             } else {
                 LOG.warn(

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/JsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/JsonDebeziumSchemaSerializer.java
@@ -37,6 +37,7 @@ import org.apache.doris.flink.sink.writer.serializer.jsondebezium.JsonDebeziumSc
 import org.apache.doris.flink.sink.writer.serializer.jsondebezium.JsonDebeziumSchemaChangeImpl;
 import org.apache.doris.flink.sink.writer.serializer.jsondebezium.JsonDebeziumSchemaChangeImplV2;
 import org.apache.doris.flink.sink.writer.serializer.jsondebezium.SQLParserSchemaChange;
+import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
     // <cdc db.schema.table, doris db.table>
     private Map<String, String> tableMapping;
     // create table properties
-    private Map<String, String> tableProperties;
+    private DorisTableConfig dorisTableConfig;
     private String targetDatabase;
     private String targetTablePrefix;
     private String targetTableSuffix;
@@ -120,18 +121,18 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
             boolean newSchemaChange,
             DorisExecutionOptions executionOptions,
             Map<String, String> tableMapping,
-            Map<String, String> tableProperties,
+            DorisTableConfig dorisTableConfig,
             String targetDatabase,
             String targetTablePrefix,
             String targetTableSuffix,
             SchemaChangeMode schemaChangeMode) {
         this(dorisOptions, pattern, sourceTableName, newSchemaChange, executionOptions);
         this.tableMapping = tableMapping;
-        this.tableProperties = tableProperties;
         this.targetDatabase = targetDatabase;
         this.targetTablePrefix = targetTablePrefix;
         this.targetTableSuffix = targetTableSuffix;
         this.schemaChangeMode = schemaChangeMode;
+        this.dorisTableConfig = dorisTableConfig;
         init();
     }
 
@@ -142,7 +143,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
                         tableMapping,
                         sourceTableName,
                         targetDatabase,
-                        tableProperties,
+                        dorisTableConfig,
                         objectMapper,
                         pattern,
                         lineDelimiter,
@@ -225,7 +226,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         private SchemaChangeMode schemaChangeMode;
         private DorisExecutionOptions executionOptions;
         private Map<String, String> tableMapping;
-        private Map<String, String> tableProperties;
+        private DorisTableConfig dorisTableConfig;
         private String targetDatabase;
         private String targetTablePrefix = "";
         private String targetTableSuffix = "";
@@ -268,8 +269,14 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
             return this;
         }
 
+        @Deprecated
         public Builder setTableProperties(Map<String, String> tableProperties) {
-            this.tableProperties = tableProperties;
+            this.dorisTableConfig = new DorisTableConfig(tableProperties);
+            return this;
+        }
+
+        public Builder setDorisTableConf(DorisTableConfig dorisTableConfig) {
+            this.dorisTableConfig = dorisTableConfig;
             return this;
         }
 
@@ -300,7 +307,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
                     newSchemaChange,
                     executionOptions,
                     tableMapping,
-                    tableProperties,
+                    dorisTableConfig,
                     targetDatabase,
                     targetTablePrefix,
                     targetTableSuffix,

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
@@ -22,6 +22,7 @@ import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -86,7 +87,9 @@ public class JsonDebeziumChangeContext implements Serializable {
 
     @Deprecated
     public Map<String, String> getTableProperties() {
-        return Objects.nonNull(dorisTableConfig) ? dorisTableConfig.getTableProperties() : null;
+        return Objects.nonNull(dorisTableConfig)
+                ? dorisTableConfig.getTableProperties()
+                : new HashMap<>();
     }
 
     public ObjectMapper getObjectMapper() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
@@ -19,9 +19,11 @@ package org.apache.doris.flink.sink.writer.serializer.jsondebezium;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /** Record the context of schema change and data change during serialization. */
@@ -33,7 +35,7 @@ public class JsonDebeziumChangeContext implements Serializable {
     private final String sourceTableName;
     private final String targetDatabase;
     // create table properties
-    private final Map<String, String> tableProperties;
+    private final DorisTableConfig dorisTableConfig;
     private final ObjectMapper objectMapper;
     private final Pattern pattern;
     private final String lineDelimiter;
@@ -46,7 +48,7 @@ public class JsonDebeziumChangeContext implements Serializable {
             Map<String, String> tableMapping,
             String sourceTableName,
             String targetDatabase,
-            Map<String, String> tableProperties,
+            DorisTableConfig dorisTableConfig,
             ObjectMapper objectMapper,
             Pattern pattern,
             String lineDelimiter,
@@ -57,7 +59,7 @@ public class JsonDebeziumChangeContext implements Serializable {
         this.tableMapping = tableMapping;
         this.sourceTableName = sourceTableName;
         this.targetDatabase = targetDatabase;
-        this.tableProperties = tableProperties;
+        this.dorisTableConfig = dorisTableConfig;
         this.objectMapper = objectMapper;
         this.pattern = pattern;
         this.lineDelimiter = lineDelimiter;
@@ -82,8 +84,9 @@ public class JsonDebeziumChangeContext implements Serializable {
         return targetDatabase;
     }
 
+    @Deprecated
     public Map<String, String> getTableProperties() {
-        return tableProperties;
+        return Objects.nonNull(dorisTableConfig) ? dorisTableConfig.getTableProperties() : null;
     }
 
     public ObjectMapper getObjectMapper() {
@@ -108,5 +111,9 @@ public class JsonDebeziumChangeContext implements Serializable {
 
     public String getTargetTableSuffix() {
         return targetTableSuffix;
+    }
+
+    public DorisTableConfig getDorisTableConf() {
+        return dorisTableConfig;
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumSchemaChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumSchemaChange.java
@@ -30,6 +30,7 @@ import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.exception.IllegalArgumentException;
 import org.apache.doris.flink.sink.schema.SchemaChangeManager;
 import org.apache.doris.flink.sink.writer.EventType;
+import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 import org.apache.doris.flink.tools.cdc.SourceConnector;
 import org.apache.doris.flink.tools.cdc.SourceSchema;
 import org.slf4j.Logger;
@@ -69,6 +70,7 @@ public abstract class JsonDebeziumSchemaChange extends CdcSchemaChange {
     protected String targetDatabase;
     protected String targetTablePrefix;
     protected String targetTableSuffix;
+    protected DorisTableConfig dorisTableConfig;
 
     public abstract boolean schemaChange(JsonNode recordRoot);
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumSchemaChangeImplV2.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumSchemaChangeImplV2.java
@@ -68,7 +68,6 @@ public class JsonDebeziumSchemaChangeImplV2 extends JsonDebeziumSchemaChange {
     // schemaChange saves table names, field, and field column information
     private Map<String, Map<String, FieldSchema>> originFieldSchemaMap = new LinkedHashMap<>();
     // create table properties
-    private final Map<String, String> tableProperties;
     private final Set<String> filledTables = new HashSet<>();
 
     public JsonDebeziumSchemaChangeImplV2(JsonDebeziumChangeContext changeContext) {
@@ -78,7 +77,7 @@ public class JsonDebeziumSchemaChangeImplV2 extends JsonDebeziumSchemaChange {
         this.dorisOptions = changeContext.getDorisOptions();
         this.schemaChangeManager = new SchemaChangeManager(dorisOptions);
         this.targetDatabase = changeContext.getTargetDatabase();
-        this.tableProperties = changeContext.getTableProperties();
+        this.dorisTableConfig = changeContext.getDorisTableConf();
         this.tableMapping = changeContext.getTableMapping();
         this.objectMapper = changeContext.getObjectMapper();
         this.targetTablePrefix =
@@ -233,7 +232,7 @@ public class JsonDebeziumSchemaChangeImplV2 extends JsonDebeziumSchemaChange {
         Preconditions.checkArgument(dbTable.length == 2);
 
         return DorisSchemaFactory.createTableSchema(
-                dbTable[0], dbTable[1], fields, pkList, tableProperties, tblComment);
+                dbTable[0], dbTable[1], fields, pkList, dorisTableConfig, tblComment);
     }
 
     private boolean checkSchemaChange(String database, String table, DDLSchema ddlSchema)

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/SQLParserSchemaChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/SQLParserSchemaChange.java
@@ -44,6 +44,7 @@ public class SQLParserSchemaChange extends JsonDebeziumSchemaChange {
         this.tableMapping = changeContext.getTableMapping();
         this.objectMapper = changeContext.getObjectMapper();
         this.targetDatabase = changeContext.getTargetDatabase();
+        this.dorisTableConfig = changeContext.getDorisTableConf();
         this.targetTablePrefix =
                 changeContext.getTargetTablePrefix() == null
                         ? ""
@@ -106,7 +107,7 @@ public class SQLParserSchemaChange extends JsonDebeziumSchemaChange {
         String ddl = extractJsonNode(historyRecord, "ddl");
         extractSourceConnector(record);
         return sqlParserSchemaManager.parseCreateTableStatement(
-                sourceConnector, ddl, dorisTable, changeContext.getTableProperties());
+                sourceConnector, ddl, dorisTable, dorisTableConfig);
     }
 
     @VisibleForTesting

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
@@ -147,7 +147,8 @@ public class CdcTools {
 
         Preconditions.checkArgument(params.has(DatabaseSyncConfig.SINK_CONF));
         Map<String, String> sinkMap = getConfigMap(params, DatabaseSyncConfig.SINK_CONF);
-        Map<String, String> tableMap = getConfigMap(params, DatabaseSyncConfig.TABLE_CONF);
+        DorisTableConfig tableConfig =
+                new DorisTableConfig(getConfigMap(params, DatabaseSyncConfig.TABLE_CONF));
         Configuration sinkConfig = Configuration.fromMap(sinkMap);
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -163,7 +164,7 @@ public class CdcTools {
                 .setMultiToOneTarget(multiToOneTarget)
                 .setIgnoreDefaultValue(ignoreDefaultValue)
                 .setSinkConfig(sinkConfig)
-                .setTableConfig(tableMap)
+                .setTableConfig(tableConfig)
                 .setCreateTableOnly(createTableOnly)
                 .setSingleSink(singleSink)
                 .setIgnoreIncompatible(ignoreIncompatible)

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DorisTableConfig.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DorisTableConfig.java
@@ -28,12 +28,15 @@ import java.util.Objects;
 public class DorisTableConfig implements Serializable {
     private static final String LIGHT_SCHEMA_CHANGE = "light_schema_change";
     // PROPERTIES parameter in doris table creation statement. such as: replication_num=1.
-    private Map<String, String> tableProperties;
+    private final Map<String, String> tableProperties;
     // The specific parameters extracted from --table-conf need to be parsed and integrated into the
     // doris table creation statement. such as: table-buckets="tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50".
     private Map<String, Integer> tableBuckets;
 
-    public DorisTableConfig() {}
+    public DorisTableConfig() {
+        tableProperties = new HashMap<>();
+        tableBuckets = new HashMap<>();
+    }
 
     public DorisTableConfig(Map<String, String> tableConfig) {
         if (Objects.isNull(tableConfig)) {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DorisTableConfig.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DorisTableConfig.java
@@ -19,31 +19,34 @@ package org.apache.doris.flink.tools.cdc;
 
 import org.apache.flink.annotation.VisibleForTesting;
 
-import org.apache.commons.collections.MapUtils;
-
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class DorisTableConfig implements Serializable {
     private static final String LIGHT_SCHEMA_CHANGE = "light_schema_change";
     // PROPERTIES parameter in doris table creation statement. such as: replication_num=1.
-    private final Map<String, String> tableProperties;
+    private Map<String, String> tableProperties;
     // The specific parameters extracted from --table-conf need to be parsed and integrated into the
     // doris table creation statement. such as: table-buckets="tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50".
     private Map<String, Integer> tableBuckets;
 
+    public DorisTableConfig() {}
+
     public DorisTableConfig(Map<String, String> tableConfig) {
-        if (MapUtils.isNotEmpty(tableConfig)) {
-            // default enable light schema change
-            if (!tableConfig.containsKey(LIGHT_SCHEMA_CHANGE)) {
-                tableConfig.put(LIGHT_SCHEMA_CHANGE, Boolean.toString(true));
-            }
-            if (tableConfig.containsKey(DatabaseSyncConfig.TABLE_BUCKETS)) {
-                this.tableBuckets =
-                        buildTableBucketMap(tableConfig.get(DatabaseSyncConfig.TABLE_BUCKETS));
-                tableConfig.remove(DatabaseSyncConfig.TABLE_BUCKETS);
-            }
+        if (Objects.isNull(tableConfig)) {
+            tableConfig = new HashMap<>();
+        }
+        // default enable light schema change
+        if (!tableConfig.containsKey(LIGHT_SCHEMA_CHANGE)) {
+            tableConfig.put(LIGHT_SCHEMA_CHANGE, Boolean.toString(true));
+        }
+        if (tableConfig.containsKey(DatabaseSyncConfig.TABLE_BUCKETS)) {
+            this.tableBuckets =
+                    buildTableBucketMap(tableConfig.get(DatabaseSyncConfig.TABLE_BUCKETS));
+            tableConfig.remove(DatabaseSyncConfig.TABLE_BUCKETS);
         }
         tableProperties = tableConfig;
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DorisTableConfig.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DorisTableConfig.java
@@ -33,6 +33,8 @@ public class DorisTableConfig implements Serializable {
     // doris table creation statement. such as: table-buckets="tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50".
     private Map<String, Integer> tableBuckets;
 
+    // Only for testing
+    @VisibleForTesting
     public DorisTableConfig() {
         tableProperties = new HashMap<>();
         tableBuckets = new HashMap<>();

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DorisTableConfig.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DorisTableConfig.java
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.tools.cdc;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.apache.commons.collections.MapUtils;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class DorisTableConfig implements Serializable {
+    private static final String LIGHT_SCHEMA_CHANGE = "light_schema_change";
+    // PROPERTIES parameter in doris table creation statement. such as: replication_num=1.
+    private final Map<String, String> tableProperties;
+    // The specific parameters extracted from --table-conf need to be parsed and integrated into the
+    // doris table creation statement. such as: table-buckets="tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50".
+    private Map<String, Integer> tableBuckets;
+
+    public DorisTableConfig(Map<String, String> tableConfig) {
+        if (MapUtils.isNotEmpty(tableConfig)) {
+            // default enable light schema change
+            if (!tableConfig.containsKey(LIGHT_SCHEMA_CHANGE)) {
+                tableConfig.put(LIGHT_SCHEMA_CHANGE, Boolean.toString(true));
+            }
+            if (tableConfig.containsKey(DatabaseSyncConfig.TABLE_BUCKETS)) {
+                this.tableBuckets =
+                        buildTableBucketMap(tableConfig.get(DatabaseSyncConfig.TABLE_BUCKETS));
+                tableConfig.remove(DatabaseSyncConfig.TABLE_BUCKETS);
+            }
+        }
+        tableProperties = tableConfig;
+    }
+
+    public Map<String, Integer> getTableBuckets() {
+        return tableBuckets;
+    }
+
+    public Map<String, String> getTableProperties() {
+        return tableProperties;
+    }
+
+    /**
+     * Build table bucket Map.
+     *
+     * @param tableBuckets the string of tableBuckets, eg:student:10,student_info:20,student.*:30
+     * @return The table name and buckets map. The key is table name, the value is buckets.
+     */
+    @VisibleForTesting
+    public Map<String, Integer> buildTableBucketMap(String tableBuckets) {
+        Map<String, Integer> tableBucketsMap = new LinkedHashMap<>();
+        String[] tableBucketsArray = tableBuckets.split(",");
+        for (String tableBucket : tableBucketsArray) {
+            String[] tableBucketArray = tableBucket.split(":");
+            tableBucketsMap.put(
+                    tableBucketArray[0].trim(), Integer.parseInt(tableBucketArray[1].trim()));
+        }
+        return tableBucketsMap;
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSync.java
@@ -208,7 +208,7 @@ public class MongoDBDatabaseSync extends DatabaseSync {
                 .setDorisOptions(dorisBuilder.build())
                 .setExecutionOptions(executionOptions)
                 .setTableMapping(tableMapping)
-                .setTableProperties(tableConfig)
+                .setTableConf(dorisTableConfig)
                 .setTargetDatabase(database)
                 .build();
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoDBJsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoDBJsonDebeziumSchemaSerializer.java
@@ -28,6 +28,7 @@ import org.apache.doris.flink.sink.writer.serializer.DorisRecordSerializer;
 import org.apache.doris.flink.sink.writer.serializer.jsondebezium.CdcDataChange;
 import org.apache.doris.flink.sink.writer.serializer.jsondebezium.CdcSchemaChange;
 import org.apache.doris.flink.sink.writer.serializer.jsondebezium.JsonDebeziumChangeContext;
+import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
     // <cdc db.schema.table, doris db.table>
     private Map<String, String> tableMapping;
     // create table properties
-    private Map<String, String> tableProperties;
+    private DorisTableConfig dorisTableConfig;
     private String targetDatabase;
 
     private CdcDataChange dataChange;
@@ -67,7 +68,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
             String sourceTableName,
             DorisExecutionOptions executionOptions,
             Map<String, String> tableMapping,
-            Map<String, String> tableProperties,
+            DorisTableConfig dorisTableConfig,
             String targetDatabase,
             String targetTablePrefix,
             String targetTableSuffix) {
@@ -79,7 +80,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
         JsonNodeFactory jsonNodeFactory = JsonNodeFactory.withExactBigDecimals(true);
         this.objectMapper.setNodeFactory(jsonNodeFactory);
         this.tableMapping = tableMapping;
-        this.tableProperties = tableProperties;
+        this.dorisTableConfig = dorisTableConfig;
         this.targetDatabase = targetDatabase;
         this.targetTablePrefix = targetTablePrefix;
         this.targetTableSuffix = targetTableSuffix;
@@ -100,7 +101,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
                         tableMapping,
                         sourceTableName,
                         targetDatabase,
-                        tableProperties,
+                        dorisTableConfig,
                         objectMapper,
                         pattern,
                         lineDelimiter,
@@ -138,7 +139,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
         private String sourceTableName;
         private DorisExecutionOptions executionOptions;
         private Map<String, String> tableMapping;
-        private Map<String, String> tableProperties;
+        private DorisTableConfig dorisTableConfig;
         private String targetDatabase;
         private String targetTablePrefix = "";
         private String targetTableSuffix = "";
@@ -172,9 +173,16 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
             return this;
         }
 
+        @Deprecated
         public MongoDBJsonDebeziumSchemaSerializer.Builder setTableProperties(
                 Map<String, String> tableProperties) {
-            this.tableProperties = tableProperties;
+            this.dorisTableConfig = new DorisTableConfig(tableProperties);
+            return this;
+        }
+
+        public MongoDBJsonDebeziumSchemaSerializer.Builder setTableConf(
+                DorisTableConfig dorisTableConfig) {
+            this.dorisTableConfig = dorisTableConfig;
             return this;
         }
 
@@ -191,7 +199,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
                     sourceTableName,
                     executionOptions,
                     tableMapping,
-                    tableProperties,
+                    dorisTableConfig,
                     targetDatabase,
                     targetTablePrefix,
                     targetTableSuffix);

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/catalog/doris/DorisSchemaFactoryTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/catalog/doris/DorisSchemaFactoryTest.java
@@ -67,7 +67,7 @@ public class DorisSchemaFactoryTest {
                         new DorisTableConfig(tableProperties),
                         tableComment);
         Assert.assertEquals(
-                "TableSchema{database='doris', table='create_tab', tableComment='auto_tab_comment', fields={name=FieldSchema{name='name', typeString='VARVHAR(100)', defaultValue='null', comment='Name_test'}, id=FieldSchema{name='id', typeString='INT', defaultValue='100', comment='int_test'}, age=FieldSchema{name='age', typeString='INT', defaultValue='null', comment='null'}, email=FieldSchema{name='email', typeString='VARCHAR(100)', defaultValue='email@doris.com', comment='e'}}, keys=email, model=UNIQUE, distributeKeys=email, properties={}, tableBuckets=null}",
+                "TableSchema{database='doris', table='create_tab', tableComment='auto_tab_comment', fields={name=FieldSchema{name='name', typeString='VARVHAR(100)', defaultValue='null', comment='Name_test'}, id=FieldSchema{name='id', typeString='INT', defaultValue='100', comment='int_test'}, age=FieldSchema{name='age', typeString='INT', defaultValue='null', comment='null'}, email=FieldSchema{name='email', typeString='VARCHAR(100)', defaultValue='email@doris.com', comment='e'}}, keys=email, model=UNIQUE, distributeKeys=email, properties={light_schema_change=true}, tableBuckets=null}",
                 tableSchema.toString());
     }
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/catalog/doris/DorisSystemTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/catalog/doris/DorisSystemTest.java
@@ -80,11 +80,11 @@ public class DorisSystemTest {
         schema.setFields(map);
         schema.setTableBuckets(1);
         Map<String, String> properties = new HashMap<>();
-        properties.put("table-buckets", "1");
+        properties.put("replication_num", "3");
         schema.setProperties(properties);
         String createTableDDL = DorisSystem.buildCreateTableDDL(schema);
         String except =
-                "CREATE TABLE IF NOT EXISTS `db`.`table`(`name` VARCHAR(65533) DEFAULT 'zhangsan' COMMENT '' )  DISTRIBUTED BY HASH(`name`) BUCKETS 1";
+                "CREATE TABLE IF NOT EXISTS `db`.`table`(`name` VARCHAR(65533) DEFAULT 'zhangsan' COMMENT '' )  DISTRIBUTED BY HASH(`name`) BUCKETS 1 PROPERTIES ('replication_num'='3')";
         Assert.assertEquals(createTableDDL, except);
     }
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManagerTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManagerTest.java
@@ -340,9 +340,8 @@ public class SQLParserSchemaManagerTest {
                         ddl,
                         dorisTable,
                         new DorisTableConfig(new HashMap<>()));
-
         String expected =
-                "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={order_id=FieldSchema{name='order_id', typeString='BIGINT', defaultValue='null', comment='null'}, customer_id=FieldSchema{name='customer_id', typeString='BIGINT', defaultValue='null', comment='null'}, order_date=FieldSchema{name='order_date', typeString='DATETIMEV2', defaultValue='SYSDATE', comment='null'}, status=FieldSchema{name='status', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, total_amount=FieldSchema{name='total_amount', typeString='DECIMALV3(12,2)', defaultValue='null', comment='null'}, shipping_address=FieldSchema{name='shipping_address', typeString='VARCHAR(765)', defaultValue='null', comment='null'}, delivery_date=FieldSchema{name='delivery_date', typeString='DATETIMEV2', defaultValue='null', comment='null'}}, keys=order_id, model=DUPLICATE, distributeKeys=order_id, properties={}, tableBuckets=null}";
+                "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={order_id=FieldSchema{name='order_id', typeString='BIGINT', defaultValue='null', comment='null'}, customer_id=FieldSchema{name='customer_id', typeString='BIGINT', defaultValue='null', comment='null'}, order_date=FieldSchema{name='order_date', typeString='DATETIMEV2', defaultValue='SYSDATE', comment='null'}, status=FieldSchema{name='status', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, total_amount=FieldSchema{name='total_amount', typeString='DECIMALV3(12,2)', defaultValue='null', comment='null'}, shipping_address=FieldSchema{name='shipping_address', typeString='VARCHAR(765)', defaultValue='null', comment='null'}, delivery_date=FieldSchema{name='delivery_date', typeString='DATETIMEV2', defaultValue='null', comment='null'}}, keys=order_id, model=DUPLICATE, distributeKeys=order_id, properties={light_schema_change=true}, tableBuckets=null}";
         Assert.assertEquals(expected, tableSchema.toString());
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManagerTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManagerTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.flink.sink.schema;
 
 import org.apache.doris.flink.catalog.doris.TableSchema;
+import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 import org.apache.doris.flink.tools.cdc.SourceConnector;
 import org.junit.Assert;
 import org.junit.Before;
@@ -222,7 +223,7 @@ public class SQLParserSchemaManagerTest {
                         + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci";
         TableSchema tableSchema =
                 schemaManager.parseCreateTableStatement(
-                        SourceConnector.MYSQL, ddl, dorisTable, new HashMap<>());
+                        SourceConnector.MYSQL, ddl, dorisTable, null);
 
         String expected =
                 "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={`id`=FieldSchema{name='`id`', typeString='INT', defaultValue='10000', comment='id_test'}, `create_time`=FieldSchema{name='`create_time`', typeString='DATETIMEV2(3)', defaultValue='CURRENT_TIMESTAMP', comment='null'}, `c1`=FieldSchema{name='`c1`', typeString='INT', defaultValue='999', comment='null'}, `decimal_type`=FieldSchema{name='`decimal_type`', typeString='DECIMALV3(9,3)', defaultValue='1.000', comment='decimal_tes'}, `aaa`=FieldSchema{name='`aaa`', typeString='VARCHAR(300)', defaultValue='NULL', comment='null'}, `decimal_type3`=FieldSchema{name='`decimal_type3`', typeString='DECIMALV3(38,9)', defaultValue='1.123456789', comment='comment_test'}, `create_time3`=FieldSchema{name='`create_time3`', typeString='DATETIMEV2(3)', defaultValue='CURRENT_TIMESTAMP', comment='ttime_aaa'}}, keys=`id`, model=UNIQUE, distributeKeys=`id`, properties={}, tableBuckets=null}";
@@ -236,7 +237,7 @@ public class SQLParserSchemaManagerTest {
                 "CREATE TABLE test_sink_unique (     id INT NOT NULL,     name VARCHAR(100) NOT NULL,     age INT,     email VARCHAR(100),     UNIQUE (email) )";
         TableSchema tableSchema =
                 schemaManager.parseCreateTableStatement(
-                        SourceConnector.MYSQL, ddl, dorisTable, new HashMap<>());
+                        SourceConnector.MYSQL, ddl, dorisTable, null);
 
         String expected =
                 "TableSchema{database='doris', table='auto_uni_tab', tableComment='null', fields={id=FieldSchema{name='id', typeString='INT', defaultValue='null', comment='null'}, name=FieldSchema{name='name', typeString='VARCHAR(300)', defaultValue='null', comment='null'}, age=FieldSchema{name='age', typeString='INT', defaultValue='null', comment='null'}, email=FieldSchema{name='email', typeString='VARCHAR(300)', defaultValue='null', comment='null'}}, keys=email, model=UNIQUE, distributeKeys=email, properties={}, tableBuckets=null}";
@@ -255,7 +256,7 @@ public class SQLParserSchemaManagerTest {
                         + ")";
         TableSchema tableSchema =
                 schemaManager.parseCreateTableStatement(
-                        SourceConnector.MYSQL, ddl, dorisTable, new HashMap<>());
+                        SourceConnector.MYSQL, ddl, dorisTable, null);
 
         String expected =
                 "TableSchema{database='doris', table='auto_duptab', tableComment='null', fields={id=FieldSchema{name='id', typeString='INT', defaultValue='null', comment='null'}, name=FieldSchema{name='name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, age=FieldSchema{name='age', typeString='INT', defaultValue='null', comment='null'}, address=FieldSchema{name='address', typeString='VARCHAR(765)', defaultValue='null', comment='null'}}, keys=id, model=DUPLICATE, distributeKeys=id, properties={}, tableBuckets=null}";
@@ -284,7 +285,7 @@ public class SQLParserSchemaManagerTest {
                         + ");";
         TableSchema tableSchema =
                 schemaManager.parseCreateTableStatement(
-                        SourceConnector.ORACLE, ddl, dorisTable, new HashMap<>());
+                        SourceConnector.ORACLE, ddl, dorisTable, null);
 
         String expected =
                 "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={employee_id=FieldSchema{name='employee_id', typeString='BIGINT', defaultValue='null', comment='null'}, first_name=FieldSchema{name='first_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, last_name=FieldSchema{name='last_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, email=FieldSchema{name='email', typeString='VARCHAR(300)', defaultValue='null', comment='null'}, phone_number=FieldSchema{name='phone_number', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, hire_date=FieldSchema{name='hire_date', typeString='DATETIMEV2', defaultValue='SYSDATE', comment='null'}, job_id=FieldSchema{name='job_id', typeString='VARCHAR(30)', defaultValue='null', comment='null'}, salary=FieldSchema{name='salary', typeString='DECIMALV3(8,2)', defaultValue='null', comment='null'}, commission_pct=FieldSchema{name='commission_pct', typeString='DECIMALV3(2,2)', defaultValue='null', comment='null'}, manager_id=FieldSchema{name='manager_id', typeString='BIGINT', defaultValue='null', comment='null'}, department_id=FieldSchema{name='department_id', typeString='BIGINT', defaultValue='null', comment='null'}}, keys=employee_id, model=UNIQUE, distributeKeys=employee_id, properties={}, tableBuckets=null}";
@@ -310,7 +311,7 @@ public class SQLParserSchemaManagerTest {
                         + ");";
         TableSchema tableSchema =
                 schemaManager.parseCreateTableStatement(
-                        SourceConnector.ORACLE, ddl, dorisTable, new HashMap<>());
+                        SourceConnector.ORACLE, ddl, dorisTable, null);
 
         String expected =
                 "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={employee_id=FieldSchema{name='employee_id', typeString='BIGINT', defaultValue='null', comment='null'}, first_name=FieldSchema{name='first_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, last_name=FieldSchema{name='last_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, email=FieldSchema{name='email', typeString='VARCHAR(300)', defaultValue='null', comment='null'}, phone_number=FieldSchema{name='phone_number', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, hire_date=FieldSchema{name='hire_date', typeString='DATETIMEV2', defaultValue='SYSDATE', comment='null'}, job_id=FieldSchema{name='job_id', typeString='VARCHAR(30)', defaultValue='null', comment='null'}, salary=FieldSchema{name='salary', typeString='DECIMALV3(8,2)', defaultValue='null', comment='null'}, commission_pct=FieldSchema{name='commission_pct', typeString='DECIMALV3(2,2)', defaultValue='null', comment='null'}, manager_id=FieldSchema{name='manager_id', typeString='BIGINT', defaultValue='null', comment='null'}, department_id=FieldSchema{name='department_id', typeString='BIGINT', defaultValue='null', comment='null'}}, keys=employee_id, model=UNIQUE, distributeKeys=employee_id, properties={}, tableBuckets=null}";
@@ -335,7 +336,10 @@ public class SQLParserSchemaManagerTest {
                         + ");";
         TableSchema tableSchema =
                 schemaManager.parseCreateTableStatement(
-                        SourceConnector.ORACLE, ddl, dorisTable, new HashMap<>());
+                        SourceConnector.ORACLE,
+                        ddl,
+                        dorisTable,
+                        new DorisTableConfig(new HashMap<>()));
 
         String expected =
                 "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={order_id=FieldSchema{name='order_id', typeString='BIGINT', defaultValue='null', comment='null'}, customer_id=FieldSchema{name='customer_id', typeString='BIGINT', defaultValue='null', comment='null'}, order_date=FieldSchema{name='order_date', typeString='DATETIMEV2', defaultValue='SYSDATE', comment='null'}, status=FieldSchema{name='status', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, total_amount=FieldSchema{name='total_amount', typeString='DECIMALV3(12,2)', defaultValue='null', comment='null'}, shipping_address=FieldSchema{name='shipping_address', typeString='VARCHAR(765)', defaultValue='null', comment='null'}, delivery_date=FieldSchema{name='delivery_date', typeString='DATETIMEV2', defaultValue='null', comment='null'}}, keys=order_id, model=DUPLICATE, distributeKeys=order_id, properties={}, tableBuckets=null}";

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
@@ -26,6 +26,7 @@ import org.apache.doris.flink.catalog.doris.TableSchema;
 import org.apache.doris.flink.exception.DorisRuntimeException;
 import org.apache.doris.flink.rest.RestService;
 import org.apache.doris.flink.rest.models.Schema;
+import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 import org.apache.doris.flink.tools.cdc.SourceConnector;
 import org.junit.After;
 import org.junit.Assert;
@@ -76,7 +77,7 @@ public class TestJsonDebeziumSchemaChangeImplV2 extends TestJsonDebeziumChangeBa
                         tableMapping,
                         sourceTableName,
                         targetDatabase,
-                        tableProperties,
+                        new DorisTableConfig(tableProperties),
                         objectMapper,
                         null,
                         lineDelimiter,

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestSQLParserSchemaChange.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestSQLParserSchemaChange.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 
 public class TestSQLParserSchemaChange extends TestJsonDebeziumChangeBase {
@@ -41,7 +40,7 @@ public class TestSQLParserSchemaChange extends TestJsonDebeziumChangeBase {
                         tableMapping,
                         null,
                         null,
-                        new HashMap<>(),
+                        null,
                         objectMapper,
                         null,
                         lineDelimiter,

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/DorisTableConfigTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/DorisTableConfigTest.java
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.tools.cdc;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class DorisTableConfigTest {
+
+    private DorisTableConfig dorisTableConfig;
+
+    @Before
+    public void init() {
+        dorisTableConfig = new DorisTableConfig(new HashMap<>());
+    }
+
+    @Test
+    public void buildTableBucketMapTest() {
+        String tableBuckets = "tbl1:10,tbl2 : 20, a.* :30,b.*:40,.*:50";
+        Map<String, Integer> tableBucketsMap = dorisTableConfig.buildTableBucketMap(tableBuckets);
+        assertEquals(10, tableBucketsMap.get("tbl1").intValue());
+        assertEquals(20, tableBucketsMap.get("tbl2").intValue());
+        assertEquals(30, tableBucketsMap.get("a.*").intValue());
+        assertEquals(40, tableBucketsMap.get("b.*").intValue());
+        assertEquals(50, tableBucketsMap.get(".*").intValue());
+    }
+}

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/DorisTableConfigTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/DorisTableConfigTest.java
@@ -20,7 +20,6 @@ package org.apache.doris.flink.tools.cdc;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -31,7 +30,7 @@ public class DorisTableConfigTest {
 
     @Before
     public void init() {
-        dorisTableConfig = new DorisTableConfig(new HashMap<>());
+        dorisTableConfig = new DorisTableConfig();
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
The early table-conf passed a `Map<String, String>` as a parameter, and the parameters included not only the `PROPERTIES()` attributes that can be directly used to create doris tables, but also the data that needs to be parsed as a table creation statement. Such as `table-buckets`.
As a result, in our actual use process, these mixed parameters need to be parsed at various stages, and the logic is also very complicated, because we abstract the parameters of table-conf as a `DorisTableConfig` object

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
