### PR TITLE
[Improve] Fix the problem caused by very small interval in batch mode

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -40,8 +40,8 @@ public class DorisExecutionOptions implements Serializable {
     private static final int DEFAULT_BUFFER_COUNT = 3;
     // batch flush
     private static final int DEFAULT_FLUSH_QUEUE_SIZE = 2;
-    private static final int DEFAULT_BUFFER_FLUSH_MAX_ROWS = 50000;
-    private static final int DEFAULT_BUFFER_FLUSH_MAX_BYTES = 10 * 1024 * 1024;
+    private static final int DEFAULT_BUFFER_FLUSH_MAX_ROWS = 500000;
+    private static final int DEFAULT_BUFFER_FLUSH_MAX_BYTES = 100 * 1024 * 1024;
     private static final long DEFAULT_BUFFER_FLUSH_INTERVAL_MS = 10 * 1000;
     private final int checkInterval;
     private final int maxRetries;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -358,9 +358,6 @@ public class DorisExecutionOptions implements Serializable {
         }
 
         public Builder setBufferFlushIntervalMs(long bufferFlushIntervalMs) {
-            Preconditions.checkState(
-                    bufferFlushIntervalMs >= 1000,
-                    "bufferFlushIntervalMs must be greater than or equal to 1 second");
             this.bufferFlushIntervalMs = bufferFlushIntervalMs;
             return this;
         }
@@ -397,6 +394,8 @@ public class DorisExecutionOptions implements Serializable {
                     && JSON.equals(streamLoadProp.getProperty(FORMAT_KEY))) {
                 streamLoadProp.put(READ_JSON_BY_LINE, true);
             }
+            checkParams();
+
             return new DorisExecutionOptions(
                     checkInterval,
                     maxRetries,
@@ -416,6 +415,18 @@ public class DorisExecutionOptions implements Serializable {
                     force2PC,
                     writeMode,
                     ignoreCommitError);
+        }
+
+        private void checkParams() {
+            Preconditions.checkState(
+                    bufferFlushIntervalMs >= 1000,
+                    "bufferFlushIntervalMs must be greater than or equal to 1 second");
+            Preconditions.checkState(
+                    bufferFlushMaxBytes >= 52428800,
+                    "bufferFlushMaxBytes must be greater than or equal to 52428800(50mb)");
+            Preconditions.checkState(
+                    bufferFlushMaxRows >= 50000,
+                    "bufferFlushMaxRows must be greater than or equal to 50000");
         }
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -358,9 +358,6 @@ public class DorisExecutionOptions implements Serializable {
         }
 
         public Builder setBufferFlushIntervalMs(long bufferFlushIntervalMs) {
-            Preconditions.checkState(
-                    bufferFlushIntervalMs >= 1000,
-                    "bufferFlushIntervalMs must be greater than or equal to 1 second");
             this.bufferFlushIntervalMs = bufferFlushIntervalMs;
             return this;
         }
@@ -397,6 +394,18 @@ public class DorisExecutionOptions implements Serializable {
                     && JSON.equals(streamLoadProp.getProperty(FORMAT_KEY))) {
                 streamLoadProp.put(READ_JSON_BY_LINE, true);
             }
+
+            Preconditions.checkArgument(
+                    bufferFlushIntervalMs >= 1000,
+                    "bufferFlushIntervalMs must be greater than or equal to 1 second");
+
+            Preconditions.checkArgument(
+                    bufferFlushMaxRows >= 10000,
+                    "bufferFlushMaxRows must be greater than or equal to 10000");
+
+            Preconditions.checkArgument(
+                    bufferFlushMaxBytes >= 10485760,
+                    "bufferFlushMaxBytes must be greater than or equal to 10485760(10MB)");
 
             return new DorisExecutionOptions(
                     checkInterval,

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -358,6 +358,9 @@ public class DorisExecutionOptions implements Serializable {
         }
 
         public Builder setBufferFlushIntervalMs(long bufferFlushIntervalMs) {
+            Preconditions.checkState(
+                    bufferFlushIntervalMs >= 1000,
+                    "bufferFlushIntervalMs must be greater than or equal to 1 second");
             this.bufferFlushIntervalMs = bufferFlushIntervalMs;
             return this;
         }
@@ -394,7 +397,6 @@ public class DorisExecutionOptions implements Serializable {
                     && JSON.equals(streamLoadProp.getProperty(FORMAT_KEY))) {
                 streamLoadProp.put(READ_JSON_BY_LINE, true);
             }
-            checkParams();
 
             return new DorisExecutionOptions(
                     checkInterval,
@@ -415,18 +417,6 @@ public class DorisExecutionOptions implements Serializable {
                     force2PC,
                     writeMode,
                     ignoreCommitError);
-        }
-
-        private void checkParams() {
-            Preconditions.checkState(
-                    bufferFlushIntervalMs >= 1000,
-                    "bufferFlushIntervalMs must be greater than or equal to 1 second");
-            Preconditions.checkState(
-                    bufferFlushMaxBytes >= 52428800,
-                    "bufferFlushMaxBytes must be greater than or equal to 52428800(50mb)");
-            Preconditions.checkState(
-                    bufferFlushMaxRows >= 50000,
-                    "bufferFlushMaxRows must be greater than or equal to 50000");
         }
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchBufferHttpEntity.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchBufferHttpEntity.java
@@ -29,7 +29,6 @@ import java.util.List;
 public class BatchBufferHttpEntity extends AbstractHttpEntity {
 
     private static final Logger LOG = LoggerFactory.getLogger(BatchBufferHttpEntity.class);
-
     protected static final int OUTPUT_BUFFER_SIZE = 4096;
     private final List<byte[]> buffer;
     private final long contentLength;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchBufferHttpEntity.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchBufferHttpEntity.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.batch;
+
+import org.apache.http.entity.AbstractHttpEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+public class BatchBufferHttpEntity extends AbstractHttpEntity {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BatchBufferHttpEntity.class);
+
+    protected static final int OUTPUT_BUFFER_SIZE = 4096;
+    private final List<byte[]> buffer;
+    private final long contentLength;
+
+    public BatchBufferHttpEntity(BatchRecordBuffer recordBuffer) {
+        this.buffer = recordBuffer.getBuffer();
+        this.contentLength = recordBuffer.getBufferSizeBytes();
+    }
+
+    @Override
+    public boolean isRepeatable() {
+        return true;
+    }
+
+    @Override
+    public boolean isChunked() {
+        return false;
+    }
+
+    @Override
+    public long getContentLength() {
+        return contentLength;
+    }
+
+    @Override
+    public InputStream getContent() {
+        return new BatchBufferStream(buffer);
+    }
+
+    @Override
+    public void writeTo(OutputStream outStream) throws IOException {
+        try (InputStream inStream = new BatchBufferStream(buffer)) {
+            final byte[] buffer = new byte[OUTPUT_BUFFER_SIZE];
+            int readLen;
+            while ((readLen = inStream.read(buffer)) != -1) {
+                outStream.write(buffer, 0, readLen);
+            }
+        }
+    }
+
+    @Override
+    public boolean isStreaming() {
+        return false;
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchBufferStream.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchBufferStream.java
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.batch;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.List;
+
+public class BatchBufferStream extends InputStream {
+    private final Iterator<byte[]> iterator;
+    private byte[] currentItem;
+    private int currentPos;
+
+    public BatchBufferStream(List<byte[]> buffer) {
+        this.iterator = buffer.iterator();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return 0;
+    }
+
+    @Override
+    public int read(byte[] buf) throws IOException {
+        return read(buf, 0, buf.length);
+    }
+
+    @Override
+    public int read(byte[] buf, int off, int len) throws IOException {
+        if (!iterator.hasNext() && currentItem == null) {
+            return -1;
+        }
+
+        byte[] item = currentItem;
+        int pos = currentPos;
+        int readBytes = 0;
+        while (readBytes < len && (item != null || iterator.hasNext())) {
+            if (item == null) {
+                item = iterator.next();
+                pos = 0;
+            }
+
+            int size = Math.min(len - readBytes, item.length - pos);
+            System.arraycopy(item, pos, buf, off + readBytes, size);
+            readBytes += size;
+            pos += size;
+
+            if (pos == item.length) {
+                item = null;
+                pos = 0;
+            }
+        }
+
+        currentItem = item;
+        currentPos = pos;
+        return readBytes;
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchBufferStream.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchBufferStream.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 public class BatchBufferStream extends InputStream {
     private final Iterator<byte[]> iterator;
-    private byte[] currentItem;
+    private byte[] currentRow;
     private int currentPos;
 
     public BatchBufferStream(List<byte[]> buffer) {
@@ -43,11 +43,11 @@ public class BatchBufferStream extends InputStream {
 
     @Override
     public int read(byte[] buf, int off, int len) throws IOException {
-        if (!iterator.hasNext() && currentItem == null) {
+        if (!iterator.hasNext() && currentRow == null) {
             return -1;
         }
 
-        byte[] item = currentItem;
+        byte[] item = currentRow;
         int pos = currentPos;
         int readBytes = 0;
         while (readBytes < len && (item != null || iterator.hasNext())) {
@@ -66,8 +66,7 @@ public class BatchBufferStream extends InputStream {
                 pos = 0;
             }
         }
-
-        currentItem = item;
+        currentRow = item;
         currentPos = pos;
         return readBytes;
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchRecordBuffer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchRecordBuffer.java
@@ -55,10 +55,11 @@ public class BatchRecordBuffer {
             loadBatchFirstRecord = false;
         } else if (lineDelimiter != null) {
             this.buffer.add(this.lineDelimiter);
+            setBufferSizeBytes(this.bufferSizeBytes + this.lineDelimiter.length);
         }
         this.buffer.add(record);
-        setNumOfRecords(getNumOfRecords() + 1);
-        setBufferSizeBytes(getBufferSizeBytes() + record.length);
+        setNumOfRecords(this.numOfRecords + 1);
+        setBufferSizeBytes(this.bufferSizeBytes + record.length);
     }
 
     public String getLabelName() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchRecordBuffer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchRecordBuffer.java
@@ -138,6 +138,9 @@ public class BatchRecordBuffer {
     }
 
     public boolean shouldFlush() {
-        return System.currentTimeMillis() - createTime > retainTime;
+        // When the buffer create time is later than the first interval trigger,
+        // the write will not be triggered in the next interval,
+        // so multiply it by 1.5 to trigger it as early as possible.
+        return (System.currentTimeMillis() - createTime) * 1.5 > retainTime;
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchRecordBuffer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchRecordBuffer.java
@@ -50,16 +50,19 @@ public class BatchRecordBuffer {
         this.retainTime = retainTime;
     }
 
-    public void insert(byte[] record) {
+    public int insert(byte[] record) {
+        int recordSize = record.length;
         if (loadBatchFirstRecord) {
             loadBatchFirstRecord = false;
         } else if (lineDelimiter != null) {
             this.buffer.add(this.lineDelimiter);
             setBufferSizeBytes(this.bufferSizeBytes + this.lineDelimiter.length);
+            recordSize += this.lineDelimiter.length;
         }
         this.buffer.add(record);
         setNumOfRecords(this.numOfRecords + 1);
         setBufferSizeBytes(this.bufferSizeBytes + record.length);
+        return recordSize;
     }
 
     public String getLabelName() {
@@ -128,6 +131,10 @@ public class BatchRecordBuffer {
             return database + "." + table;
         }
         return null;
+    }
+
+    public byte[] getLineDelimiter() {
+        return lineDelimiter;
     }
 
     public boolean shouldFlush() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchRecordBuffer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchRecordBuffer.java
@@ -36,6 +36,8 @@ public class BatchRecordBuffer {
     private boolean loadBatchFirstRecord = true;
     private String database;
     private String table;
+    private final long createTime = System.currentTimeMillis();
+    private long retainTime = 0;
 
     public BatchRecordBuffer() {}
 
@@ -45,12 +47,14 @@ public class BatchRecordBuffer {
         this.buffer = ByteBuffer.allocate(bufferSize);
     }
 
-    public BatchRecordBuffer(String database, String table, byte[] lineDelimiter, int bufferSize) {
+    public BatchRecordBuffer(
+            String database, String table, byte[] lineDelimiter, int bufferSize, long retainTime) {
         super();
         this.database = database;
         this.table = table;
         this.lineDelimiter = lineDelimiter;
         this.buffer = ByteBuffer.allocate(bufferSize);
+        this.retainTime = retainTime;
     }
 
     public void insert(byte[] record) {
@@ -159,5 +163,9 @@ public class BatchRecordBuffer {
 
     public void setTable(String table) {
         this.table = table;
+    }
+
+    public boolean shouldFlush() {
+        return System.currentTimeMillis() - createTime > retainTime;
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchRecordBuffer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/BatchRecordBuffer.java
@@ -30,7 +30,7 @@ public class BatchRecordBuffer {
     private LinkedList<byte[]> buffer;
     private byte[] lineDelimiter;
     private int numOfRecords = 0;
-    private int bufferSizeBytes = 0;
+    private long bufferSizeBytes = 0;
     private boolean loadBatchFirstRecord = true;
     private String database;
     private String table;
@@ -96,7 +96,7 @@ public class BatchRecordBuffer {
     }
 
     /** @return Buffer size in bytes */
-    public int getBufferSizeBytes() {
+    public long getBufferSizeBytes() {
         return bufferSizeBytes;
     }
 
@@ -106,7 +106,7 @@ public class BatchRecordBuffer {
     }
 
     /** @param bufferSizeBytes Updates sum of size of records present in this buffer (Bytes) */
-    public void setBufferSizeBytes(int bufferSizeBytes) {
+    public void setBufferSizeBytes(long bufferSizeBytes) {
         this.bufferSizeBytes = bufferSizeBytes;
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -425,11 +425,6 @@ public class DorisBatchStreamLoad implements Serializable {
 
         /** execute stream load. */
         public void load(String label, BatchRecordBuffer buffer) throws IOException {
-            try {
-                Thread.sleep(10000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
             if (enableGroupCommit) {
                 label = null;
             }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -84,7 +84,8 @@ public class DorisBatchStreamLoad implements Serializable {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final List<String> DORIS_SUCCESS_STATUS =
             new ArrayList<>(Arrays.asList(SUCCESS, PUBLISH_TIMEOUT));
-    private static final long STREAM_LOAD_MAX_BYTES = 10 * 1024 * 1024 * 1024L; //10 GB
+    private static final long STREAM_LOAD_MAX_BYTES = 10 * 1024 * 1024 * 1024L; // 10 GB
+    private static final long STREAM_LOAD_MAX_ROWS = Integer.MAX_VALUE;
     private final LabelGenerator labelGenerator;
     private final byte[] lineDelimiter;
     private static final String LOAD_URL_PATTERN = "http://%s/api/%s/%s/_stream_load";
@@ -106,7 +107,6 @@ public class DorisBatchStreamLoad implements Serializable {
     private boolean enableGroupCommit;
     private boolean enableGzCompress;
     private int subTaskId;
-    private long streamLoadMaxRows = Integer.MAX_VALUE;
     private long maxBlockedBytes;
     private final AtomicLong currentCacheBytes = new AtomicLong(0L);
     private final Lock lock = new ReentrantLock();
@@ -146,7 +146,9 @@ public class DorisBatchStreamLoad implements Serializable {
         this.executionOptions = executionOptions;
         this.flushQueue = new LinkedBlockingDeque<>(executionOptions.getFlushQueueSize());
         // maxBlockedBytes ensures that a buffer can be written even if the queue is full
-        this.maxBlockedBytes = (long) executionOptions.getBufferFlushMaxBytes() * (executionOptions.getFlushQueueSize() + 1);
+        this.maxBlockedBytes =
+                (long) executionOptions.getBufferFlushMaxBytes()
+                        * (executionOptions.getFlushQueueSize() + 1);
         if (StringUtils.isNotBlank(dorisOptions.getTableIdentifier())) {
             String[] tableInfo = dorisOptions.getTableIdentifier().split("\\.");
             Preconditions.checkState(
@@ -216,8 +218,8 @@ public class DorisBatchStreamLoad implements Serializable {
             boolean flush = bufferFullFlush(bufferKey);
             LOG.info("trigger flush by buffer full, flush: {}", flush);
 
-        } else if (buffer.getBufferSizeBytes() >= streamLoadMaxRows
-                || buffer.getNumOfRecords() >= STREAM_LOAD_MAX_BYTES) {
+        } else if (buffer.getBufferSizeBytes() >= STREAM_LOAD_MAX_BYTES
+                || buffer.getNumOfRecords() >= STREAM_LOAD_MAX_ROWS) {
             // The buffer capacity exceeds the stream load limit, flush
             boolean flush = bufferFullFlush(bufferKey);
             LOG.info("trigger flush by buffer exceeding the limit, flush: {}", flush);

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -163,8 +163,7 @@ public class DorisBatchStreamLoad implements Serializable {
      * @param record
      * @throws IOException
      */
-    public synchronized void writeRecord(String database, String table, byte[] record)
-            throws InterruptedException {
+    public synchronized void writeRecord(String database, String table, byte[] record) {
         checkFlushException();
         String bufferKey = getTableIdentifier(database, table);
         BatchRecordBuffer buffer =
@@ -184,15 +183,15 @@ public class DorisBatchStreamLoad implements Serializable {
         }
     }
 
-    public synchronized boolean bufferFullFlush(String bufferKey) throws InterruptedException {
+    public synchronized boolean bufferFullFlush(String bufferKey) {
         return doFlush(bufferKey, false, true);
     }
 
-    public synchronized boolean intervalFlush() throws InterruptedException {
+    public synchronized boolean intervalFlush() {
         return doFlush(null, false, false);
     }
 
-    public synchronized boolean checkpointFlush() throws InterruptedException {
+    public synchronized boolean checkpointFlush() {
         return doFlush(null, true, false);
     }
 
@@ -336,6 +335,7 @@ public class DorisBatchStreamLoad implements Serializable {
                             buffer.getBuffer().addAll(recordBuffer.getBuffer());
                         }
                     }
+                    LOG.info("merge {} buffer to one stream load", recordList.size());
                 }
             }
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -312,11 +312,6 @@ public class DorisBatchStreamLoad implements Serializable {
 
         /** execute stream load. */
         public void load(String label, BatchRecordBuffer buffer) throws IOException {
-            try {
-                Thread.sleep(10000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
             if (enableGroupCommit) {
                 label = null;
             }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchWriter.java
@@ -108,8 +108,8 @@ public class DorisBatchWriter<IN>
     private void intervalFlush() {
         try {
             boolean flush = batchStreamLoad.doFlush(null, false, false);
-            LOG.debug("interval flush triggered, flush: {}", flush);
-        } catch (InterruptedException e) {
+            LOG.debug("interval flush trigger, flush: {}", flush);
+        } catch (Exception e) {
             flushException = e;
         }
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchWriter.java
@@ -107,7 +107,7 @@ public class DorisBatchWriter<IN>
 
     private void intervalFlush() {
         try {
-            boolean flush = batchStreamLoad.doFlush(null, false, false);
+            boolean flush = batchStreamLoad.intervalFlush();
             LOG.debug("interval flush trigger, flush: {}", flush);
         } catch (Exception e) {
             flushException = e;
@@ -125,7 +125,7 @@ public class DorisBatchWriter<IN>
         checkFlushException();
         writeOneDorisRecord(serializer.flush());
         LOG.info("checkpoint flush triggered.");
-        batchStreamLoad.doFlush(null, true, false);
+        batchStreamLoad.checkpointFlush();
     }
 
     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchWriter.java
@@ -107,8 +107,8 @@ public class DorisBatchWriter<IN>
 
     private void intervalFlush() {
         try {
-            LOG.info("interval flush triggered.");
-            batchStreamLoad.flush(null, false);
+            boolean flush = batchStreamLoad.doFlush(null, false, false);
+            LOG.debug("interval flush triggered, flush: {}", flush);
         } catch (InterruptedException e) {
             flushException = e;
         }
@@ -125,7 +125,7 @@ public class DorisBatchWriter<IN>
         checkFlushException();
         writeOneDorisRecord(serializer.flush());
         LOG.info("checkpoint flush triggered.");
-        batchStreamLoad.flush(null, true);
+        batchStreamLoad.doFlush(null, true, false);
     }
 
     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchRecordBuffer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchRecordBuffer.java
@@ -15,50 +15,82 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.flink.sink.batch;
+package org.apache.doris.flink.sink.copy;
+
+import org.apache.flink.annotation.VisibleForTesting;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.LinkedList;
+import java.nio.ByteBuffer;
 
 /** buffer to queue. */
 public class BatchRecordBuffer {
     private static final Logger LOG = LoggerFactory.getLogger(BatchRecordBuffer.class);
     public static final String LINE_SEPARATOR = "\n";
     private String labelName;
-    private LinkedList<byte[]> buffer;
+    private ByteBuffer buffer;
     private byte[] lineDelimiter;
     private int numOfRecords = 0;
     private int bufferSizeBytes = 0;
     private boolean loadBatchFirstRecord = true;
     private String database;
     private String table;
-    private final long createTime = System.currentTimeMillis();
-    private long retainTime = 0;
 
-    public BatchRecordBuffer() {
-        this.buffer = new LinkedList<>();
+    public BatchRecordBuffer() {}
+
+    public BatchRecordBuffer(byte[] lineDelimiter, int bufferSize) {
+        super();
+        this.lineDelimiter = lineDelimiter;
+        this.buffer = ByteBuffer.allocate(bufferSize);
     }
 
-    public BatchRecordBuffer(String database, String table, byte[] lineDelimiter, long retainTime) {
+    public BatchRecordBuffer(String database, String table, byte[] lineDelimiter, int bufferSize) {
         super();
         this.database = database;
         this.table = table;
         this.lineDelimiter = lineDelimiter;
-        this.buffer = new LinkedList<>();
-        this.retainTime = retainTime;
+        this.buffer = ByteBuffer.allocate(bufferSize);
     }
 
     public void insert(byte[] record) {
+        ensureCapacity(record.length);
         if (loadBatchFirstRecord) {
             loadBatchFirstRecord = false;
         } else if (lineDelimiter != null) {
-            this.buffer.add(this.lineDelimiter);
+            this.buffer.put(this.lineDelimiter);
         }
-        this.buffer.add(record);
+        this.buffer.put(record);
         setNumOfRecords(getNumOfRecords() + 1);
         setBufferSizeBytes(getBufferSizeBytes() + record.length);
+    }
+
+    @VisibleForTesting
+    public void ensureCapacity(int length) {
+        int lineDelimiterSize = this.lineDelimiter == null ? 0 : this.lineDelimiter.length;
+        if (buffer.remaining() - lineDelimiterSize >= length) {
+            return;
+        }
+        int currentRemain = buffer.remaining();
+        int currentCapacity = buffer.capacity();
+        // add lineDelimiter length
+        int needed = length - buffer.remaining() + lineDelimiterSize;
+        // grow at least 1MB
+        long grow = Math.max(needed, 1024 * 1024);
+        // grow at least 50% of the current size
+        grow = Math.max(buffer.capacity() / 2, grow);
+        int newCapacity = (int) Math.min(Integer.MAX_VALUE, buffer.capacity() + grow);
+        ByteBuffer tmp = ByteBuffer.allocate(newCapacity);
+        buffer.flip();
+        tmp.put(buffer);
+        buffer.clear();
+        buffer = tmp;
+        LOG.info(
+                "record length {},buffer remain {} ,grow capacity {} to {}",
+                length,
+                currentRemain,
+                currentCapacity,
+                newCapacity);
     }
 
     public String getLabelName() {
@@ -74,6 +106,13 @@ public class BatchRecordBuffer {
         return numOfRecords == 0;
     }
 
+    public ByteBuffer getData() {
+        // change mode
+        buffer.flip();
+        LOG.debug("flush buffer: {} records, {} bytes", getNumOfRecords(), getBufferSizeBytes());
+        return buffer;
+    }
+
     public void clear() {
         this.buffer.clear();
         this.numOfRecords = 0;
@@ -82,7 +121,7 @@ public class BatchRecordBuffer {
         this.loadBatchFirstRecord = true;
     }
 
-    public LinkedList<byte[]> getBuffer() {
+    public ByteBuffer getBuffer() {
         return buffer;
     }
 
@@ -120,16 +159,5 @@ public class BatchRecordBuffer {
 
     public void setTable(String table) {
         this.table = table;
-    }
-
-    public String getTableIdentifier() {
-        if (database != null && table != null) {
-            return database + "." + table;
-        }
-        return null;
-    }
-
-    public boolean shouldFlush() {
-        return System.currentTimeMillis() - createTime > retainTime;
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
@@ -28,7 +28,6 @@ import org.apache.doris.flink.exception.DorisBatchLoadException;
 import org.apache.doris.flink.sink.EscapeHandler;
 import org.apache.doris.flink.sink.HttpPutBuilder;
 import org.apache.doris.flink.sink.HttpUtil;
-import org.apache.doris.flink.sink.batch.BatchRecordBuffer;
 import org.apache.doris.flink.sink.writer.LabelGenerator;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -139,8 +138,7 @@ public class BatchStageLoad implements Serializable {
                                         database,
                                         table,
                                         this.lineDelimiter,
-                                        executionOptions.getBufferFlushMaxBytes(),
-                                        executionOptions.getBufferFlushIntervalMs()));
+                                        executionOptions.getBufferFlushMaxBytes()));
         buffer.insert(record);
         // When it exceeds 80% of the byteSize,to flush, to avoid triggering bytebuffer expansion
         if (buffer.getBufferSizeBytes() >= executionOptions.getBufferFlushMaxBytes() * 0.8

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
@@ -139,7 +139,8 @@ public class BatchStageLoad implements Serializable {
                                         database,
                                         table,
                                         this.lineDelimiter,
-                                        executionOptions.getBufferFlushMaxBytes()));
+                                        executionOptions.getBufferFlushMaxBytes(),
+                                        executionOptions.getBufferFlushIntervalMs()));
         buffer.insert(record);
         // When it exceeds 80% of the byteSize,to flush, to avoid triggering bytebuffer expansion
         if (buffer.getBufferSizeBytes() >= executionOptions.getBufferFlushMaxBytes() * 0.8

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -275,14 +275,14 @@ public class DorisConfigOptions {
     public static final ConfigOption<Integer> SINK_BUFFER_FLUSH_MAX_ROWS =
             ConfigOptions.key("sink.buffer-flush.max-rows")
                     .intType()
-                    .defaultValue(50000)
+                    .defaultValue(500000)
                     .withDescription(
                             "The maximum number of flush items in each batch, the default is 5w");
 
     public static final ConfigOption<MemorySize> SINK_BUFFER_FLUSH_MAX_BYTES =
             ConfigOptions.key("sink.buffer-flush.max-bytes")
                     .memoryType()
-                    .defaultValue(MemorySize.parse("10mb"))
+                    .defaultValue(MemorySize.parse("100mb"))
                     .withDescription(
                             "The maximum number of bytes flushed in each batch, the default is 10MB");
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/cfg/DorisExecutionOptionsTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/cfg/DorisExecutionOptionsTest.java
@@ -52,9 +52,9 @@ public class DorisExecutionOptionsTest {
                         .setWriteMode(WriteMode.STREAM_LOAD)
                         .setLabelPrefix("doris")
                         .enable2PC()
-                        .setBufferFlushMaxBytes(10)
+                        .setBufferFlushMaxBytes(10485760)
                         .setBufferFlushIntervalMs(10000)
-                        .setBufferFlushMaxRows(12)
+                        .setBufferFlushMaxRows(10000)
                         .setCheckInterval(10)
                         .setIgnoreCommitError(true)
                         .setDeletable(true)
@@ -72,9 +72,9 @@ public class DorisExecutionOptionsTest {
                         .setWriteMode(WriteMode.STREAM_LOAD)
                         .setLabelPrefix("doris")
                         .enable2PC()
-                        .setBufferFlushMaxBytes(10)
+                        .setBufferFlushMaxBytes(10485760)
                         .setBufferFlushIntervalMs(10000)
-                        .setBufferFlushMaxRows(12)
+                        .setBufferFlushMaxRows(10000)
                         .setCheckInterval(10)
                         .setIgnoreCommitError(true)
                         .setDeletable(true)
@@ -111,17 +111,17 @@ public class DorisExecutionOptionsTest {
         Assert.assertNotEquals(exceptOptions, builder.build());
         builder.enable2PC();
 
-        builder.setBufferFlushMaxBytes(11);
+        builder.setBufferFlushMaxBytes(104857601);
         Assert.assertNotEquals(exceptOptions, builder.build());
-        builder.setBufferFlushMaxBytes(10);
+        builder.setBufferFlushMaxBytes(10485760);
 
         builder.setBufferFlushIntervalMs(100001);
         Assert.assertNotEquals(exceptOptions, builder.build());
         builder.setBufferFlushIntervalMs(10000);
 
-        builder.setBufferFlushMaxRows(2);
+        builder.setBufferFlushMaxRows(10000);
         Assert.assertNotEquals(exceptOptions, builder.build());
-        builder.setBufferFlushMaxRows(12);
+        builder.setBufferFlushMaxRows(10000);
 
         builder.setCheckInterval(11);
         Assert.assertNotEquals(exceptOptions, builder.build());

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/cfg/DorisExecutionOptionsTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/cfg/DorisExecutionOptionsTest.java
@@ -52,9 +52,9 @@ public class DorisExecutionOptionsTest {
                         .setWriteMode(WriteMode.STREAM_LOAD)
                         .setLabelPrefix("doris")
                         .enable2PC()
-                        .setBufferFlushMaxBytes(524288001)
+                        .setBufferFlushMaxBytes(10)
                         .setBufferFlushIntervalMs(10000)
-                        .setBufferFlushMaxRows(500001)
+                        .setBufferFlushMaxRows(12)
                         .setCheckInterval(10)
                         .setIgnoreCommitError(true)
                         .setDeletable(true)
@@ -72,9 +72,9 @@ public class DorisExecutionOptionsTest {
                         .setWriteMode(WriteMode.STREAM_LOAD)
                         .setLabelPrefix("doris")
                         .enable2PC()
-                        .setBufferFlushMaxBytes(524288001)
+                        .setBufferFlushMaxBytes(10)
                         .setBufferFlushIntervalMs(10000)
-                        .setBufferFlushMaxRows(500001)
+                        .setBufferFlushMaxRows(12)
                         .setCheckInterval(10)
                         .setIgnoreCommitError(true)
                         .setDeletable(true)
@@ -111,17 +111,17 @@ public class DorisExecutionOptionsTest {
         Assert.assertNotEquals(exceptOptions, builder.build());
         builder.enable2PC();
 
-        builder.setBufferFlushMaxBytes(524288002);
+        builder.setBufferFlushMaxBytes(11);
         Assert.assertNotEquals(exceptOptions, builder.build());
-        builder.setBufferFlushMaxBytes(524288001);
+        builder.setBufferFlushMaxBytes(10);
 
         builder.setBufferFlushIntervalMs(100001);
         Assert.assertNotEquals(exceptOptions, builder.build());
         builder.setBufferFlushIntervalMs(10000);
 
-        builder.setBufferFlushMaxRows(500002);
+        builder.setBufferFlushMaxRows(2);
         Assert.assertNotEquals(exceptOptions, builder.build());
-        builder.setBufferFlushMaxRows(500001);
+        builder.setBufferFlushMaxRows(12);
 
         builder.setCheckInterval(11);
         Assert.assertNotEquals(exceptOptions, builder.build());

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/cfg/DorisExecutionOptionsTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/cfg/DorisExecutionOptionsTest.java
@@ -52,9 +52,9 @@ public class DorisExecutionOptionsTest {
                         .setWriteMode(WriteMode.STREAM_LOAD)
                         .setLabelPrefix("doris")
                         .enable2PC()
-                        .setBufferFlushMaxBytes(10)
+                        .setBufferFlushMaxBytes(524288001)
                         .setBufferFlushIntervalMs(10000)
-                        .setBufferFlushMaxRows(12)
+                        .setBufferFlushMaxRows(500001)
                         .setCheckInterval(10)
                         .setIgnoreCommitError(true)
                         .setDeletable(true)
@@ -72,9 +72,9 @@ public class DorisExecutionOptionsTest {
                         .setWriteMode(WriteMode.STREAM_LOAD)
                         .setLabelPrefix("doris")
                         .enable2PC()
-                        .setBufferFlushMaxBytes(10)
+                        .setBufferFlushMaxBytes(524288001)
                         .setBufferFlushIntervalMs(10000)
-                        .setBufferFlushMaxRows(12)
+                        .setBufferFlushMaxRows(500001)
                         .setCheckInterval(10)
                         .setIgnoreCommitError(true)
                         .setDeletable(true)
@@ -111,17 +111,17 @@ public class DorisExecutionOptionsTest {
         Assert.assertNotEquals(exceptOptions, builder.build());
         builder.enable2PC();
 
-        builder.setBufferFlushMaxBytes(11);
+        builder.setBufferFlushMaxBytes(524288002);
         Assert.assertNotEquals(exceptOptions, builder.build());
-        builder.setBufferFlushMaxBytes(10);
+        builder.setBufferFlushMaxBytes(524288001);
 
         builder.setBufferFlushIntervalMs(100001);
         Assert.assertNotEquals(exceptOptions, builder.build());
         builder.setBufferFlushIntervalMs(10000);
 
-        builder.setBufferFlushMaxRows(2);
+        builder.setBufferFlushMaxRows(500002);
         Assert.assertNotEquals(exceptOptions, builder.build());
-        builder.setBufferFlushMaxRows(12);
+        builder.setBufferFlushMaxRows(500001);
 
         builder.setCheckInterval(11);
         Assert.assertNotEquals(exceptOptions, builder.build());

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
@@ -208,8 +208,8 @@ public class DorisSinkITCase extends DorisTestBase {
                                 + " 'sink.enable.batch-mode' = 'true',"
                                 + " 'sink.enable-delete' = 'true',"
                                 + " 'sink.flush.queue-size' = '2',"
-                                + " 'sink.buffer-flush.max-rows' = '100000',"
-                                + " 'sink.buffer-flush.max-bytes' = '50MB',"
+                                + " 'sink.buffer-flush.max-rows' = '1',"
+                                + " 'sink.buffer-flush.max-bytes' = '5',"
                                 + " 'sink.buffer-flush.interval' = '10s'"
                                 + ")",
                         getFenodes(),
@@ -295,8 +295,8 @@ public class DorisSinkITCase extends DorisTestBase {
                                 + " 'sink.enable.batch-mode' = 'true',"
                                 + " 'sink.enable-delete' = 'true',"
                                 + " 'sink.flush.queue-size' = '2',"
-                                + " 'sink.buffer-flush.max-rows' = '300000',"
-                                + " 'sink.buffer-flush.max-bytes' = '50MB',"
+                                + " 'sink.buffer-flush.max-rows' = '3',"
+                                + " 'sink.buffer-flush.max-bytes' = '5000',"
                                 + " 'sink.buffer-flush.interval' = '10s'"
                                 + ")",
                         getFenodes(),

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
@@ -219,7 +219,7 @@ public class DorisSinkITCase extends DorisTestBase {
         tEnv.executeSql(sinkDDL);
         tEnv.executeSql("INSERT INTO doris_sink SELECT 'doris',1 union all SELECT 'flink',2");
 
-        Thread.sleep(10000);
+        Thread.sleep(20000);
         List<String> expected = Arrays.asList("doris,1", "flink,2");
         String query =
                 String.format(
@@ -248,8 +248,9 @@ public class DorisSinkITCase extends DorisTestBase {
         executionBuilder
                 .setLabelPrefix(UUID.randomUUID().toString())
                 .setStreamLoadProp(properties)
-                .setBufferFlushMaxBytes(1)
-                .setBufferFlushMaxRows(10);
+                .setBufferFlushMaxBytes(10485760)
+                .setBufferFlushMaxRows(10000)
+                .setBufferFlushIntervalMs(1000);
 
         builder.setDorisExecutionOptions(executionBuilder.build())
                 .setSerializer(new SimpleStringSerializer())
@@ -258,7 +259,7 @@ public class DorisSinkITCase extends DorisTestBase {
         env.fromElements("doris,1", "flink,2").sinkTo(builder.build());
         env.execute();
 
-        Thread.sleep(10000);
+        Thread.sleep(20000);
         List<String> expected = Arrays.asList("doris,1", "flink,2");
         String query =
                 String.format(

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
@@ -208,9 +208,9 @@ public class DorisSinkITCase extends DorisTestBase {
                                 + " 'sink.enable.batch-mode' = 'true',"
                                 + " 'sink.enable-delete' = 'true',"
                                 + " 'sink.flush.queue-size' = '2',"
-                                + " 'sink.buffer-flush.max-rows' = '1',"
-                                + " 'sink.buffer-flush.max-bytes' = '5',"
-                                + " 'sink.buffer-flush.interval' = '10s'"
+                                + " 'sink.buffer-flush.max-rows' = '10000',"
+                                + " 'sink.buffer-flush.max-bytes' = '10MB',"
+                                + " 'sink.buffer-flush.interval' = '1s'"
                                 + ")",
                         getFenodes(),
                         DATABASE + "." + TABLE_CSV_BATCH_TBL,
@@ -295,9 +295,9 @@ public class DorisSinkITCase extends DorisTestBase {
                                 + " 'sink.enable.batch-mode' = 'true',"
                                 + " 'sink.enable-delete' = 'true',"
                                 + " 'sink.flush.queue-size' = '2',"
-                                + " 'sink.buffer-flush.max-rows' = '3',"
-                                + " 'sink.buffer-flush.max-bytes' = '5000',"
-                                + " 'sink.buffer-flush.interval' = '10s'"
+                                + " 'sink.buffer-flush.max-rows' = '10000',"
+                                + " 'sink.buffer-flush.max-bytes' = '10MB',"
+                                + " 'sink.buffer-flush.interval' = '1s'"
                                 + ")",
                         getFenodes(),
                         DATABASE + "." + TABLE_GROUP_COMMIT,

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
@@ -208,8 +208,8 @@ public class DorisSinkITCase extends DorisTestBase {
                                 + " 'sink.enable.batch-mode' = 'true',"
                                 + " 'sink.enable-delete' = 'true',"
                                 + " 'sink.flush.queue-size' = '2',"
-                                + " 'sink.buffer-flush.max-rows' = '1',"
-                                + " 'sink.buffer-flush.max-bytes' = '5',"
+                                + " 'sink.buffer-flush.max-rows' = '100000',"
+                                + " 'sink.buffer-flush.max-bytes' = '5000000',"
                                 + " 'sink.buffer-flush.interval' = '10s'"
                                 + ")",
                         getFenodes(),
@@ -295,8 +295,8 @@ public class DorisSinkITCase extends DorisTestBase {
                                 + " 'sink.enable.batch-mode' = 'true',"
                                 + " 'sink.enable-delete' = 'true',"
                                 + " 'sink.flush.queue-size' = '2',"
-                                + " 'sink.buffer-flush.max-rows' = '3',"
-                                + " 'sink.buffer-flush.max-bytes' = '5000',"
+                                + " 'sink.buffer-flush.max-rows' = '300000',"
+                                + " 'sink.buffer-flush.max-bytes' = '5000000',"
                                 + " 'sink.buffer-flush.interval' = '10s'"
                                 + ")",
                         getFenodes(),

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkITCase.java
@@ -209,7 +209,7 @@ public class DorisSinkITCase extends DorisTestBase {
                                 + " 'sink.enable-delete' = 'true',"
                                 + " 'sink.flush.queue-size' = '2',"
                                 + " 'sink.buffer-flush.max-rows' = '100000',"
-                                + " 'sink.buffer-flush.max-bytes' = '5000000',"
+                                + " 'sink.buffer-flush.max-bytes' = '50MB',"
                                 + " 'sink.buffer-flush.interval' = '10s'"
                                 + ")",
                         getFenodes(),
@@ -296,7 +296,7 @@ public class DorisSinkITCase extends DorisTestBase {
                                 + " 'sink.enable-delete' = 'true',"
                                 + " 'sink.flush.queue-size' = '2',"
                                 + " 'sink.buffer-flush.max-rows' = '300000',"
-                                + " 'sink.buffer-flush.max-bytes' = '5000000',"
+                                + " 'sink.buffer-flush.max-bytes' = '50MB',"
                                 + " 'sink.buffer-flush.interval' = '10s'"
                                 + ")",
                         getFenodes(),

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestBatchBufferHttpEntity.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestBatchBufferHttpEntity.java
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.batch;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestBatchBufferHttpEntity {
+
+    @Test
+    public void testWrite() throws Exception {
+        BatchRecordBuffer recordBuffer = TestBatchBufferStream.mockBuffer();
+        byte[] expectedData = TestBatchBufferStream.mergeByteArrays(recordBuffer.getBuffer());
+        Assert.assertEquals(recordBuffer.getNumOfRecords(), 1000);
+
+        BatchBufferHttpEntity entity = new BatchBufferHttpEntity(recordBuffer);
+        assertTrue(entity.isRepeatable());
+        assertFalse(entity.isStreaming());
+        assertEquals(entity.getContentLength(), expectedData.length);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        entity.writeTo(outputStream);
+        assertArrayEquals(expectedData, outputStream.toByteArray());
+    }
+}

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestBatchBufferStream.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestBatchBufferStream.java
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.batch;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestBatchBufferStream {
+
+    @Test
+    public void testRead() throws Exception {
+        BatchRecordBuffer recordBuffer = mockBuffer();
+        byte[] expectedData = mergeByteArrays(recordBuffer.getBuffer());
+        Assert.assertEquals(recordBuffer.getNumOfRecords(), 1000);
+
+        byte[] actualData = new byte[(int) recordBuffer.getBufferSizeBytes()];
+        try (BatchBufferStream inputStream = new BatchBufferStream(recordBuffer.getBuffer())) {
+            int len = inputStream.read(actualData, 0, actualData.length);
+            assertEquals(actualData.length, len);
+            assertArrayEquals(expectedData, actualData);
+        }
+    }
+
+    @Test
+    public void testReadBufLen() throws Exception {
+        BatchRecordBuffer recordBuffer = mockBuffer();
+        byte[] expectedData = mergeByteArrays(recordBuffer.getBuffer());
+        Assert.assertEquals(recordBuffer.getNumOfRecords(), 1000);
+
+        byte[] actualData = new byte[(int) recordBuffer.getBufferSizeBytes()];
+        try (BatchBufferStream inputStream = new BatchBufferStream(recordBuffer.getBuffer())) {
+            int pos = 0;
+            while (pos < actualData.length) {
+                // mock random length
+                int maxLen = new Random().nextInt(actualData.length - pos) + 1;
+                int len = inputStream.read(actualData, pos, maxLen);
+                if (len == -1) {
+                    break;
+                }
+                assertTrue(len > 0 && len <= maxLen);
+                pos += len;
+            }
+            assertEquals(actualData.length, pos);
+            assertArrayEquals(expectedData, actualData);
+        }
+    }
+
+    public static BatchRecordBuffer mockBuffer() {
+        BatchRecordBuffer recordBuffer = new BatchRecordBuffer();
+        for (int i = 0; i < 1000; i++) {
+            recordBuffer.insert((UUID.randomUUID() + "," + i).getBytes());
+        }
+        return recordBuffer;
+    }
+
+    public static byte[] mergeByteArrays(List<byte[]> listOfByteArrays) {
+        int totalLength = 0;
+        for (byte[] byteArray : listOfByteArrays) {
+            totalLength += byteArray.length;
+        }
+
+        byte[] mergedArray = new byte[totalLength];
+
+        int currentPosition = 0;
+        for (byte[] byteArray : listOfByteArrays) {
+            System.arraycopy(byteArray, 0, mergedArray, currentPosition, byteArray.length);
+            currentPosition += byteArray.length;
+        }
+
+        return mergedArray;
+    }
+}

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
@@ -88,6 +88,7 @@ public class TestDorisBatchStreamLoad {
 
     @Test
     public void testLoadFail() throws Exception {
+        LOG.info("testLoadFail start");
         DorisReadOptions readOptions = DorisReadOptions.builder().build();
         DorisExecutionOptions executionOptions =
                 DorisExecutionOptions.builder().setBufferFlushMaxRows(1).build();
@@ -109,7 +110,7 @@ public class TestDorisBatchStreamLoad {
                 () -> loader.isLoadThreadAlive(),
                 Deadline.fromNow(Duration.ofSeconds(10)),
                 100L,
-                "Condition was not met in given timeout.");
+                "testLoadFail wait loader start failed.");
         Assert.assertTrue(loader.isLoadThreadAlive());
         BackendUtil backendUtil = mock(BackendUtil.class);
         HttpClientBuilder httpClientBuilder = mock(HttpClientBuilder.class);
@@ -127,16 +128,18 @@ public class TestDorisBatchStreamLoad {
 
         TestUtil.waitUntilCondition(
                 () -> !loader.isLoadThreadAlive(),
-                Deadline.fromNow(Duration.ofSeconds(10)),
+                Deadline.fromNow(Duration.ofSeconds(20)),
                 100L,
-                "Condition was not met in given timeout.");
+                "testLoadFail wait loader exit failed." + loader.isLoadThreadAlive());
         AtomicReference<Throwable> exception = loader.getException();
         Assert.assertTrue(exception.get() instanceof Exception);
         Assert.assertTrue(exception.get().getMessage().contains("stream load error"));
+        LOG.info("testLoadFail end");
     }
 
     @Test
     public void testLoadError() throws Exception {
+        LOG.info("testLoadError start");
         DorisReadOptions readOptions = DorisReadOptions.builder().build();
         DorisExecutionOptions executionOptions =
                 DorisExecutionOptions.builder().setBufferFlushMaxRows(1).build();
@@ -159,7 +162,7 @@ public class TestDorisBatchStreamLoad {
                 () -> loader.isLoadThreadAlive(),
                 Deadline.fromNow(Duration.ofSeconds(10)),
                 100L,
-                "Condition was not met in given timeout.");
+                "testLoadError wait loader start failed.");
         Assert.assertTrue(loader.isLoadThreadAlive());
         BackendUtil backendUtil = mock(BackendUtil.class);
         HttpClientBuilder httpClientBuilder = mock(HttpClientBuilder.class);
@@ -176,12 +179,13 @@ public class TestDorisBatchStreamLoad {
 
         TestUtil.waitUntilCondition(
                 () -> !loader.isLoadThreadAlive(),
-                Deadline.fromNow(Duration.ofSeconds(10)),
+                Deadline.fromNow(Duration.ofSeconds(20)),
                 100L,
-                "Condition was not met in given timeout.");
+                "testLoadError wait loader exit failed." + loader.isLoadThreadAlive());
         AtomicReference<Throwable> exception = loader.getException();
         Assert.assertTrue(exception.get() instanceof Exception);
         Assert.assertTrue(exception.get().getMessage().contains("stream load error"));
+        LOG.info("testLoadError end");
     }
 
     @After
@@ -192,7 +196,7 @@ public class TestDorisBatchStreamLoad {
     }
 
     @Test
-    public void mergeBufferTest() throws Exception {
+    public void mergeBufferTest() {
         DorisReadOptions readOptions = DorisReadOptions.builder().build();
         DorisExecutionOptions executionOptions = DorisExecutionOptions.builder().build();
         DorisOptions options =

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
@@ -118,8 +118,13 @@ public class TestDorisBatchStreamLoad {
         when(httpClientBuilder.build()).thenReturn(httpClient);
         when(httpClient.execute(any())).thenReturn(response);
         loader.writeRecord("db", "tbl", "1,data".getBytes());
-        loader.doFlush("db.tbl", true, false);
+        loader.checkpointFlush();
 
+        TestUtil.waitUntilCondition(
+                () -> !loader.isLoadThreadAlive(),
+                Deadline.fromNow(Duration.ofSeconds(10)),
+                100L,
+                "Condition was not met in given timeout.");
         AtomicReference<Throwable> exception = loader.getException();
         Assert.assertTrue(exception.get() instanceof Exception);
         Assert.assertTrue(exception.get().getMessage().contains("stream load error"));
@@ -161,10 +166,14 @@ public class TestDorisBatchStreamLoad {
         when(httpClientBuilder.build()).thenReturn(httpClient);
         when(httpClient.execute(any())).thenReturn(response);
         loader.writeRecord("db", "tbl", "1,data".getBytes());
-        loader.doFlush("db.tbl", true, false);
+        loader.checkpointFlush();
 
+        TestUtil.waitUntilCondition(
+                () -> !loader.isLoadThreadAlive(),
+                Deadline.fromNow(Duration.ofSeconds(10)),
+                100L,
+                "Condition was not met in given timeout.");
         AtomicReference<Throwable> exception = loader.getException();
-
         Assert.assertTrue(exception.get() instanceof Exception);
         Assert.assertTrue(exception.get().getMessage().contains("stream load error"));
     }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
@@ -91,7 +91,7 @@ public class TestDorisBatchStreamLoad {
         LOG.info("testLoadFail start");
         DorisReadOptions readOptions = DorisReadOptions.builder().build();
         DorisExecutionOptions executionOptions =
-                DorisExecutionOptions.builder().setBufferFlushMaxRows(1).build();
+                DorisExecutionOptions.builder().setBufferFlushIntervalMs(1000).build();
         DorisOptions options =
                 DorisOptions.builder()
                         .setFenodes("127.0.0.1:1")
@@ -142,7 +142,7 @@ public class TestDorisBatchStreamLoad {
         LOG.info("testLoadError start");
         DorisReadOptions readOptions = DorisReadOptions.builder().build();
         DorisExecutionOptions executionOptions =
-                DorisExecutionOptions.builder().setBufferFlushMaxRows(1).build();
+                DorisExecutionOptions.builder().setBufferFlushIntervalMs(1000).build();
         DorisOptions options =
                 DorisOptions.builder()
                         .setFenodes("127.0.0.1:1")

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
@@ -118,7 +118,7 @@ public class TestDorisBatchStreamLoad {
         when(httpClientBuilder.build()).thenReturn(httpClient);
         when(httpClient.execute(any())).thenReturn(response);
         loader.writeRecord("db", "tbl", "1,data".getBytes());
-        loader.flush("db.tbl", true);
+        loader.doFlush("db.tbl", true, false);
 
         AtomicReference<Throwable> exception = loader.getException();
         Assert.assertTrue(exception.get() instanceof Exception);
@@ -161,7 +161,7 @@ public class TestDorisBatchStreamLoad {
         when(httpClientBuilder.build()).thenReturn(httpClient);
         when(httpClient.execute(any())).thenReturn(response);
         loader.writeRecord("db", "tbl", "1,data".getBytes());
-        loader.flush("db.tbl", true);
+        loader.doFlush("db.tbl", true, false);
 
         AtomicReference<Throwable> exception = loader.getException();
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
@@ -85,7 +85,8 @@ public class TestDorisBatchStreamLoad {
     @Test
     public void testLoadFail() throws Exception {
         DorisReadOptions readOptions = DorisReadOptions.builder().build();
-        DorisExecutionOptions executionOptions = DorisExecutionOptions.builder().build();
+        DorisExecutionOptions executionOptions =
+                DorisExecutionOptions.builder().setBufferFlushMaxRows(1).build();
         DorisOptions options =
                 DorisOptions.builder()
                         .setFenodes("127.0.0.1:1")
@@ -133,7 +134,8 @@ public class TestDorisBatchStreamLoad {
     @Test
     public void testLoadError() throws Exception {
         DorisReadOptions readOptions = DorisReadOptions.builder().build();
-        DorisExecutionOptions executionOptions = DorisExecutionOptions.builder().build();
+        DorisExecutionOptions executionOptions =
+                DorisExecutionOptions.builder().setBufferFlushMaxRows(1).build();
         DorisOptions options =
                 DorisOptions.builder()
                         .setFenodes("127.0.0.1:1")

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/copy/TestBatchRecordBuffer.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/copy/TestBatchRecordBuffer.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.flink.sink.batch;
+package org.apache.doris.flink.sink.copy;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableFactoryTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableFactoryTest.java
@@ -132,7 +132,7 @@ public class DorisDynamicTableFactoryTest {
         properties.put("sink.use-cache", "true");
         properties.put("sink.enable.batch-mode", "true");
         properties.put("sink.flush.queue-size", "2");
-        properties.put("sink.buffer-flush.max-rows", "1000");
+        properties.put("sink.buffer-flush.max-rows", "10000");
         properties.put("sink.buffer-flush.max-bytes", "10MB");
         properties.put("sink.buffer-flush.interval", "10s");
         properties.put("sink.ignore.update-before", "true");
@@ -166,7 +166,7 @@ public class DorisDynamicTableFactoryTest {
                         .enable2PC()
                         .setBufferFlushIntervalMs(10000)
                         .setBufferFlushMaxBytes(10 * 1024 * 1024)
-                        .setBufferFlushMaxRows(1000)
+                        .setBufferFlushMaxRows(10000)
                         .setFlushQueueSize(2)
                         .setUseCache(true)
                         .setIgnoreCommitError(false)

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableFactoryTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableFactoryTest.java
@@ -132,8 +132,8 @@ public class DorisDynamicTableFactoryTest {
         properties.put("sink.use-cache", "true");
         properties.put("sink.enable.batch-mode", "true");
         properties.put("sink.flush.queue-size", "2");
-        properties.put("sink.buffer-flush.max-rows", "1000");
-        properties.put("sink.buffer-flush.max-bytes", "10MB");
+        properties.put("sink.buffer-flush.max-rows", "50000");
+        properties.put("sink.buffer-flush.max-bytes", "50MB");
         properties.put("sink.buffer-flush.interval", "10s");
         properties.put("sink.ignore.update-before", "true");
         properties.put("sink.ignore.commit-error", "false");
@@ -165,8 +165,8 @@ public class DorisDynamicTableFactoryTest {
                         .setBatchMode(true)
                         .enable2PC()
                         .setBufferFlushIntervalMs(10000)
-                        .setBufferFlushMaxBytes(10 * 1024 * 1024)
-                        .setBufferFlushMaxRows(1000)
+                        .setBufferFlushMaxBytes(50 * 1024 * 1024)
+                        .setBufferFlushMaxRows(50000)
                         .setFlushQueueSize(2)
                         .setUseCache(true)
                         .setIgnoreCommitError(false)

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableFactoryTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableFactoryTest.java
@@ -132,8 +132,8 @@ public class DorisDynamicTableFactoryTest {
         properties.put("sink.use-cache", "true");
         properties.put("sink.enable.batch-mode", "true");
         properties.put("sink.flush.queue-size", "2");
-        properties.put("sink.buffer-flush.max-rows", "50000");
-        properties.put("sink.buffer-flush.max-bytes", "50MB");
+        properties.put("sink.buffer-flush.max-rows", "1000");
+        properties.put("sink.buffer-flush.max-bytes", "10MB");
         properties.put("sink.buffer-flush.interval", "10s");
         properties.put("sink.ignore.update-before", "true");
         properties.put("sink.ignore.commit-error", "false");
@@ -165,8 +165,8 @@ public class DorisDynamicTableFactoryTest {
                         .setBatchMode(true)
                         .enable2PC()
                         .setBufferFlushIntervalMs(10000)
-                        .setBufferFlushMaxBytes(50 * 1024 * 1024)
-                        .setBufferFlushMaxRows(50000)
+                        .setBufferFlushMaxBytes(10 * 1024 * 1024)
+                        .setBufferFlushMaxRows(1000)
                         .setFlushQueueSize(2)
                         .setUseCache(true)
                         .setIgnoreCommitError(false)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Optimize data writing in batch mode
1. When the interval is small, streamload will occur frequently. When the amount of data is large, it will cause small writes and back pressure.
Optimized to: schedule thread will not trigger writing when the queue is full
2. Adjust the default values ​​of sink.buffer-flush.max-rows and sink.buffer-flush.max-bytes to 50w and 100MB respectively, and the minimum number of imports (1w) and bytes (10MB) are limited
3. Add back pressure strategy. When the data accumulated in memory exceeds maxBlockByte, block data writing to prevent OOM of flink program
4. The load asynchronous import thread will take out the data in the queue at one time, merge multiple buffers into one buffer, and increase the import throughput.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
