### PR TITLE
[fix] Fix auto create database failed when it's name contains special symbols

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeHelper.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeHelper.java
@@ -150,7 +150,7 @@ public class SchemaChangeHelper {
     }
 
     public static String buildCreateDatabaseDDL(String database) {
-        return String.format(CREATE_DATABASE_DDL, database);
+        return String.format(CREATE_DATABASE_DDL, DorisSchemaFactory.identifier(database));
     }
 
     public static String buildModifyColumnCommentDDL(

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SchemaManagerITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SchemaManagerITCase.java
@@ -226,8 +226,22 @@ public class SchemaManagerITCase extends AbstractITCaseService {
     public void testCreateTableWhenDatabaseNotExists()
             throws IOException, IllegalArgumentException, InterruptedException {
         String databaseName = DATABASE + "_" + Integer.toUnsignedString(new Random().nextInt(), 36);
-        String tableName = "auto_create_database";
+        createTableWhenDatabaseNotExists(databaseName);
+    }
 
+    @Test
+    public void testCreateTableWhenDatabaseNotExistsAndContainsSpecialSymbol()
+            throws IOException, IllegalArgumentException, InterruptedException {
+        String databaseName =
+                DATABASE.replace("_", "-")
+                        + "_"
+                        + Integer.toUnsignedString(new Random().nextInt(), 36);
+        createTableWhenDatabaseNotExists(databaseName);
+    }
+
+    public void createTableWhenDatabaseNotExists(String databaseName)
+            throws IOException, IllegalArgumentException, InterruptedException {
+        String tableName = "auto_create_database";
         TableSchema tableSchema = new TableSchema();
         tableSchema.setDatabase(databaseName);
         tableSchema.setTable(tableName);
@@ -240,6 +254,7 @@ public class SchemaManagerITCase extends AbstractITCaseService {
         Map<String, String> tableProperties = new HashMap<>();
         tableProperties.put("replication_num", "1");
         tableSchema.setProperties(tableProperties);
+
         schemaChangeManager.createTable(tableSchema);
 
         Thread.sleep(3_000);


### PR DESCRIPTION
# Proposed changes

Fix auto create database failed when it's name contains special symbols.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
