### PR TITLE
[fix]Fix doris backend connection via http does not take effect

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
@@ -56,6 +56,7 @@ public class BackendUtil {
         nodes.forEach(
                 node -> {
                     if (tryHttpConnection(node)) {
+                        LOG.info("{} backend http connection success.", node);
                         node = node.trim();
                         String[] ipAndPort = node.split(":");
                         BackendRowV2 backendRowV2 = new BackendRowV2();
@@ -100,11 +101,20 @@ public class BackendUtil {
             LOG.debug("try to connect host {}", host);
             host = "http://" + host;
             URL url = new URL(host);
-            HttpURLConnection co = (HttpURLConnection) url.openConnection();
-            co.setConnectTimeout(60000);
-            co.connect();
-            co.disconnect();
-            return true;
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(2000);
+            connection.setReadTimeout(2000);
+            int responseCode = connection.getResponseCode();
+            if (200 == responseCode) {
+                return true;
+            }
+            LOG.warn(
+                    "Failed to connect host {}, responseCode={}, msg={}",
+                    host,
+                    responseCode,
+                    connection.getResponseMessage());
+            return false;
         } catch (Exception ex) {
             LOG.warn("Failed to connect to host:{}", host, ex);
             return false;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
@@ -103,8 +103,8 @@ public class BackendUtil {
             URL url = new URL(host);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
-            connection.setConnectTimeout(2000);
-            connection.setReadTimeout(2000);
+            connection.setConnectTimeout(30000);
+            connection.setReadTimeout(30000);
             int responseCode = connection.getResponseCode();
             String responseMessage = connection.getResponseMessage();
             connection.disconnect();

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
@@ -103,8 +103,8 @@ public class BackendUtil {
             URL url = new URL(host);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
-            connection.setConnectTimeout(30000);
-            connection.setReadTimeout(30000);
+            connection.setConnectTimeout(60000);
+            connection.setReadTimeout(60000);
             int responseCode = connection.getResponseCode();
             String responseMessage = connection.getResponseMessage();
             connection.disconnect();

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
@@ -106,6 +106,8 @@ public class BackendUtil {
             connection.setConnectTimeout(2000);
             connection.setReadTimeout(2000);
             int responseCode = connection.getResponseCode();
+            String responseMessage = connection.getResponseMessage();
+            connection.disconnect();
             if (200 == responseCode) {
                 return true;
             }
@@ -113,7 +115,7 @@ public class BackendUtil {
                     "Failed to connect host {}, responseCode={}, msg={}",
                     host,
                     responseCode,
-                    connection.getResponseMessage());
+                    responseMessage);
             return false;
         } catch (Exception ex) {
             LOG.warn("Failed to connect to host:{}", host, ex);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
The current method of connect doris backend cannot accurately determine whether the port is open. Now, through the GET  method of http, it is more ready to determine whether the `200` response is successful.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
