### PR TITLE
[cdc] fix create doris table failed when load data from DB2

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/db2/Db2Schema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/db2/Db2Schema.java
@@ -21,7 +21,6 @@ import org.apache.doris.flink.catalog.doris.FieldSchema;
 import org.apache.doris.flink.tools.cdc.JdbcSourceSchema;
 
 import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
 
@@ -50,26 +49,6 @@ public class Db2Schema extends JdbcSourceSchema {
     public LinkedHashMap<String, FieldSchema> getColumnInfo(
             DatabaseMetaData metaData, String databaseName, String schemaName, String tableName)
             throws SQLException {
-        LinkedHashMap<String, FieldSchema> fields = new LinkedHashMap<>();
-        //
-        try (ResultSet rs = metaData.getColumns(null, schemaName, tableName, null)) {
-            while (rs.next()) {
-                String fieldName = rs.getString("COLUMN_NAME");
-                String comment = rs.getString("REMARKS");
-                String fieldType = rs.getString("TYPE_NAME");
-                Integer precision = rs.getInt("COLUMN_SIZE");
-
-                if (rs.wasNull()) {
-                    precision = null;
-                }
-                Integer scale = rs.getInt("DECIMAL_DIGITS");
-                if (rs.wasNull()) {
-                    scale = null;
-                }
-                String dorisTypeStr = convertToDorisType(fieldType, precision, scale);
-                fields.put(fieldName, new FieldSchema(fieldName, dorisTypeStr, comment));
-            }
-        }
-        return fields;
+        return super.getColumnInfo(metaData, null, schemaName, tableName);
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcDb2SyncDatabaseCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/CdcDb2SyncDatabaseCase.java
@@ -17,9 +17,12 @@
 
 package org.apache.doris.flink.tools.cdc;
 
+import org.apache.flink.cdc.connectors.base.options.JdbcSourceOptions;
+import org.apache.flink.cdc.connectors.base.options.SourceOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import org.apache.doris.flink.table.DorisConfigOptions;
 import org.apache.doris.flink.tools.cdc.db2.Db2DatabaseSync;
 
 import java.util.HashMap;
@@ -35,42 +38,31 @@ public class CdcDb2SyncDatabaseCase {
         env.disableOperatorChaining();
         env.enableCheckpointing(10000);
 
-        //  Map<String,String> flinkMap = new HashMap<>();
-        //  flinkMap.put("execution.checkpointing.interval","10s");
-        //  flinkMap.put("pipeline.operator-chaining","false");
-        //  flinkMap.put("parallelism.default","1");
-
-        //  Configuration configuration = Configuration.fromMap(flinkMap);
-        //  env.configure(configuration);
-
         String database = "db2_test";
         String tablePrefix = "";
         String tableSuffix = "";
         Map<String, String> sourceConfig = new HashMap<>();
-        sourceConfig.put("database-name", "testdb");
-        sourceConfig.put("schema-name", "DB2INST1");
-        sourceConfig.put("hostname", "127.0.0.1");
-        sourceConfig.put("port", "50000");
-        sourceConfig.put("username", "db2inst1");
-        sourceConfig.put("password", "=doris123456");
-        // sourceConfig.put("debezium.database.tablename.case.insensitive","false");
-        sourceConfig.put("scan.incremental.snapshot.enabled", "true");
-        // sourceConfig.put("debezium.include.schema.changes","false");
+        sourceConfig.put(JdbcSourceOptions.DATABASE_NAME.key(), "testdb");
+        sourceConfig.put(JdbcSourceOptions.SCHEMA_NAME.key(), "DB2INST1");
+        sourceConfig.put(JdbcSourceOptions.HOSTNAME.key(), "127.0.0.1");
+        sourceConfig.put(Db2DatabaseSync.PORT.key(), "50000");
+        sourceConfig.put(JdbcSourceOptions.USERNAME.key(), "db2inst1");
+        sourceConfig.put(JdbcSourceOptions.PASSWORD.key(), "=doris123456");
+        sourceConfig.put(SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED.key(), "true");
 
         Configuration config = Configuration.fromMap(sourceConfig);
 
         Map<String, String> sinkConfig = new HashMap<>();
-        sinkConfig.put("fenodes", "127.0.0.1:8030");
-        // sinkConfig.put("benodes","10.20.30.1:8040, 10.20.30.2:8040, 10.20.30.3:8040");
-        sinkConfig.put("username", "root");
-        sinkConfig.put("password", "123456");
-        sinkConfig.put("jdbc-url", "jdbc:mysql://127.0.0.1:9030");
-        sinkConfig.put("sink.label-prefix", UUID.randomUUID().toString());
+        sinkConfig.put(DorisConfigOptions.FENODES.key(), "127.0.0.1:8030");
+        sinkConfig.put(DorisConfigOptions.USERNAME.key(), "root");
+        sinkConfig.put(DorisConfigOptions.PASSWORD.key(), "123456");
+        sinkConfig.put(DorisConfigOptions.JDBC_URL.key(), "jdbc:mysql://127.0.0.1:9030");
+        sinkConfig.put(DorisConfigOptions.SINK_LABEL_PREFIX.key(), UUID.randomUUID().toString());
         Configuration sinkConf = Configuration.fromMap(sinkConfig);
 
         Map<String, String> tableConfig = new HashMap<>();
-        tableConfig.put("replication_num", "1");
-        //        tableConfig.put("table-buckets", "tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50");
+        tableConfig.put(DatabaseSyncConfig.REPLICATION_NUM, "1");
+        tableConfig.put(DatabaseSyncConfig.TABLE_BUCKETS, "tbl1:10,tbl2:20,a.*:30,b.*:40,.*:50");
         String includingTables = "FULL_TYPES";
         String excludingTables = null;
         String multiToOneOrigin = null;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx


## Problem Summary:
When synchronizing data from DB2 to Doris and disabling --single-sink, you may not be able to obtain the column schema via JDBC, which could lead to the failure of creating a table in Apache Doris.
Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
