### PR TITLE
[Fix] connect arrow with  ClassNotFoundException  by Caffeine

### DIFF
--- a/flink-doris-connector/pom.xml
+++ b/flink-doris-connector/pom.xml
@@ -199,10 +199,6 @@ under the License.
                     <artifactId>arrow-vector</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.github.ben-manes.caffeine</groupId>
-                    <artifactId>caffeine</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.arrow.adbc</groupId>
                     <artifactId>adbc-driver-manager</artifactId>
                 </exclusion>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments
in [[Fix] Invalid signature file digest for Manifest main attributes && slimming of arrow flight driver #](https://github.com/apache/doris-flink-connector/pull/472) 。
Due to local Maven cache issues, the effective dependency on Caffeine was removed from the driver
![image](https://github.com/user-attachments/assets/a2a51497-f64a-46c5-82b3-feaa5f9de6fe) 