### PR TITLE
[fix](oracle-cdc) fix oracle regular expresion too long

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleDatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/oracle/OracleDatabaseSync.java
@@ -164,11 +164,16 @@ public class OracleDatabaseSync extends DatabaseSync {
         Preconditions.checkNotNull(databaseName, "database-name in oracle is required");
         Preconditions.checkNotNull(schemaName, "schema-name in oracle is required");
         String tableName = config.get(OracleSourceOptions.TABLE_NAME);
-        // When debezium incrementally reads, it will be judged based on regexp_like.
-        // When the regular length exceeds 512, an error will be reported,
-        // like ORA-12733: regular expression too long
-        if (tableName.length() > 512) {
-            tableName = StringUtils.isNullOrWhitespaceOnly(includingTables) ? ".*" : tableName;
+        // When debezium incrementally reads (refer LogMinerQueryBuilder.listOfPatternsToSql),
+        // it will be judged based on regexp_like. When the regular length exceeds 512, an error
+        // will be reported, like ORA-12733: regular expression too long
+        if (tableName.length() > 450) {
+            // REGEXP_LIKE('^SCHEMA.(TBL1|TBL2)$')
+            if (StringUtils.isNullOrWhitespaceOnly(excludingTables)
+                    && (StringUtils.isNullOrWhitespaceOnly(includingTables)
+                            || ".*".equals(includingTables))) {
+                tableName = ".*";
+            }
         }
 
         String url = config.get(OracleSourceOptions.URL);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When it is not a single-sink, and includeTable=.* and the table name is schema.(tbl1|tbl2), it may exceed the limit of 512 and an error will be reported.
Caused by: java.sql.SQLException: ORA-12733: regular expression too long，

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
