### PR TITLE
[bugfix]Fix a mismatch between the type of jdbc query result and the datatype

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
@@ -18,6 +18,7 @@
 package org.apache.doris.flink.lookup;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.types.DataType;
 
 import org.apache.doris.flink.cfg.DorisLookupOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
@@ -200,8 +201,10 @@ public class Worker implements Runnable {
                     try (ResultSet rs = ps.executeQuery()) {
                         while (rs.next()) {
                             Record record = new Record(schema);
-                            for (int index = 0; index < schema.getFieldTypes().length; index++) {
-                                record.setObject(index, rs.getObject(index + 1));
+                            DataType[] fieldTypes = schema.getFieldTypes();
+                            for (int index = 0; index < fieldTypes.length; index++) {
+                                Class<?> conversionClass = fieldTypes[index].getConversionClass();
+                                record.setObject(index, rs.getObject(index + 1, conversionClass));
                             }
                             List<Record> records =
                                     resultRecordMap.computeIfAbsent(

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
@@ -17,14 +17,13 @@
 
 package org.apache.doris.flink.lookup;
 
-import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.table.types.DataType;
-
 import org.apache.doris.flink.cfg.DorisLookupOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.connection.JdbcConnectionProvider;
 import org.apache.doris.flink.connection.SimpleJdbcConnectionProvider;
 import org.apache.doris.flink.exception.DorisRuntimeException;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.types.DataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/lookup/Worker.java
@@ -17,13 +17,14 @@
 
 package org.apache.doris.flink.lookup;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.types.DataType;
+
 import org.apache.doris.flink.cfg.DorisLookupOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.connection.JdbcConnectionProvider;
 import org.apache.doris.flink.connection.SimpleJdbcConnectionProvider;
 import org.apache.doris.flink.exception.DorisRuntimeException;
-import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.table.types.DataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/lookup/DorisLookupTableITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/lookup/DorisLookupTableITCase.java
@@ -1,0 +1,89 @@
+package org.apache.doris.flink.lookup;
+
+import org.apache.doris.flink.container.AbstractITCaseService;
+import org.apache.doris.flink.container.ContainerUtils;
+import org.apache.doris.flink.source.DorisSourceITCase;
+import org.apache.doris.flink.table.DorisConfigOptions;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DorisLookupTableITCase extends AbstractITCaseService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DorisSourceITCase.class);
+    private static final String DATABASE = "test_lookup";
+    private static final String TABLE_READ_TBL = "tbl_read_tbl";
+
+    @Test
+    public void testLookupTable() throws Exception {
+        initializeTable(TABLE_READ_TBL);
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(DEFAULT_PARALLELISM);
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        String datagenDDL = "CREATE TABLE datagen (" +
+                " `id` INT," +
+                " `proctime` AS PROCTIME()" +
+                ") WITH (" +
+                " 'connector' = 'datagen'," +
+                " 'rows-per-second' = '1'," +
+                " 'fields.id.kind' = 'random'," +
+                " 'fields.id.min' = '1'," +
+                " 'fields.id.max' = '10'" +
+                ")";
+        tEnv.executeSql(datagenDDL);
+        String lookupDDL = String.format("CREATE TABLE `doris_lookup`(" +
+                        "  `id` INTEGER," +
+                        "  `tinyintColumn` TINYINT," +
+                        "  `smallintColumn` SMALLINT," +
+                        "  `bigintColumn` BIGINT," +
+                        "  PRIMARY KEY (`id`) NOT ENFORCED" +
+                        ")  WITH (" +
+                        "'connector' = '" + DorisConfigOptions.IDENTIFIER + "'," +
+                        "'fenodes' = '%s'," +
+                        "'jdbc-url' = '%s'," +
+                        "'table.identifier' = '%s'," +
+                        "'username' = '%s'," +
+                        "'password' = '%s'," +
+                        "'lookup.cache.max-rows' = '100'" +
+                        ")",
+                getFenodes(),
+                getDorisQueryUrl(),
+                DATABASE + "." + TABLE_READ_TBL,
+                getDorisUsername(),
+                getDorisPassword());
+        tEnv.executeSql(lookupDDL);
+        tEnv.executeSql("select datagen.id," +
+                "tinyintColumn," +
+                "smallintColumn," +
+                "bigintColumn" +
+                " from `datagen`" +
+                " inner join `doris_lookup` FOR SYSTEM_TIME AS OF datagen.proctime on datagen.id = doris_lookup.id").print();
+        env.execute("Flink doris lookup test");
+    }
+
+    private void initializeTable(String table) {
+        ContainerUtils.executeSQLStatement(
+                getDorisQueryConnection(),
+                LOG,
+                String.format("CREATE DATABASE IF NOT EXISTS %s", DATABASE),
+                String.format("DROP TABLE IF EXISTS %s.%s", DATABASE, table),
+                String.format(
+                        "CREATE TABLE %s.%s ( \n"
+                                + "`id` int(11),\n"
+                                + "`tinyintColumn` tinyint(4),\n"
+                                + "`smallintColumn` smallint(6),\n"
+                                + "`bigintColumn` bigint(20),\n"
+                                + ") DISTRIBUTED BY HASH(`id`) BUCKETS 10\n"
+                                + "PROPERTIES (\n"
+                                + "\"replication_num\" = \"1\"\n"
+                                + ")\n",
+                        DATABASE, table),
+                String.format("insert into %s.%s  values (1,97,27479,8670353564751764000)", DATABASE, table),
+                String.format("insert into %s.%s  values (2,79,17119,-4381380624467725000)", DATABASE, table),
+                String.format("insert into %s.%s  values (3,-106,-14878,1466614815449373200)", DATABASE, table));
+    }
+}

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/lookup/DorisLookupTableITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/lookup/DorisLookupTableITCase.java
@@ -2,18 +2,27 @@ package org.apache.doris.flink.lookup;
 
 import org.apache.doris.flink.container.AbstractITCaseService;
 import org.apache.doris.flink.container.ContainerUtils;
-import org.apache.doris.flink.source.DorisSourceITCase;
 import org.apache.doris.flink.table.DorisConfigOptions;
-import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class DorisLookupTableITCase extends AbstractITCaseService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DorisSourceITCase.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DorisLookupTableITCase.class);
     private static final String DATABASE = "test_lookup";
     private static final String TABLE_READ_TBL = "tbl_read_tbl";
 
@@ -22,19 +31,15 @@ public class DorisLookupTableITCase extends AbstractITCaseService {
         initializeTable(TABLE_READ_TBL);
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(DEFAULT_PARALLELISM);
-        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        DataStreamSource<Integer> sourceStream = env.<Integer>fromElements(1, 2, 3, 4);
         final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
-        String datagenDDL = "CREATE TABLE datagen (" +
-                " `id` INT," +
-                " `proctime` AS PROCTIME()" +
-                ") WITH (" +
-                " 'connector' = 'datagen'," +
-                " 'rows-per-second' = '1'," +
-                " 'fields.id.kind' = 'random'," +
-                " 'fields.id.min' = '1'," +
-                " 'fields.id.max' = '10'" +
-                ")";
-        tEnv.executeSql(datagenDDL);
+        Schema schema = Schema.newBuilder()
+                .column("f0", DataTypes.INT())
+                .columnByExpression("proctime", "PROCTIME()")
+                .build();
+        Table table = tEnv.fromDataStream(sourceStream, schema);
+        tEnv.createTemporaryView("source", table);
+
         String lookupDDL = String.format("CREATE TABLE `doris_lookup`(" +
                         "  `id` INTEGER," +
                         "  `tinyintColumn` TINYINT," +
@@ -56,13 +61,22 @@ public class DorisLookupTableITCase extends AbstractITCaseService {
                 getDorisUsername(),
                 getDorisPassword());
         tEnv.executeSql(lookupDDL);
-        tEnv.executeSql("select datagen.id," +
+        TableResult tableResult = tEnv.executeSql("select source.f0," +
                 "tinyintColumn," +
                 "smallintColumn," +
                 "bigintColumn" +
-                " from `datagen`" +
-                " inner join `doris_lookup` FOR SYSTEM_TIME AS OF datagen.proctime on datagen.id = doris_lookup.id").print();
-        env.execute("Flink doris lookup test");
+                " from `source`" +
+                " inner join `doris_lookup` FOR SYSTEM_TIME AS OF source.proctime on source.f0 = doris_lookup.id");
+
+        List<String> actual = new ArrayList<>();
+        try (CloseableIterator<Row> iterator = tableResult.collect()) {
+            while (iterator.hasNext()) {
+                actual.add(iterator.next().toString());
+            }
+        }
+
+        String[] expected = new String[]{"+I[1, 97, 27479, 8670353564751764000]", "+I[2, 79, 17119, -4381380624467725000]", "+I[3, -106, -14878, 1466614815449373200]"};
+        assertEqualsInAnyOrder(Arrays.asList(expected), Arrays.asList(actual.toArray()));
     }
 
     private void initializeTable(String table) {

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/lookup/DorisLookupTableITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/lookup/DorisLookupTableITCase.java
@@ -1,8 +1,5 @@
 package org.apache.doris.flink.lookup;
 
-import org.apache.doris.flink.container.AbstractITCaseService;
-import org.apache.doris.flink.container.ContainerUtils;
-import org.apache.doris.flink.table.DorisConfigOptions;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
@@ -12,6 +9,10 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
+
+import org.apache.doris.flink.container.AbstractITCaseService;
+import org.apache.doris.flink.container.ContainerUtils;
+import org.apache.doris.flink.table.DorisConfigOptions;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/lookup/DorisLookupTableITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/lookup/DorisLookupTableITCase.java
@@ -28,10 +28,10 @@ public class DorisLookupTableITCase extends AbstractITCaseService {
 
     @Test
     public void testLookupTable() throws Exception {
-        initializeTable(TABLE_READ_TBL);
+        initializeTable();
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(DEFAULT_PARALLELISM);
-        DataStreamSource<Integer> sourceStream = env.<Integer>fromElements(1, 2, 3, 4);
+        DataStreamSource<Integer> sourceStream = env.fromElements(1, 2, 3, 4);
         final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
         Schema schema =
                 Schema.newBuilder()
@@ -91,12 +91,14 @@ public class DorisLookupTableITCase extends AbstractITCaseService {
         assertEqualsInAnyOrder(Arrays.asList(expected), Arrays.asList(actual.toArray()));
     }
 
-    private void initializeTable(String table) {
+    private void initializeTable() {
         ContainerUtils.executeSQLStatement(
                 getDorisQueryConnection(),
                 LOG,
                 String.format("CREATE DATABASE IF NOT EXISTS %s", DATABASE),
-                String.format("DROP TABLE IF EXISTS %s.%s", DATABASE, table),
+                String.format(
+                        "DROP TABLE IF EXISTS %s.%s",
+                        DATABASE, DorisLookupTableITCase.TABLE_READ_TBL),
                 String.format(
                         "CREATE TABLE %s.%s ( \n"
                                 + "`id` int(11),\n"
@@ -107,15 +109,15 @@ public class DorisLookupTableITCase extends AbstractITCaseService {
                                 + "PROPERTIES (\n"
                                 + "\"replication_num\" = \"1\"\n"
                                 + ")\n",
-                        DATABASE, table),
+                        DATABASE, DorisLookupTableITCase.TABLE_READ_TBL),
                 String.format(
                         "insert into %s.%s  values (1,97,27479,8670353564751764000)",
-                        DATABASE, table),
+                        DATABASE, DorisLookupTableITCase.TABLE_READ_TBL),
                 String.format(
                         "insert into %s.%s  values (2,79,17119,-4381380624467725000)",
-                        DATABASE, table),
+                        DATABASE, DorisLookupTableITCase.TABLE_READ_TBL),
                 String.format(
                         "insert into %s.%s  values (3,-106,-14878,1466614815449373200)",
-                        DATABASE, table));
+                        DATABASE, DorisLookupTableITCase.TABLE_READ_TBL));
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
The value type obtained by rs.getObject(index + 1) is inconsistent with the field type obtained by flink Context, resulting in a conversion failure in encapsulating flink RowData. For example, the java type corresponding to TINYINT is Java.lang. Byte, while the java type obtained by rs.getObject(index + 1) is Java.lang. Integer, which has a type conversion problem. SMALLINT had the same problem.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
 NO
2. Has unit tests been added: (Yes/No/No Need)
 YES
3. Has document been added or modified: (Yes/No/No Need)
 NO
4. Does it need to update dependencies: (Yes/No)
 NO
5. Are there any changes that cannot be rolled back: (Yes/No)
 NO

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
