### PR TITLE
Edit DorisConfigOptions withDescription

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -150,7 +150,7 @@ public class DorisConfigOptions {
             ConfigOptions.key("doris.exec.mem.limit")
                     .memoryType()
                     .defaultValue(MemorySize.parse(DORIS_EXEC_MEM_LIMIT_DEFAULT_STR))
-                    .withDescription("Memory limit for a single query. The default is 2048mb.");
+                    .withDescription("Memory limit for a single query. The default is 8192mb.");
     public static final ConfigOption<Boolean> SOURCE_USE_OLD_API =
             ConfigOptions.key("source.use-old-api")
                     .booleanType()


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The DorisConfigOptions class has an incorrect description of the "doris.exec.mem.limit" parameter,
Change to correct description

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)  
    No
2. Has unit tests been added: (Yes/No/No Need) 
   No 
3. Has document been added or modified: (Yes/No/No Need)
    No
4. Does it need to update dependencies: (Yes/No)
   No
5. Are there any changes that cannot be rolled back: (Yes/No)
   No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
