### PR TITLE
[Improve](batch) change label when batch streamload retry

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -33,7 +33,6 @@ import org.apache.doris.flink.sink.BackendUtil;
 import org.apache.doris.flink.sink.EscapeHandler;
 import org.apache.doris.flink.sink.HttpPutBuilder;
 import org.apache.doris.flink.sink.HttpUtil;
-import org.apache.doris.flink.sink.LoadStatus;
 import org.apache.doris.flink.sink.writer.LabelGenerator;
 import org.apache.http.client.entity.GzipCompressingEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -481,11 +480,6 @@ public class DorisBatchStreamLoad implements Serializable {
                                     lock.unlock();
                                 }
                                 return;
-                            } else if (LoadStatus.LABEL_ALREADY_EXIST.equals(
-                                    respContent.getStatus())) {
-                                // todo: need to abort transaction when JobStatus not finished
-                                putBuilder.setLabel(label + "_" + retry);
-                                reason = respContent.getMessage();
                             } else {
                                 String errMsg = null;
                                 if (StringUtils.isBlank(respContent.getMessage())
@@ -522,6 +516,7 @@ public class DorisBatchStreamLoad implements Serializable {
                 // get available backend retry
                 refreshLoadUrl(buffer.getDatabase(), buffer.getTable());
                 putBuilder.setUrl(loadUrl);
+                putBuilder.setLabel(label + "_" + retry);
             }
             buffer.clear();
             buffer = null;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Sometimes, after a streamload error is reported, txn cannot automatically abort. In this case, when retrying with the same label, an error message "label already exists" will be reported. In this case, you need to retry with a different label to avoid ambiguity for users.

```
2024-12-04 09:42:14,208 INFO  org.apache.doris.flink.sink.batch.DorisBatchStreamLoad       [] - load Result {
    "TxnId": 6427153,
    "Label": "label-doris-ods-loc-oc228108_23_xxx_rt_bba4a7b1-917d-4f05-bb6c-b8db0377ae15_1",
    "Comment": "",
    "TwoPhaseCommit": "false",
    "Status": "Fail",
    "Message": "[ANALYSIS_ERROR]TStatus: errCode = 2, detailMessage = get tableList write lock timeout, tableList=(Table [id=6065479, name=xxx_rt, type=OLAP])",
    "NumberTotalRows": 814,
    "NumberLoadedRows": 814,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 635419,
    "LoadTimeMs": 45071,
    "BeginTxnTimeMs": 2362,
    "StreamLoadPutTimeMs": 12367,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 338,
    "CommitAndPublishTimeMs": 0
}
2024-12-04 09:42:14,208 ERROR org.apache.doris.flink.sink.batch.DorisBatchStreamLoad       [] - stream load error with 192.168.3.56:8030, to retry, cause by
org.apache.doris.flink.exception.DorisBatchLoadException: stream load error: [ANALYSIS_ERROR]TStatus: errCode = 2, detailMessage = get tableList write lock timeout, tableList=(Table [id=6065479, name=xxx_rt, type=OLAP]), see more in null
	at org.apache.doris.flink.sink.batch.DorisBatchStreamLoad$LoadAsyncExecutor.load(DorisBatchStreamLoad.java:494) [flink-doris-connector-1.18-24.0.1.jar:24.0.1]
	at org.apache.doris.flink.sink.batch.DorisBatchStreamLoad$LoadAsyncExecutor.run(DorisBatchStreamLoad.java:407) [flink-doris-connector-1.18-24.0.1.jar:24.0.1]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_391]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_391]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_391]

2024-12-04 09:42:14,212 INFO  org.apache.doris.flink.sink.batch.DorisBatchStreamLoad       [] - stream load started for label-doris-ods-loc-oc228108_23_xxx_rt_bba4a7b1-917d-4f05-bb6c-b8db0377ae15_1 on host 192.168.3.56:8030
2024-12-04 09:42:15,463 INFO  org.apache.doris.flink.sink.batch.DorisBatchStreamLoad       [] - load Result {
    "TxnId": -1,
    "Label": "label-doris-ods-loc-oc228108_23_xxx_rt_bba4a7b1-917d-4f05-bb6c-b8db0377ae15_1",
    "Comment": "",
    "TwoPhaseCommit": "false",
    "Status": "Label Already Exists",
    "ExistingJobStatus": "RUNNING",
    "Message": "[LABEL_ALREADY_EXISTS]TStatus: errCode = 2, detailMessage = Label [label-doris-ods-loc-oc228108_23_xxx_rt_bba4a7b1-917d-4f05-bb6c-b8db0377ae15_1] has already been used, relate to txn [6427153], status [PREPARE].",
    "NumberTotalRows": 0,
    "NumberLoadedRows": 0,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 0,
    "LoadTimeMs": 0,
    "BeginTxnTimeMs": 0,
    "StreamLoadPutTimeMs": 0,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 0,
    "CommitAndPublishTimeMs": 0
}
```



## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
