### PR TITLE
[cdc] fix enable-delete  option not work

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/JsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/JsonDebeziumSchemaSerializer.java
@@ -70,6 +70,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
     private final boolean newSchemaChange;
     private String lineDelimiter = LINE_DELIMITER_DEFAULT;
     private boolean ignoreUpdateBefore = true;
+    private boolean enableDelete = true;
     // <cdc db.schema.table, doris db.table>
     private Map<String, String> tableMapping;
     // create table properties
@@ -111,6 +112,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
                             .getStreamLoadProp()
                             .getProperty(LINE_DELIMITER_KEY, LINE_DELIMITER_DEFAULT);
             this.ignoreUpdateBefore = executionOptions.getIgnoreUpdateBefore();
+            this.enableDelete = executionOptions.getDeletable();
         }
     }
 
@@ -149,7 +151,8 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
                         lineDelimiter,
                         ignoreUpdateBefore,
                         targetTablePrefix,
-                        targetTableSuffix);
+                        targetTableSuffix,
+                        enableDelete);
         initSchemaChangeInstance(changeContext);
         this.dataChange = new JsonDebeziumDataChange(changeContext);
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
@@ -41,6 +41,7 @@ public class JsonDebeziumChangeContext implements Serializable {
     private final Pattern pattern;
     private final String lineDelimiter;
     private final boolean ignoreUpdateBefore;
+    private final boolean enableDelete;
     private final String targetTablePrefix;
     private final String targetTableSuffix;
 
@@ -55,7 +56,8 @@ public class JsonDebeziumChangeContext implements Serializable {
             String lineDelimiter,
             boolean ignoreUpdateBefore,
             String targetTablePrefix,
-            String targetTableSuffix) {
+            String targetTableSuffix,
+            boolean enableDelete) {
         this.dorisOptions = dorisOptions;
         this.tableMapping = tableMapping;
         this.sourceTableName = sourceTableName;
@@ -65,6 +67,7 @@ public class JsonDebeziumChangeContext implements Serializable {
         this.pattern = pattern;
         this.lineDelimiter = lineDelimiter;
         this.ignoreUpdateBefore = ignoreUpdateBefore;
+        this.enableDelete = enableDelete;
         this.targetTablePrefix = targetTablePrefix;
         this.targetTableSuffix = targetTableSuffix;
     }
@@ -114,6 +117,10 @@ public class JsonDebeziumChangeContext implements Serializable {
 
     public String getTargetTableSuffix() {
         return targetTableSuffix;
+    }
+
+    public boolean isEnableDelete() {
+        return enableDelete;
     }
 
     public DorisTableConfig getDorisTableConf() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
@@ -119,7 +119,7 @@ public class JsonDebeziumChangeContext implements Serializable {
         return targetTableSuffix;
     }
 
-    public boolean isEnableDelete() {
+    public boolean enableDelete() {
         return enableDelete;
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumDataChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumDataChange.java
@@ -60,7 +60,7 @@ public class JsonDebeziumDataChange extends CdcDataChange {
         this.objectMapper = changeContext.getObjectMapper();
         this.ignoreUpdateBefore = changeContext.isIgnoreUpdateBefore();
         this.lineDelimiter = changeContext.getLineDelimiter();
-        this.enableDelete = changeContext.isEnableDelete();
+        this.enableDelete = changeContext.enableDelete();
     }
 
     public DorisRecord serialize(String record, JsonNode recordRoot, String op) throws IOException {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumDataChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumDataChange.java
@@ -50,6 +50,7 @@ public class JsonDebeziumDataChange extends CdcDataChange {
     private final ObjectMapper objectMapper;
     private final DorisOptions dorisOptions;
     private final boolean ignoreUpdateBefore;
+    private final boolean enableDelete;
     private final String lineDelimiter;
     private final JsonDebeziumChangeContext changeContext;
 
@@ -59,6 +60,7 @@ public class JsonDebeziumDataChange extends CdcDataChange {
         this.objectMapper = changeContext.getObjectMapper();
         this.ignoreUpdateBefore = changeContext.isIgnoreUpdateBefore();
         this.lineDelimiter = changeContext.getLineDelimiter();
+        this.enableDelete = changeContext.isEnableDelete();
     }
 
     public DorisRecord serialize(String record, JsonNode recordRoot, String op) throws IOException {
@@ -87,7 +89,7 @@ public class JsonDebeziumDataChange extends CdcDataChange {
                 return DorisRecord.of(dorisTableIdentifier, extractUpdate(recordRoot));
             case OP_DELETE:
                 valueMap = extractBeforeRow(recordRoot);
-                addDeleteSign(valueMap, true);
+                addDeleteSign(valueMap, enableDelete);
                 break;
             default:
                 LOG.error("parse record fail, unknown op {} in {}", op, record);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoDBJsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoDBJsonDebeziumSchemaSerializer.java
@@ -50,6 +50,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
     private final String sourceTableName;
     private String lineDelimiter = LINE_DELIMITER_DEFAULT;
     private boolean ignoreUpdateBefore = true;
+    private boolean enableDelete = true;
     // <cdc db.schema.table, doris db.table>
     private Map<String, String> tableMapping;
     // create table properties
@@ -90,6 +91,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
                             .getStreamLoadProp()
                             .getProperty(LINE_DELIMITER_KEY, LINE_DELIMITER_DEFAULT);
             this.ignoreUpdateBefore = executionOptions.getIgnoreUpdateBefore();
+            this.enableDelete = executionOptions.getDeletable();
         }
         init();
     }
@@ -107,7 +109,8 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
                         lineDelimiter,
                         ignoreUpdateBefore,
                         targetTablePrefix,
-                        targetTableSuffix);
+                        targetTableSuffix,
+                        enableDelete);
         this.dataChange = new MongoJsonDebeziumDataChange(changeContext);
         this.schemaChange = new MongoJsonDebeziumSchemaChange(changeContext);
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoJsonDebeziumDataChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoJsonDebeziumDataChange.java
@@ -61,6 +61,7 @@ public class MongoJsonDebeziumDataChange extends CdcDataChange implements Change
     public JsonDebeziumChangeContext changeContext;
     public ObjectMapper objectMapper;
     public Map<String, String> tableMapping;
+    private final boolean enableDelete;
 
     public MongoJsonDebeziumDataChange(JsonDebeziumChangeContext changeContext) {
         this.changeContext = changeContext;
@@ -68,6 +69,7 @@ public class MongoJsonDebeziumDataChange extends CdcDataChange implements Change
         this.objectMapper = changeContext.getObjectMapper();
         this.lineDelimiter = changeContext.getLineDelimiter();
         this.tableMapping = changeContext.getTableMapping();
+        this.enableDelete = changeContext.isEnableDelete();
     }
 
     @Override
@@ -93,7 +95,7 @@ public class MongoJsonDebeziumDataChange extends CdcDataChange implements Change
                 break;
             case OP_DELETE:
                 valueMap = extractDeleteRow(recordRoot);
-                addDeleteSign(valueMap, true);
+                addDeleteSign(valueMap, enableDelete);
                 break;
             default:
                 LOG.error("parse record fail, unknown op {} in {}", op, record);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoJsonDebeziumDataChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoJsonDebeziumDataChange.java
@@ -69,7 +69,7 @@ public class MongoJsonDebeziumDataChange extends CdcDataChange implements Change
         this.objectMapper = changeContext.getObjectMapper();
         this.lineDelimiter = changeContext.getLineDelimiter();
         this.tableMapping = changeContext.getTableMapping();
-        this.enableDelete = changeContext.isEnableDelete();
+        this.enableDelete = changeContext.enableDelete();
     }
 
     @Override

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumDataChange.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumDataChange.java
@@ -50,7 +50,8 @@ public class TestJsonDebeziumDataChange extends TestJsonDebeziumChangeBase {
                         lineDelimiter,
                         ignoreUpdateBefore,
                         "",
-                        "");
+                        "",
+                        true);
         dataChange = new JsonDebeziumDataChange(changeContext);
     }
 
@@ -113,7 +114,8 @@ public class TestJsonDebeziumDataChange extends TestJsonDebeziumChangeBase {
                         lineDelimiter,
                         false,
                         "",
-                        "");
+                        "",
+                        true);
         dataChange = new JsonDebeziumDataChange(changeContext);
 
         // update t1 set name='doris-update' WHERE id =1;

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImpl.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImpl.java
@@ -63,7 +63,8 @@ public class TestJsonDebeziumSchemaChangeImpl extends TestJsonDebeziumChangeBase
                         lineDelimiter,
                         ignoreUpdateBefore,
                         "",
-                        "");
+                        "",
+                        true);
         schemaChange = new JsonDebeziumSchemaChangeImpl(changeContext);
     }
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
@@ -83,7 +83,8 @@ public class TestJsonDebeziumSchemaChangeImplV2 extends TestJsonDebeziumChangeBa
                         lineDelimiter,
                         ignoreUpdateBefore,
                         "",
-                        "");
+                        "",
+                        true);
         schemaChange = new JsonDebeziumSchemaChangeImplV2(changeContext);
     }
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestSQLParserSchemaChange.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestSQLParserSchemaChange.java
@@ -46,7 +46,8 @@ public class TestSQLParserSchemaChange extends TestJsonDebeziumChangeBase {
                         lineDelimiter,
                         ignoreUpdateBefore,
                         "",
-                        "");
+                        "",
+                        true);
         schemaChange = new SQLParserSchemaChange(changeContext);
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
In the previous version, when we set `sink.enable-delete=false`, the flink-connector-doris would also synchronize this deleted data to Doris. 

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
