### PR TITLE
[fix](cdc) Fix possible loss of precision in MongoCDC Decimal sampling.

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchema.java
@@ -29,11 +29,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class MongoDBSchema extends SourceSchema {
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBSchema.class);
+    private static final List<String> CONVERT_TYPE =
+            Arrays.asList(DorisType.BIGINT, DorisType.INT, DorisType.SMALLINT, DorisType.TINYINT);
+
+    public enum DecimalJudgement {
+        NOT_DECIMAL,
+        CERTAIN_DECIMAL,
+        CONVERT_TO_DECIMAL;
+
+        public static boolean needProcessing(DecimalJudgement decimalJudgement) {
+            return !decimalJudgement.equals(NOT_DECIMAL);
+        }
+    }
 
     public MongoDBSchema(
             ArrayList<Document> sampleData,
@@ -51,21 +65,37 @@ public class MongoDBSchema extends SourceSchema {
         primaryKeys.add("_id");
     }
 
-    private void processSampleData(Document sampleData) {
+    @VisibleForTesting
+    protected void processSampleData(Document sampleData) {
         for (Map.Entry<String, Object> entry : sampleData.entrySet()) {
             String fieldName = entry.getKey();
             Object value = entry.getValue();
             String dorisType = MongoDBType.toDorisType(value);
-            if (isDecimalField(fieldName)) {
+            DecimalJudgement decimalJudgement = judgeDecimalField(fieldName, dorisType);
+            if (DecimalJudgement.needProcessing(decimalJudgement)) {
+                if (decimalJudgement.equals(DecimalJudgement.CONVERT_TO_DECIMAL)) {
+                    int precision = value.toString().length();
+                    dorisType = MongoDBType.formatDecimalType(precision, 0);
+                }
                 dorisType = replaceDecimalTypeIfNeeded(fieldName, dorisType);
             }
             fields.put(fieldName, new FieldSchema(fieldName, dorisType, null));
         }
     }
 
-    private boolean isDecimalField(String fieldName) {
+    private DecimalJudgement judgeDecimalField(String fieldName, String dorisType) {
         FieldSchema existingField = fields.get(fieldName);
-        return existingField != null && existingField.getTypeString().startsWith(DorisType.DECIMAL);
+        if (existingField == null) {
+            return DecimalJudgement.NOT_DECIMAL;
+        }
+        boolean existDecimal = existingField.getTypeString().startsWith(DorisType.DECIMAL);
+        boolean isDecimal = dorisType.startsWith(DorisType.DECIMAL);
+        if (existDecimal && isDecimal) {
+            return DecimalJudgement.CERTAIN_DECIMAL;
+        } else if (CONVERT_TYPE.contains(dorisType)) {
+            return DecimalJudgement.CONVERT_TO_DECIMAL;
+        }
+        return DecimalJudgement.NOT_DECIMAL;
     }
 
     @VisibleForTesting
@@ -91,12 +121,8 @@ public class MongoDBSchema extends SourceSchema {
 
                 return DorisType.DECIMAL + "(" + newPrecision + "," + newScale + ")";
             } catch (DorisRuntimeException e) {
-                LOG.warn(
-                        "Replace decimal type of field:{} failed, the newly type is:{}, rollback to existing type:{}",
-                        fieldName,
-                        newDorisType,
-                        existingField.getTypeString());
-                return existingField.getTypeString();
+                LOG.error("Replace Decimal type error");
+                throw new DorisRuntimeException(e);
             }
         }
         return newDorisType;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBType.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBType.java
@@ -118,9 +118,11 @@ public class MongoDBType {
             decimal = new BigDecimal(decimal.toPlainString());
         }
         return decimal.precision() <= 38
-                ? String.format(
-                        "%s(%s,%s)",
-                        DorisType.DECIMAL_V3, decimal.precision(), Math.max(decimal.scale(), 0))
+                ? formatDecimalType(decimal.precision(), Math.max(decimal.scale(), 0))
                 : DorisType.STRING;
+    }
+
+    public static String formatDecimalType(int precision, int scale) {
+        return String.format("%s(%s,%s)", DorisType.DECIMAL_V3, precision, scale);
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchemaTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchemaTest.java
@@ -93,4 +93,46 @@ public class MongoDBSchemaTest {
             }
         }
     }
+
+    @Test
+    public void replaceDecimalTypeIfNeededTest2() throws Exception {
+        ArrayList<Document> documents = new ArrayList<>();
+        documents.add(new Document("fields1", "yes"));
+        documents.add(new Document("fields1", 1234567.666666));
+        documents.add(new Document("fields1", 123456789));
+        documents.add(new Document("fields1", 1234567.7777777));
+        documents.add(
+                new Document("fields1", new Decimal128(new BigDecimal("12345679012.999999999"))));
+
+        MongoDBSchema mongoDBSchema = new MongoDBSchema(documents, "db_TEST", "test_table", "");
+        Map<String, FieldSchema> fields = mongoDBSchema.getFields();
+        for (Map.Entry<String, FieldSchema> entry : fields.entrySet()) {
+            FieldSchema fieldSchema = entry.getValue();
+            String fieldName = entry.getKey();
+            if (fieldName.equals("fields1")) {
+                assertEquals("STRING", fieldSchema.getTypeString());
+            }
+        }
+    }
+
+    @Test
+    public void replaceDecimalTypeIfNeededTest3() throws Exception {
+        ArrayList<Document> documents = new ArrayList<>();
+        documents.add(new Document("fields1", 1234567.666666));
+        documents.add(new Document("fields1", 123456789));
+        documents.add(new Document("fields1", 1234567.7777777));
+        documents.add(new Document("fields1", "yes"));
+        documents.add(
+                new Document("fields1", new Decimal128(new BigDecimal("12345679012.999999999"))));
+
+        MongoDBSchema mongoDBSchema = new MongoDBSchema(documents, "db_TEST", "test_table", "");
+        Map<String, FieldSchema> fields = mongoDBSchema.getFields();
+        for (Map.Entry<String, FieldSchema> entry : fields.entrySet()) {
+            FieldSchema fieldSchema = entry.getValue();
+            String fieldName = entry.getKey();
+            if (fieldName.equals("fields1")) {
+                assertEquals("STRING", fieldSchema.getTypeString());
+            }
+        }
+    }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchemaTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchemaTest.java
@@ -41,7 +41,7 @@ public class MongoDBSchemaTest {
     }
 
     @Test
-    public void replaceDecimalTypeIfNeeded() throws Exception {
+    public void replaceDecimalTypeIfNeededTest1() throws Exception {
         ArrayList<Document> documents = new ArrayList<>();
         documents.add(new Document("fields1", 1234567.666666));
         documents.add(new Document("fields1", 123456789.88888888));
@@ -58,7 +58,7 @@ public class MongoDBSchemaTest {
     }
 
     @Test
-    public void replaceDecimalTypeIfNeededWhenContainsNonDecimalType() throws Exception {
+    public void replaceDecimalTypeIfNeededTest2() throws Exception {
         ArrayList<Document> documents = new ArrayList<>();
         documents.add(new Document("fields1", 1234567.666666));
         documents.add(new Document("fields1", 123456789));
@@ -75,7 +75,7 @@ public class MongoDBSchemaTest {
     }
 
     @Test
-    public void replaceDecimalTypeIfNeededTest() throws Exception {
+    public void replaceDecimalTypeIfNeededTest3() throws Exception {
         ArrayList<Document> documents = new ArrayList<>();
         documents.add(new Document("fields1", 1234567.666666));
         documents.add(new Document("fields1", 123456789));
@@ -95,7 +95,7 @@ public class MongoDBSchemaTest {
     }
 
     @Test
-    public void replaceDecimalTypeIfNeededTest2() throws Exception {
+    public void replaceDecimalTypeIfNeededTest4() throws Exception {
         ArrayList<Document> documents = new ArrayList<>();
         documents.add(new Document("fields1", "yes"));
         documents.add(new Document("fields1", 1234567.666666));
@@ -116,7 +116,7 @@ public class MongoDBSchemaTest {
     }
 
     @Test
-    public void replaceDecimalTypeIfNeededTest3() throws Exception {
+    public void replaceDecimalTypeIfNeededTest5() throws Exception {
         ArrayList<Document> documents = new ArrayList<>();
         documents.add(new Document("fields1", 1234567.666666));
         documents.add(new Document("fields1", 123456789));
@@ -132,6 +132,27 @@ public class MongoDBSchemaTest {
             String fieldName = entry.getKey();
             if (fieldName.equals("fields1")) {
                 assertEquals("STRING", fieldSchema.getTypeString());
+            }
+        }
+    }
+
+    @Test
+    public void replaceDecimalTypeIfNeededTest6() throws Exception {
+        ArrayList<Document> documents = new ArrayList<>();
+        documents.add(new Document("fields1", 1234567.666666));
+        documents.add(new Document("fields1", 123456789));
+        documents.add(new Document("fields1", 1234567.7777777));
+        documents.add(new Document("fields1", 123444555433445L));
+        documents.add(
+                new Document("fields1", new Decimal128(new BigDecimal("12345679012.999999999"))));
+
+        MongoDBSchema mongoDBSchema = new MongoDBSchema(documents, "db_TEST", "test_table", "");
+        Map<String, FieldSchema> fields = mongoDBSchema.getFields();
+        for (Map.Entry<String, FieldSchema> entry : fields.entrySet()) {
+            FieldSchema fieldSchema = entry.getValue();
+            String fieldName = entry.getKey();
+            if (fieldName.equals("fields1")) {
+                assertEquals("DECIMAL(24,9)", fieldSchema.getTypeString());
             }
         }
     }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchemaTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchemaTest.java
@@ -17,10 +17,14 @@
 
 package org.apache.doris.flink.tools.cdc.mongodb;
 
+import org.apache.doris.flink.catalog.doris.FieldSchema;
 import org.bson.Document;
+import org.bson.types.Decimal128;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -40,19 +44,53 @@ public class MongoDBSchemaTest {
     public void replaceDecimalTypeIfNeeded() throws Exception {
         ArrayList<Document> documents = new ArrayList<>();
         documents.add(new Document("fields1", 1234567.666666));
+        documents.add(new Document("fields1", 123456789.88888888));
+
         MongoDBSchema mongoDBSchema = new MongoDBSchema(documents, "db_TEST", "test_table", "");
-        String d = mongoDBSchema.replaceDecimalTypeIfNeeded("fields1", "DECIMALV3(12,8)");
-        assertEquals("DECIMAL(15,8)", d);
+        Map<String, FieldSchema> fields = mongoDBSchema.getFields();
+        for (Map.Entry<String, FieldSchema> entry : fields.entrySet()) {
+            FieldSchema fieldSchema = entry.getValue();
+            String fieldName = entry.getKey();
+            if (fieldName.equals("fields1")) {
+                assertEquals("DECIMAL(17,8)", fieldSchema.getTypeString());
+            }
+        }
     }
 
     @Test
     public void replaceDecimalTypeIfNeededWhenContainsNonDecimalType() throws Exception {
         ArrayList<Document> documents = new ArrayList<>();
         documents.add(new Document("fields1", 1234567.666666));
-        documents.add(new Document("fields1", 1234567));
-        documents.add(new Document("fields1", 1234567.7777777));
+        documents.add(new Document("fields1", 123456789));
+
         MongoDBSchema mongoDBSchema = new MongoDBSchema(documents, "db_TEST", "test_table", "");
-        String d = mongoDBSchema.replaceDecimalTypeIfNeeded("fields1", "DECIMALV3(12,8)");
-        assertEquals("DECIMAL(15,8)", d);
+        Map<String, FieldSchema> fields = mongoDBSchema.getFields();
+        for (Map.Entry<String, FieldSchema> entry : fields.entrySet()) {
+            FieldSchema fieldSchema = entry.getValue();
+            String fieldName = entry.getKey();
+            if (fieldName.equals("fields1")) {
+                assertEquals("DECIMAL(15,6)", fieldSchema.getTypeString());
+            }
+        }
+    }
+
+    @Test
+    public void replaceDecimalTypeIfNeededTest() throws Exception {
+        ArrayList<Document> documents = new ArrayList<>();
+        documents.add(new Document("fields1", 1234567.666666));
+        documents.add(new Document("fields1", 123456789));
+        documents.add(new Document("fields1", 1234567.7777777));
+        documents.add(
+                new Document("fields1", new Decimal128(new BigDecimal("12345679012.999999999"))));
+
+        MongoDBSchema mongoDBSchema = new MongoDBSchema(documents, "db_TEST", "test_table", "");
+        Map<String, FieldSchema> fields = mongoDBSchema.getFields();
+        for (Map.Entry<String, FieldSchema> entry : fields.entrySet()) {
+            FieldSchema fieldSchema = entry.getValue();
+            String fieldName = entry.getKey();
+            if (fieldName.equals("fields1")) {
+                assertEquals("DECIMAL(20,9)", fieldSchema.getTypeString());
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix a possible loss of precision when decimal and other number types appear in the same field in the sampled data.