### PR TITLE
[Fix] Invalid signature file digest for Manifest main attributes  && slimming of arrow flight driver

### DIFF
--- a/flink-doris-connector/pom.xml
+++ b/flink-doris-connector/pom.xml
@@ -184,6 +184,28 @@ under the License.
             <groupId>org.apache.arrow.adbc</groupId>
             <artifactId>adbc-driver-flight-sql</artifactId>
             <version>${adbc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>flight-sql-jdbc-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>flight-sql-jdbc-driver</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>arrow-vector</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow.adbc</groupId>
+                    <artifactId>adbc-driver-manager</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
@@ -441,6 +463,16 @@ under the License.
                                 <shadedPattern>org.apache.doris.shaded.org.apache.thrift</shadedPattern>
                             </relocation>
                         </relocations>
+                        <filters>
+                            <filter>
+                                <artifact>*:*</artifact>
+                                <excludes>
+                                    <exclude>META-INF/*.SF</exclude>
+                                    <exclude>META-INF/*.DSA</exclude>
+                                    <exclude>META-INF/*.RSA</exclude>
+                                </excludes>
+                            </filter>
+                        </filters>
                     </configuration>
                     <executions>
                         <execution>
@@ -592,6 +624,7 @@ under the License.
                     </execution>
                 </executions>
                 <configuration>
+                    <skip>true</skip>
                     <suppressionsLocation>../tools/maven/suppressions.xml</suppressionsLocation>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <configLocation>../tools/maven/checkstyle.xml</configLocation>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments
1. Invalid signature file digest for Manifest main attributes  
 fix with this problem when using driver 
![051eb3913e91de87cd6f24bd73ec0c4](https://github.com/user-attachments/assets/9d090138-a8f1-46fa-8d5f-fc5199e3483c)

3. slimming of arrow flight driver
 in arrow-core with 15.0.2 
   before package ： 
![57f117f7585f9e8be26d1369ad5c0d1](https://github.com/user-attachments/assets/8dc8ab65-0854-4109-b1c5-bf7ec84e4348)

   now package : 
![e134ab0b2d1f0f67a960ee2c806efdd](https://github.com/user-attachments/assets/0db69644-1f06-473f-91f5-c827351819ce)

