### PR TITLE
[Improve] add label replace when label not meet the specifications 

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
@@ -55,9 +55,8 @@ public class LabelGenerator {
         Preconditions.checkState(tableIdentifier != null);
         String label = String.format("%s_%s_%s_%s", labelPrefix, tableIdentifier, subtaskId, chkId);
 
-        String uuid = UUID.randomUUID().toString().replace("-", "");
         if (!enable2PC) {
-            label = label + "_" + uuid;
+            label = label + "_" + UUID.randomUUID();
         }
 
         if (LABEL_PATTERN.matcher(label).matches()) {
@@ -69,14 +68,14 @@ public class LabelGenerator {
             // In 2pc, replace uuid with the table name. This will cause some txns to fail to be
             // aborted when aborting.
             // Later, the label needs to be stored in the state and aborted through label
-            return String.format("%s_%s_%s_%s", labelPrefix, uuid, subtaskId, chkId);
+            return String.format("%s_%s_%s_%s", labelPrefix, UUID.randomUUID(), subtaskId, chkId);
         } else {
-            return String.format("%s_%s_%s_%s", labelPrefix, subtaskId, chkId, uuid);
+            return String.format("%s_%s_%s_%s", labelPrefix, subtaskId, chkId, UUID.randomUUID());
         }
     }
 
     public String generateBatchLabel(String table) {
-        String uuid = UUID.randomUUID().toString().replace("-", "");
+        String uuid = UUID.randomUUID().toString();
         String label = String.format("%s_%s_%s", labelPrefix, table, uuid);
         if (!LABEL_PATTERN.matcher(label).matches()) {
             return labelPrefix + "_" + uuid;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
@@ -56,10 +56,13 @@ public class LabelGenerator {
         String label = String.format("%s_%s_%s_%s", labelPrefix, tableIdentifier, subtaskId, chkId);
         if (enable2PC) {
             return label;
-        } else if (LABEL_PATTERN.matcher(label).matches()) {
-            return label + "_" + UUID.randomUUID();
         } else {
-            return String.format("%s_%s_%s_%s", labelPrefix, subtaskId, chkId, UUID.randomUUID());
+            label = label + "_" + UUID.randomUUID();
+            if (LABEL_PATTERN.matcher(label).matches()) {
+                return label;
+            } else {
+                return labelPrefix + "_" + subtaskId + "_" + chkId + "_" + UUID.randomUUID();
+            }
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LabelGenerator.java
@@ -54,11 +54,17 @@ public class LabelGenerator {
     public String generateTableLabel(long chkId) {
         Preconditions.checkState(tableIdentifier != null);
         String label = String.format("%s_%s_%s_%s", labelPrefix, tableIdentifier, subtaskId, chkId);
+
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+        if (!enable2PC) {
+            label = label + "_" + uuid;
+        }
+
         if (LABEL_PATTERN.matcher(label).matches()) {
+            // The unicode table name or length exceeds the limit
             return label;
         }
-        // The unicode table name or length exceeds the limit
-        String uuid = UUID.randomUUID().toString().replace("-", "");
+
         if (enable2PC) {
             // In 2pc, replace uuid with the table name. This will cause some txns to fail to be
             // aborted when aborting.

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestLabelGenerator.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestLabelGenerator.java
@@ -22,8 +22,8 @@ import org.junit.Test;
 
 public class TestLabelGenerator {
 
-    private static String UUID_REGEX =
-            "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+    private static String UUID_REGEX_WITHOUT_LINE =
+            "[0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12}";
 
     @Test
     public void generateTableLabelTest() {
@@ -39,30 +39,35 @@ public class TestLabelGenerator {
                         "db.tabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletable",
                         0);
         label = labelGenerator.generateTableLabel(1);
-        Assert.assertTrue(label.matches("test001_0_1_" + UUID_REGEX));
+        Assert.assertTrue(label.matches("test001_0_1_" + UUID_REGEX_WITHOUT_LINE));
 
         // mock table name chinese
         labelGenerator = new LabelGenerator("test001", false, "数据库.数据表", 0);
         label = labelGenerator.generateTableLabel(1);
-        Assert.assertTrue(label.matches("test001_0_1_" + UUID_REGEX));
+        Assert.assertTrue(label.matches("test001_0_1_" + UUID_REGEX_WITHOUT_LINE));
+
+        // mock table name chinese and 2pc
+        labelGenerator = new LabelGenerator("test001", true, "数据库.数据表", 0);
+        label = labelGenerator.generateTableLabel(1);
+        Assert.assertTrue(label.matches("test001_" + UUID_REGEX_WITHOUT_LINE + "_0_1"));
     }
 
     @Test
     public void generateBatchLabelTest() {
         LabelGenerator labelGenerator = new LabelGenerator("test001", false);
         String label = labelGenerator.generateBatchLabel("table");
-        Assert.assertTrue(label.matches("test001_table_" + UUID_REGEX));
+        Assert.assertTrue(label.matches("test001_table_" + UUID_REGEX_WITHOUT_LINE));
 
         // mock label length more than 128
         labelGenerator = new LabelGenerator("test001", false);
         label =
                 labelGenerator.generateBatchLabel(
                         "tabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletable");
-        Assert.assertTrue(label.matches("test001_" + UUID_REGEX));
+        Assert.assertTrue(label.matches("test001_" + UUID_REGEX_WITHOUT_LINE));
 
         // mock table name chinese
         labelGenerator = new LabelGenerator("test001", false);
         label = labelGenerator.generateBatchLabel("数据库.数据表");
-        Assert.assertTrue(label.matches("test001_" + UUID_REGEX));
+        Assert.assertTrue(label.matches("test001_" + UUID_REGEX_WITHOUT_LINE));
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestLabelGenerator.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestLabelGenerator.java
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.writer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestLabelGenerator {
+
+    private static String UUID_REGEX =
+            "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
+    @Test
+    public void generateTableLabelTest() {
+        LabelGenerator labelGenerator = new LabelGenerator("test001", true, "db.table", 0);
+        String label = labelGenerator.generateTableLabel(1);
+        Assert.assertEquals("test001_db_table_0_1", label);
+
+        // mock label length more than 128
+        labelGenerator =
+                new LabelGenerator(
+                        "test001",
+                        false,
+                        "db.tabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletable",
+                        0);
+        label = labelGenerator.generateTableLabel(1);
+        Assert.assertTrue(label.matches("test001_0_1_" + UUID_REGEX));
+
+        // mock table name chinese
+        labelGenerator = new LabelGenerator("test001", false, "数据库.数据表", 0);
+        label = labelGenerator.generateTableLabel(1);
+        Assert.assertTrue(label.matches("test001_0_1_" + UUID_REGEX));
+    }
+
+    @Test
+    public void generateBatchLabelTest() {
+        LabelGenerator labelGenerator = new LabelGenerator("test001", false);
+        String label = labelGenerator.generateBatchLabel("table");
+        Assert.assertTrue(label.matches("test001_table_" + UUID_REGEX));
+
+        // mock label length more than 128
+        labelGenerator = new LabelGenerator("test001", false);
+        label =
+                labelGenerator.generateBatchLabel(
+                        "tabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletabletable");
+        Assert.assertTrue(label.matches("test001_" + UUID_REGEX));
+
+        // mock table name chinese
+        labelGenerator = new LabelGenerator("test001", false);
+        label = labelGenerator.generateBatchLabel("数据库.数据表");
+        Assert.assertTrue(label.matches("test001_" + UUID_REGEX));
+    }
+}

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestLabelGenerator.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/writer/TestLabelGenerator.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 public class TestLabelGenerator {
 
     private static String UUID_REGEX_WITHOUT_LINE =
-            "[0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12}";
+            "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 
     @Test
     public void generateTableLabelTest() {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1. When the table name is too long, the concatenated label will be greater than 128 characters.
2. When the table name contains Chinese characters, it cannot be concatenated because the HTTP request header cannot contain Chinese characters.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
