### PR TITLE
Fix a mismatch between the type of jdbc query result and the datatype

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
@@ -24,6 +24,7 @@ import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.connection.JdbcConnectionProvider;
 import org.apache.doris.flink.connection.SimpleJdbcConnectionProvider;
 import org.apache.doris.flink.exception.DorisRuntimeException;
+import org.apache.flink.table.types.DataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,8 +201,10 @@ public class Worker implements Runnable {
                     try (ResultSet rs = ps.executeQuery()) {
                         while (rs.next()) {
                             Record record = new Record(schema);
-                            for (int index = 0; index < schema.getFieldTypes().length; index++) {
-                                record.setObject(index, rs.getObject(index + 1));
+                            DataType[] fieldTypes = schema.getFieldTypes();
+                            for (int index = 0; index < fieldTypes.length; index++) {
+                                Class<?> conversionClass = fieldTypes[index].getConversionClass();
+                                record.setObject(index, rs.getObject(index + 1, conversionClass));
                             }
                             List<Record> records =
                                     resultRecordMap.computeIfAbsent(

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -150,7 +150,7 @@ public class DorisConfigOptions {
             ConfigOptions.key("doris.exec.mem.limit")
                     .memoryType()
                     .defaultValue(MemorySize.parse(DORIS_EXEC_MEM_LIMIT_DEFAULT_STR))
-                    .withDescription("Memory limit for a single query. The default is 2048mb.");
+                    .withDescription("Memory limit for a single query. The default is 8192mb.");
     public static final ConfigOption<Boolean> SOURCE_USE_OLD_API =
             ConfigOptions.key("source.use-old-api")
                     .booleanType()


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
The value type obtained by rs.getObject(index + 1) is inconsistent with the field type obtained by flink Context, resulting in a conversion failure in encapsulating flink RowData. For example, the java type corresponding to TINYINT is Java.lang. Byte, while the java type obtained by rs.getObject(index + 1) is Java.lang. Integer, which has a type conversion problem. SMALLINT had the same problem.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
 NO
2. Has unit tests been added: (Yes/No/No Need)
 NO
3. Has document been added or modified: (Yes/No/No Need)
 NO
4. Does it need to update dependencies: (Yes/No)
 NO
5. Are there any changes that cannot be rolled back: (Yes/No)
 NO

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
