### PR TITLE
[improvement] fix batch streamload when label already exist

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpPutBuilder.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpPutBuilder.java
@@ -117,6 +117,10 @@ public class HttpPutBuilder {
         return this;
     }
 
+    public String getLabel() {
+        return header.get("label");
+    }
+
     public HttpPut build() {
         Preconditions.checkNotNull(url);
         Preconditions.checkNotNull(httpEntity);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

In batch mode, the label may already exist when importing, and need to regenerate the label when retrying.
```
2024-08-13 13:42:14,888 INFO  org.apache.doris.flink.sink.batch.DorisBatchStreamLoad       [] - load Result {
    "TxnId": -1,
    "Label": "doris-label2433c8f9-7338-4285-826c-ce2f3dd01f86_17_test_tbl_b592eaaa-8c35-44ba-b959-1538cc78d072",
    "Comment": "",
    "TwoPhaseCommit": "false",
    "Status": "Label Already Exists",
    "ExistingJobStatus": "",
    "Message": "[LABEL_ALREADY_EXISTS]TStatus: errCode = 2, detailMessage = Label [doris-label2433c8f9-7338-4285-826c-ce2f3dd01f86_17_test_tbl_b592eaaa-8c35-44ba-b959-1538cc78d072] has already been used, relate to txn [1897945320369152]",
    "NumberTotalRows": 0,
    "NumberLoadedRows": 0,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 0,
    "LoadTimeMs": 0,
    "BeginTxnTimeMs": 0,
    "StreamLoadPutTimeMs": 0,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 0,
    "CommitAndPublishTimeMs": 0
}
```


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
