### PR TITLE
[fix]fix the problem of inconsistent data when enable-delete is set to false

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumDataChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumDataChange.java
@@ -86,6 +86,9 @@ public class JsonDebeziumDataChange extends CdcDataChange {
             case OP_UPDATE:
                 return DorisRecord.of(dorisTableIdentifier, extractUpdate(recordRoot));
             case OP_DELETE:
+                if (!enableDelete) {
+                    return DorisRecord.of(dorisTableIdentifier, null);
+                }
                 valueMap = extractBeforeRow(recordRoot);
                 addDeleteSign(valueMap, true);
                 break;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoJsonDebeziumDataChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoJsonDebeziumDataChange.java
@@ -92,6 +92,9 @@ public class MongoJsonDebeziumDataChange extends CdcDataChange implements Change
                 addDeleteSign(valueMap, false);
                 break;
             case OP_DELETE:
+                if (!enableDelete) {
+                    return DorisRecord.of(dorisTableIdentifier, null);
+                }
                 valueMap = extractDeleteRow(recordRoot);
                 addDeleteSign(valueMap, true);
                 break;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
  For example, when `sink.enable-delete = false` is configured, we only synchronize the incremental data of MySQL to Doris. If a deletion event is inserted into Doris at this time, it will cause data inconsistency. Therefore, this deletion data should be ignored. 


Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
