### PR TITLE
[fix]Fix SQLParser parsing the default value of datetime type as the current time

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManager.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManager.java
@@ -44,10 +44,13 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /** Use {@link CCJSqlParserUtil} to parse SQL statements. */
 public class SQLParserSchemaManager implements Serializable {
@@ -58,14 +61,15 @@ public class SQLParserSchemaManager implements Serializable {
     private static final String PRIMARY_KEY = "PRIMARY KEY";
     private static final String UNIQUE = "UNIQUE";
     private static final String DORIS_CURRENT_TIMESTAMP = "CURRENT_TIMESTAMP";
-    private static final List<String> sourceConnectorTimeValues =
-            Arrays.asList(
-                    "SYSDATE",
-                    "SYSTIMESTAMP",
-                    "CURRENT_TIMESTAMP",
-                    "NOW()",
-                    "CURRENT TIMESTAMP",
-                    "GETDATE()");
+    private static final Set<String> sourceConnectorTimeValues =
+            new HashSet<>(
+                    Arrays.asList(
+                            "SYSDATE",
+                            "SYSTIMESTAMP",
+                            "CURRENT_TIMESTAMP",
+                            "NOW()",
+                            "CURRENT TIMESTAMP",
+                            "GETDATE()"));
 
     /**
      * Doris' schema change only supports ADD, DROP, and RENAME operations. This method is only used
@@ -294,12 +298,9 @@ public class SQLParserSchemaManager implements Serializable {
         }
         // In doris, DATETIME supports specifying the current time by default through
         // CURRENT_TIMESTAMP.
-        if (dateType.startsWith(DorisType.DATETIME) || dateType.startsWith(DorisType.DATETIME_V2)) {
-            for (String timeValue : sourceConnectorTimeValues) {
-                if (timeValue.equalsIgnoreCase(defaultValue)) {
-                    return DORIS_CURRENT_TIMESTAMP;
-                }
-            }
+        if ((dateType.startsWith(DorisType.DATETIME) || dateType.startsWith(DorisType.DATETIME_V2))
+                && sourceConnectorTimeValues.contains(defaultValue.toUpperCase(Locale.ROOT))) {
+            return DORIS_CURRENT_TIMESTAMP;
         }
         return defaultValue;
     }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManagerTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.flink.sink.schema;
 
+import org.apache.doris.flink.catalog.doris.DorisType;
 import org.apache.doris.flink.catalog.doris.TableSchema;
 import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 import org.apache.doris.flink.tools.cdc.SourceConnector;
@@ -139,7 +140,7 @@ public class SQLParserSchemaManagerTest {
     public void testExtractDefaultValue() {
         String expectDefault = "100";
         List<String> columnSpecs = Arrays.asList("default", "'100'", "comment", "");
-        String actualDefault = schemaManager.extractDefaultValue(columnSpecs);
+        String actualDefault = schemaManager.extractDefaultValue(DorisType.INT, columnSpecs);
         Assert.assertEquals(expectDefault, actualDefault);
     }
 
@@ -147,14 +148,14 @@ public class SQLParserSchemaManagerTest {
     public void testExtractDefaultValueQuotes() {
         String expectDefault = "100";
         List<String> columnSpecs = Arrays.asList("default", "\"100\"", "comment", "");
-        String actualDefault = schemaManager.extractDefaultValue(columnSpecs);
+        String actualDefault = schemaManager.extractDefaultValue(DorisType.BIGINT, columnSpecs);
         Assert.assertEquals(expectDefault, actualDefault);
     }
 
     @Test
     public void testExtractDefaultValueNull() {
         List<String> columnSpecs = Arrays.asList("Default", null, "comment", null);
-        String actualDefault = schemaManager.extractDefaultValue(columnSpecs);
+        String actualDefault = schemaManager.extractDefaultValue(DorisType.STRING, columnSpecs);
         Assert.assertNull(actualDefault);
     }
 
@@ -162,7 +163,7 @@ public class SQLParserSchemaManagerTest {
     public void testExtractDefaultValueEmpty() {
         String expectDefault = null;
         List<String> columnSpecs = Arrays.asList("DEFAULT", "comment", null);
-        String actualDefault = schemaManager.extractDefaultValue(columnSpecs);
+        String actualDefault = schemaManager.extractDefaultValue(DorisType.STRING, columnSpecs);
         Assert.assertEquals(expectDefault, actualDefault);
     }
 
@@ -170,14 +171,14 @@ public class SQLParserSchemaManagerTest {
     public void testExtractDefaultValueA() {
         String expectDefault = "aaa";
         List<String> columnSpecs = Arrays.asList("default", "aaa");
-        String actualDefault = schemaManager.extractDefaultValue(columnSpecs);
+        String actualDefault = schemaManager.extractDefaultValue(DorisType.STRING, columnSpecs);
         Assert.assertEquals(expectDefault, actualDefault);
     }
 
     @Test
     public void testExtractDefaultValueNULL() {
         List<String> columnSpecs = Collections.singletonList("default");
-        String actualDefault = schemaManager.extractDefaultValue(columnSpecs);
+        String actualDefault = schemaManager.extractDefaultValue(DorisType.STRING, columnSpecs);
         Assert.assertNull(actualDefault);
     }
 
@@ -288,7 +289,7 @@ public class SQLParserSchemaManagerTest {
                         SourceConnector.ORACLE, ddl, dorisTable, null);
 
         String expected =
-                "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={employee_id=FieldSchema{name='employee_id', typeString='BIGINT', defaultValue='null', comment='null'}, first_name=FieldSchema{name='first_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, last_name=FieldSchema{name='last_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, email=FieldSchema{name='email', typeString='VARCHAR(300)', defaultValue='null', comment='null'}, phone_number=FieldSchema{name='phone_number', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, hire_date=FieldSchema{name='hire_date', typeString='DATETIMEV2', defaultValue='SYSDATE', comment='null'}, job_id=FieldSchema{name='job_id', typeString='VARCHAR(30)', defaultValue='null', comment='null'}, salary=FieldSchema{name='salary', typeString='DECIMALV3(8,2)', defaultValue='null', comment='null'}, commission_pct=FieldSchema{name='commission_pct', typeString='DECIMALV3(2,2)', defaultValue='null', comment='null'}, manager_id=FieldSchema{name='manager_id', typeString='BIGINT', defaultValue='null', comment='null'}, department_id=FieldSchema{name='department_id', typeString='BIGINT', defaultValue='null', comment='null'}}, keys=employee_id, model=UNIQUE, distributeKeys=employee_id, properties={}, tableBuckets=null}";
+                "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={employee_id=FieldSchema{name='employee_id', typeString='BIGINT', defaultValue='null', comment='null'}, first_name=FieldSchema{name='first_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, last_name=FieldSchema{name='last_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, email=FieldSchema{name='email', typeString='VARCHAR(300)', defaultValue='null', comment='null'}, phone_number=FieldSchema{name='phone_number', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, hire_date=FieldSchema{name='hire_date', typeString='DATETIMEV2', defaultValue='CURRENT_TIMESTAMP', comment='null'}, job_id=FieldSchema{name='job_id', typeString='VARCHAR(30)', defaultValue='null', comment='null'}, salary=FieldSchema{name='salary', typeString='DECIMALV3(8,2)', defaultValue='null', comment='null'}, commission_pct=FieldSchema{name='commission_pct', typeString='DECIMALV3(2,2)', defaultValue='null', comment='null'}, manager_id=FieldSchema{name='manager_id', typeString='BIGINT', defaultValue='null', comment='null'}, department_id=FieldSchema{name='department_id', typeString='BIGINT', defaultValue='null', comment='null'}}, keys=employee_id, model=UNIQUE, distributeKeys=employee_id, properties={}, tableBuckets=null}";
         Assert.assertEquals(expected, tableSchema.toString());
     }
 
@@ -314,7 +315,7 @@ public class SQLParserSchemaManagerTest {
                         SourceConnector.ORACLE, ddl, dorisTable, null);
 
         String expected =
-                "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={employee_id=FieldSchema{name='employee_id', typeString='BIGINT', defaultValue='null', comment='null'}, first_name=FieldSchema{name='first_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, last_name=FieldSchema{name='last_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, email=FieldSchema{name='email', typeString='VARCHAR(300)', defaultValue='null', comment='null'}, phone_number=FieldSchema{name='phone_number', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, hire_date=FieldSchema{name='hire_date', typeString='DATETIMEV2', defaultValue='SYSDATE', comment='null'}, job_id=FieldSchema{name='job_id', typeString='VARCHAR(30)', defaultValue='null', comment='null'}, salary=FieldSchema{name='salary', typeString='DECIMALV3(8,2)', defaultValue='null', comment='null'}, commission_pct=FieldSchema{name='commission_pct', typeString='DECIMALV3(2,2)', defaultValue='null', comment='null'}, manager_id=FieldSchema{name='manager_id', typeString='BIGINT', defaultValue='null', comment='null'}, department_id=FieldSchema{name='department_id', typeString='BIGINT', defaultValue='null', comment='null'}}, keys=employee_id, model=UNIQUE, distributeKeys=employee_id, properties={}, tableBuckets=null}";
+                "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={employee_id=FieldSchema{name='employee_id', typeString='BIGINT', defaultValue='null', comment='null'}, first_name=FieldSchema{name='first_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, last_name=FieldSchema{name='last_name', typeString='VARCHAR(150)', defaultValue='null', comment='null'}, email=FieldSchema{name='email', typeString='VARCHAR(300)', defaultValue='null', comment='null'}, phone_number=FieldSchema{name='phone_number', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, hire_date=FieldSchema{name='hire_date', typeString='DATETIMEV2', defaultValue='CURRENT_TIMESTAMP', comment='null'}, job_id=FieldSchema{name='job_id', typeString='VARCHAR(30)', defaultValue='null', comment='null'}, salary=FieldSchema{name='salary', typeString='DECIMALV3(8,2)', defaultValue='null', comment='null'}, commission_pct=FieldSchema{name='commission_pct', typeString='DECIMALV3(2,2)', defaultValue='null', comment='null'}, manager_id=FieldSchema{name='manager_id', typeString='BIGINT', defaultValue='null', comment='null'}, department_id=FieldSchema{name='department_id', typeString='BIGINT', defaultValue='null', comment='null'}}, keys=employee_id, model=UNIQUE, distributeKeys=employee_id, properties={}, tableBuckets=null}";
         Assert.assertEquals(expected, tableSchema.toString());
     }
 
@@ -341,7 +342,7 @@ public class SQLParserSchemaManagerTest {
                         dorisTable,
                         new DorisTableConfig(new HashMap<>()));
         String expected =
-                "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={order_id=FieldSchema{name='order_id', typeString='BIGINT', defaultValue='null', comment='null'}, customer_id=FieldSchema{name='customer_id', typeString='BIGINT', defaultValue='null', comment='null'}, order_date=FieldSchema{name='order_date', typeString='DATETIMEV2', defaultValue='SYSDATE', comment='null'}, status=FieldSchema{name='status', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, total_amount=FieldSchema{name='total_amount', typeString='DECIMALV3(12,2)', defaultValue='null', comment='null'}, shipping_address=FieldSchema{name='shipping_address', typeString='VARCHAR(765)', defaultValue='null', comment='null'}, delivery_date=FieldSchema{name='delivery_date', typeString='DATETIMEV2', defaultValue='null', comment='null'}}, keys=order_id, model=DUPLICATE, distributeKeys=order_id, properties={light_schema_change=true}, tableBuckets=null}";
+                "TableSchema{database='doris', table='auto_tab', tableComment='null', fields={order_id=FieldSchema{name='order_id', typeString='BIGINT', defaultValue='null', comment='null'}, customer_id=FieldSchema{name='customer_id', typeString='BIGINT', defaultValue='null', comment='null'}, order_date=FieldSchema{name='order_date', typeString='DATETIMEV2', defaultValue='CURRENT_TIMESTAMP', comment='null'}, status=FieldSchema{name='status', typeString='VARCHAR(60)', defaultValue='null', comment='null'}, total_amount=FieldSchema{name='total_amount', typeString='DECIMALV3(12,2)', defaultValue='null', comment='null'}, shipping_address=FieldSchema{name='shipping_address', typeString='VARCHAR(765)', defaultValue='null', comment='null'}, delivery_date=FieldSchema{name='delivery_date', typeString='DATETIMEV2', defaultValue='null', comment='null'}}, keys=order_id, model=DUPLICATE, distributeKeys=order_id, properties={light_schema_change=true}, tableBuckets=null}";
         Assert.assertEquals(expected, tableSchema.toString());
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManagerTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManagerTest.java
@@ -183,6 +183,42 @@ public class SQLParserSchemaManagerTest {
     }
 
     @Test
+    public void testExtractDefaultValueDateTime() {
+        List<String> columnSpecs = Arrays.asList("default", "SYSTIMESTAMP");
+        String actualDefault = schemaManager.extractDefaultValue(DorisType.DATETIME, columnSpecs);
+        Assert.assertEquals("CURRENT_TIMESTAMP", actualDefault);
+    }
+
+    @Test
+    public void testExtractDefaultValueDateTimeV2() {
+        List<String> columnSpecs = Arrays.asList("default", "GETDATE()");
+        String actualDefault =
+                schemaManager.extractDefaultValue(DorisType.DATETIME_V2, columnSpecs);
+        Assert.assertEquals("CURRENT_TIMESTAMP", actualDefault);
+    }
+
+    @Test
+    public void testExtractDefaultValueDateTimeV2Time() {
+        List<String> columnSpecs = Arrays.asList("default", "2024-03-14 17:50:36.002");
+        String actualDefault = schemaManager.extractDefaultValue("DATETIMEV2(3)", columnSpecs);
+        Assert.assertEquals("2024-03-14 17:50:36.002", actualDefault);
+    }
+
+    @Test
+    public void testExtractDefaultValueDateTimeV2CurrentTime() {
+        List<String> columnSpecs = Arrays.asList("default", "now()");
+        String actualDefault = schemaManager.extractDefaultValue("DATETIMEV2(3)", columnSpecs);
+        Assert.assertEquals("CURRENT_TIMESTAMP", actualDefault);
+    }
+
+    @Test
+    public void testExtractDefaultValueDate() {
+        List<String> columnSpecs = Arrays.asList("default", "2024-03-14 17:50:36");
+        String actualDefault = schemaManager.extractDefaultValue(DorisType.DATE, columnSpecs);
+        Assert.assertEquals("2024-03-14 17:50:36", actualDefault);
+    }
+
+    @Test
     public void testRemoveContinuousChar() {
         // Test removing continuous target characters from both ends
         Assert.assertEquals("bc", schemaManager.removeContinuousChar("aaaabcaaa", 'a'));


### PR DESCRIPTION


# Proposed changes

Issue Number: close #xxx

## Problem Summary:
Only the `datetime` type in doris supports setting the default to the current time, and the current time can only be set through the `CURRENT_TIMESTAMP` keyword.
When various upstream data sources synchronize various keywords that set the current time, they are uniformly converted to `CURRENT_TIMESTAMP`

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
