### PR TITLE
[Improve](http) add timeout  and waitForContinue config  for sink httpclient  

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/ConfigurationOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/ConfigurationOptions.java
@@ -33,8 +33,8 @@ public interface ConfigurationOptions {
     String DORIS_REQUEST_READ_TIMEOUT_MS = "doris.request.read.timeout";
     String DORIS_REQUEST_QUERY_TIMEOUT_S = "doris.request.query.timeout";
     Integer DORIS_REQUEST_RETRIES_DEFAULT = 3;
-    Integer DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT = 30 * 1000;
-    Integer DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT = 30 * 1000;
+    Integer DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT = 60 * 1000;
+    Integer DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT = 60 * 1000;
     Integer DORIS_REQUEST_QUERY_TIMEOUT_S_DEFAULT = 21600;
 
     String DORIS_TABLET_SIZE = "doris.request.tablet.size";

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisReadOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisReadOptions.java
@@ -210,17 +210,22 @@ public class DorisReadOptions implements Serializable {
 
         private String readFields;
         private String filterQuery;
-        private Integer requestTabletSize;
-        private Integer requestConnectTimeoutMs;
-        private Integer requestReadTimeoutMs;
-        private Integer requestQueryTimeoutS;
-        private Integer requestRetries;
-        private Integer requestBatchSize;
-        private Long execMemLimit;
-        private Integer deserializeQueueSize;
-        private Boolean deserializeArrowAsync;
+        private Integer requestTabletSize = ConfigurationOptions.DORIS_TABLET_SIZE_DEFAULT;
+        private Integer requestConnectTimeoutMs =
+                ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT;
+        private Integer requestReadTimeoutMs =
+                ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT;
+        private Integer requestQueryTimeoutS =
+                ConfigurationOptions.DORIS_REQUEST_QUERY_TIMEOUT_S_DEFAULT;
+        private Integer requestRetries = ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT;
+        private Integer requestBatchSize = ConfigurationOptions.DORIS_BATCH_SIZE_DEFAULT;
+        private Long execMemLimit = ConfigurationOptions.DORIS_EXEC_MEM_LIMIT_DEFAULT;
+        private Integer deserializeQueueSize =
+                ConfigurationOptions.DORIS_DESERIALIZE_QUEUE_SIZE_DEFAULT;
+        private Boolean deserializeArrowAsync =
+                ConfigurationOptions.DORIS_DESERIALIZE_ARROW_ASYNC_DEFAULT;
         private Boolean useOldApi = false;
-        private Boolean useFlightSql = false;
+        private Boolean useFlightSql = ConfigurationOptions.USE_FLIGHT_SQL_DEFAULT;
         private Integer flightSqlPort;
 
         /**

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
@@ -17,50 +17,70 @@
 
 package org.apache.doris.flink.sink;
 
+import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HttpRequestExecutor;
 
-import java.util.concurrent.TimeUnit;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT;
 
 /** util to build http client. */
 public class HttpUtil {
+    private final int connectTimeout;
+    private final int socketTimeout;
+    private HttpClientBuilder httpClientBuilder;
 
-    private RequestConfig requestConfigStream =
-            RequestConfig.custom()
-                    .setConnectTimeout(60 * 1000)
-                    .setConnectionRequestTimeout(60 * 1000)
-                    .build();
+    public HttpUtil() {
+        this.connectTimeout = DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT;
+        this.socketTimeout = DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT;
+        settingStreamHttpClientBuilder();
+    }
 
-    private final HttpClientBuilder httpClientBuilder =
-            HttpClients.custom()
-                    .setRedirectStrategy(
-                            new DefaultRedirectStrategy() {
-                                @Override
-                                protected boolean isRedirectable(String method) {
-                                    return true;
-                                }
-                            })
-                    .setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE)
-                    .evictExpiredConnections()
-                    .evictIdleConnections(60, TimeUnit.SECONDS)
-                    .setDefaultRequestConfig(requestConfigStream);
+    public HttpUtil(DorisReadOptions readOptions) {
+        this.connectTimeout = readOptions.getRequestConnectTimeoutMs();
+        this.socketTimeout = readOptions.getRequestReadTimeoutMs();
+        settingStreamHttpClientBuilder();
+    }
 
+    private void settingStreamHttpClientBuilder() {
+        this.httpClientBuilder =
+                HttpClients.custom()
+                        // default timeout 3s, maybe report 307 error when fe busy
+                        .setRequestExecutor(new HttpRequestExecutor(socketTimeout))
+                        .setRedirectStrategy(
+                                new DefaultRedirectStrategy() {
+                                    @Override
+                                    protected boolean isRedirectable(String method) {
+                                        return true;
+                                    }
+                                })
+                        .setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE)
+                        .setDefaultRequestConfig(
+                                RequestConfig.custom()
+                                        .setConnectTimeout(connectTimeout)
+                                        .setConnectionRequestTimeout(connectTimeout)
+                                        .build());
+    }
+
+    /**
+     * for stream http
+     *
+     * @return
+     */
     public CloseableHttpClient getHttpClient() {
         return httpClientBuilder.build();
     }
 
-    private RequestConfig requestConfig =
-            RequestConfig.custom()
-                    .setConnectTimeout(60 * 1000)
-                    .setConnectionRequestTimeout(60 * 1000)
-                    // default checkpoint timeout is 10min
-                    .setSocketTimeout(9 * 60 * 1000)
-                    .build();
-
+    /**
+     * for batch http
+     *
+     * @return
+     */
     public HttpClientBuilder getHttpClientBuilderForBatch() {
         return HttpClients.custom()
                 .setRedirectStrategy(
@@ -70,12 +90,22 @@ public class HttpUtil {
                                 return true;
                             }
                         })
-                .setDefaultRequestConfig(requestConfig);
+                .setDefaultRequestConfig(
+                        RequestConfig.custom()
+                                .setConnectTimeout(connectTimeout)
+                                .setConnectionRequestTimeout(connectTimeout)
+                                .setSocketTimeout(socketTimeout)
+                                .build());
     }
 
     public HttpClientBuilder getHttpClientBuilderForCopyBatch() {
         return HttpClients.custom()
                 .disableRedirectHandling()
-                .setDefaultRequestConfig(requestConfig);
+                .setDefaultRequestConfig(
+                        RequestConfig.custom()
+                                .setConnectTimeout(connectTimeout)
+                                .setConnectionRequestTimeout(connectTimeout)
+                                .setSocketTimeout(socketTimeout)
+                                .build());
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -103,7 +103,7 @@ public class DorisBatchStreamLoad implements Serializable {
     private final AtomicBoolean started;
     private volatile boolean loadThreadAlive = false;
     private AtomicReference<Throwable> exception = new AtomicReference<>(null);
-    private HttpClientBuilder httpClientBuilder = new HttpUtil().getHttpClientBuilderForBatch();
+    private HttpClientBuilder httpClientBuilder;
     private BackendUtil backendUtil;
     private boolean enableGroupCommit;
     private boolean enableGzCompress;
@@ -170,6 +170,7 @@ public class DorisBatchStreamLoad implements Serializable {
         this.started = new AtomicBoolean(true);
         this.loadExecutorService.execute(loadAsyncExecutor);
         this.subTaskId = subTaskId;
+        this.httpClientBuilder = new HttpUtil(dorisReadOptions).getHttpClientBuilderForBatch();
     }
 
     /**

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
@@ -66,7 +66,11 @@ public class DorisCommitter implements Committer<DorisCommittable>, Closeable {
             DorisOptions dorisOptions,
             DorisReadOptions dorisReadOptions,
             DorisExecutionOptions executionOptions) {
-        this(dorisOptions, dorisReadOptions, executionOptions, new HttpUtil().getHttpClient());
+        this(
+                dorisOptions,
+                dorisReadOptions,
+                executionOptions,
+                new HttpUtil(dorisReadOptions).getHttpClient());
     }
 
     public DorisCommitter(

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -346,7 +346,7 @@ public class DorisWriter<IN>
                                 dorisOptions,
                                 executionOptions,
                                 labelGenerator,
-                                new HttpUtil().getHttpClient()));
+                                new HttpUtil(dorisReadOptions).getHttpClient()));
     }
 
     /** Check the streamload http request regularly. */

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableFactoryTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableFactoryTest.java
@@ -248,8 +248,8 @@ public class DorisDynamicTableFactoryTest {
         options.put("password", "");
         options.put("auto-redirect", "true");
         options.put("doris.request.retries", "3");
-        options.put("doris.request.connect.timeout", "30s");
-        options.put("doris.request.read.timeout", "30s");
+        options.put("doris.request.connect.timeout", "60s");
+        options.put("doris.request.read.timeout", "60s");
         return options;
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1. Fix 307 error
```
Caused by: org.apache.doris.flink.exception.DorisRuntimeException: org.apache.doris.flink.exception.StreamLoadException: stream load error: HTTP/1.1 307 Temporary Redirect
	at org.apache.doris.flink.sink.writer.DorisStreamLoad.stopLoad(DorisStreamLoad.java:305) ~[classes/:?]
	at org.apache.doris.flink.sink.writer.DorisWriter.prepareCommit(DorisWriter.java:250) ~[classes/:?]
	at org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperator.emitCommittables(SinkWriterOperator.java:199) ~[flink-streaming-java-1.18.0.jar:1.18.0]
	at org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperator.prepareSnapshotPreBarrier(SinkWriterOperator.java:169) ~[flink-streaming-java-1.18.0.jar:1.18.0]
```
Currently, the default **auto-redirect=true**, the normal process is: **request FE -> FE returns 307 -> get BE address and send data**
If FE (high pressure/ FullGC/ network problem), etc., waiting for the 307 response will be slow, HttpClient will send data first after judging that the waiting timeout (refer to here https://github.com/apache/httpcomponents-core/blob/rel/v4.4.13/httpcore/src/main/java/org/apache/http/protocol/HttpRequestExecutor.java#L219-L239), because InpustStreamEntity cannot be read repeatedly, an error will be reported.
The solution is to increase the waitForContinue time to avoid errors caused by jitter.

The following is a partial request process. When **Read timed out**, data will be sent actively. After receiving 307 again, an error will be reported because it cannot be consumed repeatedly.

```
15:00:01,712 DEBUG org.apache.http.headers      - http-outgoing-51 >> PUT /api/test/test_flink/_stream_load HTTP/1.1
...
15:00:02,716 DEBUG org.apache.http.wire  - http-outgoing-51 << "[read] I/O error: Read timed out"
15:00:03,793 DEBUG org.apache.http.wire  - http-outgoing-51 >> "4f[\r][\n]"
15:00:03,793 DEBUG org.apache.http.wire  - http-outgoing-51 >> "099c50c5-cb4f-4228-8334-942c4fe10767,48[\n]"
15:00:03,793 DEBUG org.apache.http.wire  - http-outgoing-51 >> "c2014e23-2241-4506-a700-9cd136263e40,58[\r][\n]"
15:00:03,793 DEBUG org.apache.http.wire  - http-outgoing-51 >> "0[\r][\n]"
15:00:03,793 DEBUG org.apache.http.wire  - http-outgoing-51 >> "[\r][\n]"
15:00:03,793 DEBUG org.apache.http.wire  - http-outgoing-51 << "**HTTP/1.1 307 Temporary Redirect**[\r][\n]"
15:00:03,794 DEBUG org.apache.http.wire  - http-outgoing-51 << "Date: Tue, 03 Dec 2024 07:00:03 GMT[\r][\n]"
15:00:03,794 DEBUG org.apache.http.wire  - http-outgoing-51 << "Vary: Origin[\r][\n]"
15:00:03,794 DEBUG org.apache.http.wire  - http-outgoing-51 << "Vary: Access-Control-Request-Method[\r][\n]"
...
15:00:03,796 DEBUG org.apache.http.impl.execchain.RedirectExec         - Cannot redirect non-repeatable request
```

2. Currently, **doris.request.connect.timeout** and **doris.request.read.timeout** are provided. Add these two configurations to the HttpUtil method.



## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
