### PR TITLE
[fix] Fixed the issue that batchwriter may be blocked when writing to multiple tables

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -178,7 +178,7 @@ public class DorisBatchStreamLoad implements Serializable {
      * @param record
      * @throws IOException
      */
-    public synchronized void writeRecord(String database, String table, byte[] record) {
+    public void writeRecord(String database, String table, byte[] record) {
         checkFlushException();
         String bufferKey = getTableIdentifier(database, table);
 
@@ -228,15 +228,15 @@ public class DorisBatchStreamLoad implements Serializable {
         }
     }
 
-    public synchronized boolean bufferFullFlush(String bufferKey) {
+    public boolean bufferFullFlush(String bufferKey) {
         return doFlush(bufferKey, false, true);
     }
 
-    public synchronized boolean intervalFlush() {
+    public boolean intervalFlush() {
         return doFlush(null, false, false);
     }
 
-    public synchronized boolean checkpointFlush() {
+    public boolean checkpointFlush() {
         return doFlush(null, true, false);
     }
 
@@ -407,11 +407,6 @@ public class DorisBatchStreamLoad implements Serializable {
                             }
                             load(bf.getLabelName(), bf);
                         }
-                    }
-
-                    if (flushQueue.size() < flushQueueSize) {
-                        // Avoid waiting for 2 rounds of intervalMs
-                        doFlush(null, false, false);
                     }
                 } catch (Exception e) {
                     LOG.error("worker running error", e);


### PR DESCRIPTION
# Proposed changes

Fixed two issues:
1. Since the current cache is global, when there are multiple tables written upstream, such as
tbl1, tbl2, tbl3, when the cached data of the three tables does not reach bufferFlushBytes, but reaches maxBlockBytes, the sinkwriter will be blocked at cache full
When the intervalFlush thread calls the write, it will wait for a long time because it cannot obtain the lock, resulting in the inability to consume the cache.

2. If the flushqueue is full, the sinkwriter will be blocked at flushQueue.put(buffer); at this time, the streamload-executor thread will also call the doflush method after flush, and it will also be stuck because it cannot obtain the lock, and the data cannot be consumed.