### PR TITLE
[Bug] Fix retry of lost tablet when tablet read fails

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/backend/BackendClient.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/backend/BackendClient.java
@@ -134,7 +134,11 @@ public class BackendClient {
      * @throws ConnectedFailedException throw if cannot connect to Doris BE
      */
     public TScanOpenResult openScanner(TScanOpenParams openParams) {
-        logger.debug("OpenScanner to '{}', parameter is '{}'.", routing, openParams);
+        logger.info(
+                "OpenScanner to '{}', table is '{}', tablets is '{}'",
+                routing,
+                openParams.table,
+                openParams.tablet_ids);
         if (!isConnected) {
             open();
         }
@@ -161,7 +165,10 @@ public class BackendClient {
                 ex = e;
             }
         }
-        logger.error(ErrorMessages.CONNECT_FAILED_MESSAGE, routing);
+        logger.error(
+                "Connect to doris {} failed, to open scanner for tablet {}",
+                routing,
+                openParams.tablet_ids);
         throw new ConnectedFailedException(routing.toString(), ex);
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/backend/BackendClient.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/backend/BackendClient.java
@@ -134,19 +134,16 @@ public class BackendClient {
      * @throws ConnectedFailedException throw if cannot connect to Doris BE
      */
     public TScanOpenResult openScanner(TScanOpenParams openParams) {
-        logger.info(
-                "OpenScanner to '{}', table is '{}', tablets is '{}'",
-                routing,
-                openParams.table,
-                openParams.tablet_ids);
+        logger.debug("OpenScanner to '{}', parameter is '{}'.", routing, openParams);
         if (!isConnected) {
             open();
         }
         TException ex = null;
+        TScanOpenResult result = null;
         for (int attempt = 0; attempt < retries; ++attempt) {
             logger.debug("Attempt {} to openScanner {}.", attempt, routing);
             try {
-                TScanOpenResult result = client.openScanner(openParams);
+                result = client.openScanner(openParams);
                 if (result == null) {
                     logger.warn("Open scanner result from {} is null.", routing);
                     continue;
@@ -159,16 +156,29 @@ public class BackendClient {
                             result.getStatus().getErrorMsgs());
                     continue;
                 }
+                logger.info(
+                        "OpenScanner success for Doris BE '{}' with contextId '{}' for tablets '{}'.",
+                        routing,
+                        result.getContextId(),
+                        openParams.tablet_ids);
                 return result;
             } catch (TException e) {
                 logger.warn("Open scanner from {} failed.", routing, e);
                 ex = e;
             }
         }
-        logger.error(
-                "Connect to doris {} failed, to open scanner for tablet {}",
-                routing,
-                openParams.tablet_ids);
+        if (result != null && (TStatusCode.OK != (result.getStatus().getStatusCode()))) {
+            logger.error(
+                    ErrorMessages.DORIS_INTERNAL_FAIL_MESSAGE,
+                    routing,
+                    result.getStatus().getStatusCode(),
+                    result.getStatus().getErrorMsgs());
+            throw new DorisInternalException(
+                    routing.toString(),
+                    result.getStatus().getStatusCode(),
+                    result.getStatus().getErrorMsgs());
+        }
+        logger.error(ErrorMessages.CONNECT_FAILED_MESSAGE, routing);
         throw new ConnectedFailedException(routing.toString(), ex);
     }
 
@@ -251,7 +261,10 @@ public class BackendClient {
                 logger.warn("Close scanner from {} failed.", routing, e);
             }
         }
-        logger.info("CloseScanner to Doris BE '{}' success.", routing);
+        logger.info(
+                "CloseScanner to Doris BE '{}' success for contextId {} ",
+                routing,
+                closeParams.getContextId());
         close();
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/PartitionDefinition.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/PartitionDefinition.java
@@ -144,4 +144,20 @@ public class PartitionDefinition implements Serializable, Comparable<PartitionDe
                 + '\''
                 + '}';
     }
+
+    public String toStringWithoutPlan() {
+        return "PartitionDefinition{"
+                + "database='"
+                + database
+                + '\''
+                + ", table='"
+                + table
+                + '\''
+                + ", beAddress='"
+                + beAddress
+                + '\''
+                + ", tabletIds="
+                + tabletIds
+                + '}';
+    }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/assigners/SimpleSplitAssigner.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/assigners/SimpleSplitAssigner.java
@@ -45,9 +45,9 @@ public class SimpleSplitAssigner implements DorisSplitAssigner {
     }
 
     @Override
-    public void addSplits(Collection<DorisSourceSplit> splits) {
-        LOG.info("Adding splits: {}", splits);
-        splits.addAll(splits);
+    public void addSplits(Collection<DorisSourceSplit> newSplits) {
+        LOG.info("Adding splits: {}", newSplits);
+        splits.addAll(newSplits);
     }
 
     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/DorisValueReader.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/DorisValueReader.java
@@ -182,6 +182,11 @@ public class DorisValueReader extends ValueReader implements AutoCloseable {
                                         } catch (InterruptedException e) {
                                             throw new DorisRuntimeException(e);
                                         }
+                                    } else {
+                                        LOG.info(
+                                                "Async scan finished , tablets: {}, offset: {}",
+                                                partition.getTabletIds(),
+                                                offset);
                                     }
                                 }
                             } finally {
@@ -245,6 +250,11 @@ public class DorisValueReader extends ValueReader implements AutoCloseable {
                     eos.set(nextResult.isEos());
                     if (!eos.get()) {
                         rowBatch = new RowBatch(nextResult, schema).readArrow();
+                    } else {
+                        LOG.info(
+                                "Scan finished, tablets: {}, offset: {}",
+                                partition.getTabletIds(),
+                                offset);
                     }
                 }
                 hasNext = !eos.get();

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/ValueReader.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/ValueReader.java
@@ -34,7 +34,7 @@ public abstract class ValueReader {
             DorisReadOptions readOptions,
             Logger logger)
             throws DorisException {
-        logger.info("create reader for partition: {}", partition);
+        logger.info("create reader for partition: {}", partition.toStringWithoutPlan());
         if (readOptions.getUseFlightSql()) {
             return new DorisFlightValueReader(
                     partition,

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisTableInputSplit.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisTableInputSplit.java
@@ -39,4 +39,15 @@ public class DorisTableInputSplit implements InputSplit, java.io.Serializable {
     public int getSplitNumber() {
         return splitNumber;
     }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "DorisTableInputSplit: %s.%s,id=%s,be=%s,tablets=%s",
+                partition.getDatabase(),
+                partition.getTable(),
+                splitNumber,
+                partition.getBeAddress(),
+                partition.getTabletIds());
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When tablet data reading fails, such as openscanner failure, the FLink task will retry. During the retry, some readers (which have not yet done a checkpoint) may lose the tablets they are reading.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
