### PR TITLE
[Improve](log) add print log for NoRouteToHostException

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -282,9 +282,10 @@ public class DorisStreamLoad implements Serializable {
         Preconditions.checkState(pendingLoadFuture != null);
         try {
             return handlePreCommitResponse(pendingLoadFuture.get());
-        } catch (NoRouteToHostException nex){
+        } catch (NoRouteToHostException nex) {
             LOG.error("Failed to connect, cause ", nex);
-            throw new DorisRuntimeException("No Route to Host to " + hostPort + ", exception: " + nex);
+            throw new DorisRuntimeException(
+                    "No Route to Host to " + hostPort + ", exception: " + nex);
         } catch (Exception e) {
             throw new DorisRuntimeException(e);
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.NoRouteToHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -281,6 +282,9 @@ public class DorisStreamLoad implements Serializable {
         Preconditions.checkState(pendingLoadFuture != null);
         try {
             return handlePreCommitResponse(pendingLoadFuture.get());
+        } catch (NoRouteToHostException nex){
+            LOG.error("Failed to connect, cause ", nex);
+            throw new DorisRuntimeException("No Route to Host to " + hostPort + ", exception: " + nex);
         } catch (Exception e) {
             throw new DorisRuntimeException(e);
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Currently, if there is a network problem, an error NoRouteToHost will be reported, but from the jobmanager log, you can't see which be it is connected to, so print it out here


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
