### PR TITLE
[fix] Fix error like:aused by: org.apache.http.ProtocolException: Transfer-encoding header already present

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
@@ -25,6 +25,7 @@ import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.protocol.HttpRequestExecutor;
+import org.apache.http.protocol.RequestContent;
 
 import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT;
 import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT;
@@ -64,7 +65,8 @@ public class HttpUtil {
                                 RequestConfig.custom()
                                         .setConnectTimeout(connectTimeout)
                                         .setConnectionRequestTimeout(connectTimeout)
-                                        .build());
+                                        .build())
+                        .addInterceptorLast(new RequestContent(true));;
     }
 
     /**

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
@@ -66,7 +66,8 @@ public class HttpUtil {
                                         .setConnectTimeout(connectTimeout)
                                         .setConnectionRequestTimeout(connectTimeout)
                                         .build())
-                        .addInterceptorLast(new RequestContent(true));;
+                        .addInterceptorLast(new RequestContent(true));
+        ;
     }
 
     /**

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
@@ -67,7 +67,6 @@ public class HttpUtil {
                                         .setConnectionRequestTimeout(connectTimeout)
                                         .build())
                         .addInterceptorLast(new RequestContent(true));
-        ;
     }
 
     /**


### PR DESCRIPTION
[fix] Fix error like:
Caused by: org.apache.http.ProtocolException: Transfer-encoding header already present
	at org.apache.http.protocol.RequestContent.process(RequestContent.java:93) ~[xxx-cdh-flink1-20-0-sql-gitlab-runner-1.0.0.jar:?]
	at org.apache.http.protocol.ImmutableHttpProcessor.process(ImmutableHttpProcessor.java:132) ~[xxx-cdh-flink1-20-0-sql-gitlab-runner-1.0.0.jar:?]
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:182) ~[xxx-cdh-flink1-20-0-sql-gitlab-runner-1.0.0.jar:?]
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:88) ~[xxx-cdh-flink1-20-0-sql-gitlab-runner-1.0.0.jar:?]
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110) ~[xxx-cdh-flink1-20-0-sql-gitlab-runner-1.0.0.jar:?]
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184) ~[xxx-cdh-flink1-20-0-sql-gitlab-runner-1.0.0.jar:?]
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82) ~[xxx-cdh-flink1-20-0-sql-gitlab-runner-1.0.0.jar:?]
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:107) ~[xxx-cdh-flink1-20-0-sql-gitlab-runner-1.0.0.jar:?]
	at org.apache.doris.flink.sink.writer.DorisStreamLoad.lambda$startLoad$0(DorisStreamLoad.java:347) ~[xxx-cdh-flink1-20-0-sql-gitlab-runner-1.0.0.jar:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_232]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_232]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_232]
	... 1 more