### PR TITLE
[Improve]Support modify column type without default when column exists default value

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/IllegalArgumentException.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/IllegalArgumentException.java
@@ -25,4 +25,8 @@ public class IllegalArgumentException extends DorisException {
     public IllegalArgumentException(String arg, String value) {
         super("argument '" + arg + "' is illegal, value is '" + value + "'.");
     }
+
+    public IllegalArgumentException(String msg) {
+        super(msg);
+    }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeHelper.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeHelper.java
@@ -44,6 +44,7 @@ public class SchemaChangeHelper {
     private static final String CREATE_DATABASE_DDL = "CREATE DATABASE IF NOT EXISTS %s";
     private static final String MODIFY_TYPE_DDL = "ALTER TABLE %s MODIFY COLUMN %s %s";
     private static final String MODIFY_COMMENT_DDL = "ALTER TABLE %s MODIFY COLUMN %s COMMENT '%s'";
+    private static final String SHOW_FULL_COLUMN_DDL = "SHOW FULL COLUMNS FROM `%s`.`%s`";
 
     public static void compareSchema(
             Map<String, FieldSchema> updateFiledSchemaMap,
@@ -166,6 +167,7 @@ public class SchemaChangeHelper {
         String columnName = fieldSchema.getName();
         String dataType = fieldSchema.getTypeString();
         String comment = fieldSchema.getComment();
+        String defaultValue = fieldSchema.getDefaultValue();
         StringBuilder modifyDDL =
                 new StringBuilder(
                         String.format(
@@ -173,6 +175,11 @@ public class SchemaChangeHelper {
                                 DorisSchemaFactory.quoteTableIdentifier(tableIdentifier),
                                 DorisSchemaFactory.identifier(columnName),
                                 dataType));
+        if (StringUtils.isNotBlank(defaultValue)) {
+            modifyDDL
+                    .append(" DEFAULT ")
+                    .append(DorisSchemaFactory.quoteDefaultValue(defaultValue));
+        }
         commentColumn(modifyDDL, comment);
         return modifyDDL.toString();
     }
@@ -181,6 +188,10 @@ public class SchemaChangeHelper {
         if (StringUtils.isNotEmpty(comment)) {
             ddl.append(" COMMENT '").append(DorisSchemaFactory.quoteComment(comment)).append("'");
         }
+    }
+
+    public static String buildShowFullColumnDDL(String database, String table) {
+        return String.format(SHOW_FULL_COLUMN_DDL, database, table);
     }
 
     public static List<DDLSchema> getDdlSchemas() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeManager.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeManager.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.StringUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.doris.flink.catalog.doris.DorisSystem;
 import org.apache.doris.flink.catalog.doris.FieldSchema;
@@ -123,11 +124,30 @@ public class SchemaChangeManager implements Serializable {
             throws IOException, IllegalArgumentException {
         if (!checkColumnExists(database, table, field.getName())) {
             LOG.warn(
-                    "The column {} is not exists in table {}, can not modify it type",
+                    "The column {} is not exists in table {}, can not modify it's type",
                     field.getName(),
                     table);
             return false;
         }
+
+        String ddl = SchemaChangeHelper.buildShowFullColumnDDL(database, table);
+        String defaultValue = getDefaultValue(ddl, database, field.getName());
+        if (!StringUtils.isNullOrWhitespaceOnly(field.getDefaultValue())) {
+            // Can not change default value
+            if (!field.getDefaultValue().equals(defaultValue)) {
+                LOG.warn(
+                        "Column:{} can not change default value from {} to {}, fallback it",
+                        field.getName(),
+                        defaultValue,
+                        field.getDefaultValue());
+                field.setDefaultValue(defaultValue);
+            }
+        } else {
+            // If user does not give a default value, need fill it from
+            // original table schema to avoid change type failed if default value exists
+            field.setDefaultValue(defaultValue);
+        }
+
         // If user does not give a comment, need fill it from
         // original table schema to avoid miss comment
         if (StringUtils.isNullOrWhitespaceOnly(field.getComment())) {
@@ -214,15 +234,42 @@ public class SchemaChangeManager implements Serializable {
         }
     }
 
+    private String getDefaultValue(String ddl, String database, String column)
+            throws IOException, IllegalArgumentException {
+        String responseEntity = executeThenReturnResponse(ddl, database);
+        JsonNode responseNode = objectMapper.readTree(responseEntity);
+        String code = responseNode.get("code").asText("-1");
+        if (code.equals("0")) {
+            JsonNode data = responseNode.get("data").get("data");
+            for (JsonNode node : data) {
+                if (node.get(0).asText().equals(column)) {
+                    JsonNode defaultValueNode = node.get(5);
+                    return (defaultValueNode instanceof NullNode)
+                            ? null
+                            : defaultValueNode.asText();
+                }
+            }
+            return null;
+        } else {
+            throw new DorisSchemaChangeException(
+                    "Failed to get default value, response: " + responseEntity);
+        }
+    }
+
     /** execute sql in doris. */
-    public boolean execute(String ddl, String database)
+    public String executeThenReturnResponse(String ddl, String database)
             throws IOException, IllegalArgumentException {
         if (StringUtils.isNullOrWhitespaceOnly(ddl)) {
-            return false;
+            return null;
         }
         LOG.info("Execute SQL: {}", ddl);
         HttpPost httpPost = buildHttpPost(ddl, database);
-        String responseEntity = handleResponse(httpPost);
+        return handleResponse(httpPost);
+    }
+
+    public boolean execute(String ddl, String database)
+            throws IOException, IllegalArgumentException {
+        String responseEntity = executeThenReturnResponse(ddl, database);
         return handleSchemaChange(responseEntity);
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeManager.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeManager.java
@@ -257,10 +257,10 @@ public class SchemaChangeManager implements Serializable {
     }
 
     /** execute sql in doris. */
-    public String executeThenReturnResponse(String ddl, String database)
+    private String executeThenReturnResponse(String ddl, String database)
             throws IOException, IllegalArgumentException {
         if (StringUtils.isNullOrWhitespaceOnly(ddl)) {
-            return null;
+            throw new IllegalArgumentException("ddl can not be null or empty string!");
         }
         LOG.info("Execute SQL: {}", ddl);
         HttpPost httpPost = buildHttpPost(ddl, database);


### PR DESCRIPTION
# Proposed changes

1. Allow modifying a column type that has a default value even if upstream does not carry a default value.
2. Fallback to the original default value if upstream wants to change the default value to others.

Issue Number: close #xxx

## Problem Summary:

Currently, it's not allowed to change a column type that has a default value when upstream does not carry a default value.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
