### PR TITLE
[Fix] fix multi database sync npe error

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -479,7 +479,7 @@ public abstract class DatabaseSync {
             }
             TableSchema dorisSchema =
                     DorisSchemaFactory.createTableSchema(
-                            database,
+                            targetDb,
                             dorisTable,
                             schema.getFields(),
                             schema.getPrimaryKeys(),

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -170,7 +170,7 @@ public abstract class DatabaseSync {
                     streamSource.process(buildProcessFunction());
             for (Tuple2<String, String> dbTbl : dorisTables) {
                 OutputTag<String> recordOutputTag =
-                        ParsingProcessFunction.createRecordOutputTag(dbTbl.f1);
+                        ParsingProcessFunction.createRecordOutputTag(dbTbl.f0, dbTbl.f1);
                 DataStream<String> sideOutput = parsedStream.getSideOutput(recordOutputTag);
                 int sinkParallel =
                         sinkConfig.getInteger(
@@ -230,7 +230,7 @@ public abstract class DatabaseSync {
     }
 
     public ParsingProcessFunction buildProcessFunction() {
-        return new ParsingProcessFunction(converter);
+        return new ParsingProcessFunction(database, converter);
     }
 
     /** create doris sink. */

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSync.java
@@ -198,7 +198,7 @@ public class MongoDBDatabaseSync extends DatabaseSync {
 
     @Override
     public ParsingProcessFunction buildProcessFunction() {
-        return new MongoParsingProcessFunction(converter);
+        return new MongoParsingProcessFunction(database, converter);
     }
 
     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoParsingProcessFunction.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoParsingProcessFunction.java
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
 public class MongoParsingProcessFunction extends ParsingProcessFunction {
     private static final Logger LOG = LoggerFactory.getLogger(MongoParsingProcessFunction.class);
 
-    public MongoParsingProcessFunction(TableNameConverter converter) {
-        super(converter);
+    public MongoParsingProcessFunction(String databaseName, TableNameConverter converter) {
+        super(databaseName, converter);
     }
 
     @Override

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/container/ContainerUtils.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/container/ContainerUtils.java
@@ -104,6 +104,16 @@ public class ContainerUtils {
             List<String> expected,
             String query,
             int columnSize) {
+        checkResult(connection, logger, expected, query, columnSize, true);
+    }
+
+    public static void checkResult(
+            Connection connection,
+            Logger logger,
+            List<String> expected,
+            String query,
+            int columnSize,
+            boolean ordered) {
         List<String> actual = new ArrayList<>();
         try (Statement statement = connection.createStatement()) {
             ResultSet sinkResultSet = statement.executeQuery(query);
@@ -131,6 +141,13 @@ public class ContainerUtils {
                 "checking test result. expected={}, actual={}",
                 String.join(",", expected),
                 String.join(",", actual));
-        Assert.assertArrayEquals(expected.toArray(), actual.toArray());
+        if (ordered) {
+            Assert.assertArrayEquals(expected.toArray(), actual.toArray());
+        } else {
+            Assert.assertEquals(expected.size(), actual.size());
+            Assert.assertArrayEquals(
+                    expected.stream().sorted().toArray(Object[]::new),
+                    actual.stream().sorted().toArray(Object[]::new));
+        }
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/container/e2e/Mysql2DorisE2ECase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/container/e2e/Mysql2DorisE2ECase.java
@@ -56,8 +56,8 @@ public class Mysql2DorisE2ECase extends AbstractE2EService {
         argList.add(USERNAME + "=" + getMySQLUsername());
         argList.add(MYSQL_CONF);
         argList.add(PASSWORD + "=" + getMySQLPassword());
-        // argList.add(MYSQL_CONF);
-        // argList.add("server-time-zone=UTC");
+        argList.add(MYSQL_CONF);
+        argList.add("server-time-zone=UTC");
 
         setSinkConfDefaultConfig(argList);
         return argList;
@@ -427,20 +427,35 @@ public class Mysql2DorisE2ECase extends AbstractE2EService {
     @Test
     public void testMySQL2DorisMultiDatabaseSync() throws Exception {
         String jobName = "testMySQL2DorisMultiDatabaseSync";
+        ContainerUtils.executeSQLStatement(
+                getDorisQueryConnection(), LOG, "DROP DATABASE IF EXISTS test_e2e_mysql_db1");
+        ContainerUtils.executeSQLStatement(
+                getDorisQueryConnection(), LOG, "DROP DATABASE IF EXISTS test_e2e_mysql_db2");
         initEnvironment(jobName, "container/e2e/mysql2doris/testMySQL2DorisMultiDbSync_init.sql");
         startMysql2DorisJob(jobName, "container/e2e/mysql2doris/testMySQL2DorisMultiDbSync.txt");
 
-        // wait 2 times checkpoint
-        Thread.sleep(20000);
+        // wait 3 times checkpoint
+        Thread.sleep(30000);
         LOG.info("Start to verify init result.");
-        List<String> initExpected =
-                Arrays.asList("1,db1_tb1,18", "1,db1_tb2,19", "1,db2_tb1,20", "1,db2_tb2,21");
-        String sql =
-                "SELECT * FROM test_e2e_mysql_db1.tbl1 UNION ALL \n"
-                        + "SELECT * FROM test_e2e_mysql_db1.tbl2 UNION ALL \n"
-                        + "SELECT * FROM test_e2e_mysql_db2.tbl1 UNION ALL \n"
-                        + "SELECT * FROM test_e2e_mysql_db2.tbl2 ";
-        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, initExpected, sql, 3);
+        List<String> initExpected1 = Arrays.asList("1,db1_tb1,18");
+        String sql1 = "SELECT * FROM test_e2e_mysql_db1.tbl1";
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, initExpected1, sql1, 3, false);
+
+        List<String> initExpected2 = Arrays.asList("1,db1_tb2,19");
+        String sql2 = "SELECT * FROM test_e2e_mysql_db1.tbl2";
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, initExpected2, sql2, 3, false);
+
+        List<String> initExpected3 = Arrays.asList("1,db2_tb1,20");
+        String sql3 = "SELECT * FROM test_e2e_mysql_db2.tbl1";
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, initExpected3, sql3, 3, false);
+
+        List<String> initExpected4 = Arrays.asList("1,db2_tb2,21");
+        String sql4 = "SELECT * FROM test_e2e_mysql_db2.tbl2";
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, initExpected4, sql4, 3, false);
+
+        List<String> initExpected5 = Arrays.asList("1,db2_tb3,22");
+        String sql5 = "SELECT * FROM test_e2e_mysql_db2.tbl3";
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, initExpected5, sql5, 3, false);
 
         // add incremental data
         ContainerUtils.executeSQLStatement(
@@ -449,20 +464,89 @@ public class Mysql2DorisE2ECase extends AbstractE2EService {
                 "insert into test_e2e_mysql_db1.tbl1 values (2,'db1_tb1',180)",
                 "insert into test_e2e_mysql_db1.tbl2 values (2,'db1_tb2',190)",
                 "insert into test_e2e_mysql_db2.tbl1 values (2,'db2_tb1',200)",
-                "insert into test_e2e_mysql_db2.tbl2 values (2,'db2_tb2',210)");
+                "insert into test_e2e_mysql_db2.tbl2 values (2,'db2_tb2',210)",
+                "insert into test_e2e_mysql_db2.tbl3 values (2,'db2_tb3',220)");
 
         Thread.sleep(20000);
-        List<String> expected =
+        List<String> incrExpected1 = Arrays.asList("1,db1_tb1,18", "2,db1_tb1,180");
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, incrExpected1, sql1, 3, false);
+
+        List<String> incrExpected2 = Arrays.asList("1,db1_tb2,19", "2,db1_tb2,190");
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, incrExpected2, sql2, 3, false);
+
+        List<String> incrExpected3 = Arrays.asList("1,db2_tb1,20", "2,db2_tb1,200");
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, incrExpected3, sql3, 3, false);
+
+        List<String> incrExpected4 = Arrays.asList("1,db2_tb2,21", "2,db2_tb2,210");
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, incrExpected4, sql4, 3, false);
+
+        List<String> incrExpected5 = Arrays.asList("1,db2_tb3,22", "2,db2_tb3,220");
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, incrExpected5, sql5, 3, false);
+
+        cancelE2EJob(jobName);
+    }
+
+    /**
+     * Separate databases and tables to write to the same database and table
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testMySQL2DorisMultiDatabase2OneSync() throws Exception {
+        String jobName = "testMySQL2DorisMultiDatabase2OneSync";
+        initEnvironment(jobName, "container/e2e/mysql2doris/testMySQL2DorisMultiDb2One_init.sql");
+        startMysql2DorisJob(jobName, "container/e2e/mysql2doris/testMySQL2DorisMultiDb2One.txt");
+
+        // wait 3 times checkpoint
+        Thread.sleep(30000);
+        LOG.info("Start to verify init result.");
+        List<String> initExpected = Arrays.asList("1,db1_tb1,18", "2,db2_tb1,20");
+        String sql1 = "SELECT * FROM test_e2e_mysql.tbl1";
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, initExpected, sql1, 3, false);
+
+        List<String> initExpected2 =
                 Arrays.asList(
-                        "1,db1_tb1,18",
-                        "1,db1_tb2,19",
-                        "1,db2_tb1,20",
-                        "1,db2_tb2,21",
-                        "2,db1_tb1,180",
-                        "2,db1_tb2,190",
-                        "2,db2_tb1,200",
-                        "2,db2_tb2,210");
-        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, expected, sql, 3);
+                        "1,db1_tb2_1,19", "2,db1_tb2_2,191", "3,db2_tb2_2,21", "4,db2_tbl2_2,211");
+        String sql2 = "SELECT * FROM test_e2e_mysql.tbl2_merge";
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, initExpected2, sql2, 3, false);
+
+        List<String> initExpected3 = Arrays.asList("1,db2_tb3,22");
+        String sql3 = "SELECT * FROM test_e2e_mysql.tbl3";
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, initExpected3, sql3, 3, false);
+
+        // add incremental data
+        ContainerUtils.executeSQLStatement(
+                getMySQLQueryConnection(),
+                LOG,
+                "insert into test_e2e_mysql_db1.tbl1 values (3,'db1_tb1',180)",
+                "insert into test_e2e_mysql_db2.tbl1 values (4,'db2_tb1',200)",
+                "insert into test_e2e_mysql_db1.tbl2_1 values (5,'db1_tb2_1',1901)",
+                "insert into test_e2e_mysql_db1.tbl2_2 values (6,'db1_tb2_2',1902)",
+                "insert into test_e2e_mysql_db2.tbl2_1 values (7,'db2_tb2_1',2101)",
+                "insert into test_e2e_mysql_db2.tbl2_2 values (8,'db2_tb2_2',2102)",
+                "insert into test_e2e_mysql_db2.tbl3 values (3,'db2_tb3',220)");
+
+        Thread.sleep(20000);
+
+        List<String> incrExpected =
+                Arrays.asList("1,db1_tb1,18", "2,db2_tb1,20", "3,db1_tb1,180", "4,db2_tb1,200");
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, incrExpected, sql1, 3, false);
+
+        List<String> incrExpected2 =
+                Arrays.asList(
+                        "1,db1_tb2_1,19",
+                        "2,db1_tb2_2,191",
+                        "3,db2_tb2_2,21",
+                        "4,db2_tbl2_2,211",
+                        "5,db1_tb2_1,1901",
+                        "6,db1_tb2_2,1902",
+                        "7,db2_tb2_1,2101",
+                        "8,db2_tb2_2,2102");
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, incrExpected2, sql2, 3, false);
+
+        List<String> incrExpected3 = Arrays.asList("1,db2_tb3,22", "3,db2_tb3,220");
+        ContainerUtils.checkResult(getDorisQueryConnection(), LOG, incrExpected3, sql3, 3, false);
+
         cancelE2EJob(jobName);
     }
 

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoParsingProcessFunctionTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoParsingProcessFunctionTest.java
@@ -28,7 +28,7 @@ public class MongoParsingProcessFunctionTest {
         String record =
                 "{\"_id\":\"{\\\"_id\\\": {\\\"$oid\\\": \\\"66583533791a67a6f8c5a339\\\"}}\",\"operationType\":\"insert\",\"fullDocument\":\"{\\\"_id\\\": {\\\"$oid\\\": \\\"66583533791a67a6f8c5a339\\\"}, \\\"key1\\\": \\\"value1\\\"}\",\"source\":{\"ts_ms\":0,\"snapshot\":\"true\"},\"ts_ms\":1717065582062,\"ns\":{\"db\":\"test\",\"coll\":\"cdc_test\"},\"to\":null,\"documentKey\":\"{\\\"_id\\\": {\\\"$oid\\\": \\\"66583533791a67a6f8c5a339\\\"}}\",\"updateDescription\":null,\"clusterTime\":null,\"txnNumber\":null,\"lsid\":null}";
         MongoParsingProcessFunction mongoParsingProcessFunction =
-                new MongoParsingProcessFunction(null);
+                new MongoParsingProcessFunction(null, null);
         String recordTableName = mongoParsingProcessFunction.getRecordTableName(record);
         assertEquals("cdc_test", recordTableName);
     }

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testAutoAddTable.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testAutoAddTable.txt
@@ -1,4 +1,6 @@
 mysql-sync-database
+    --database test_e2e_mysql
+    --mysql-conf database-name=test_e2e_mysql
     --including-tables "tbl.*|auto_add"
     --table-conf replication_num=1
     --single-sink true

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testAutoAddTable_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testAutoAddTable_init.sql
@@ -1,3 +1,4 @@
+DROP DATABASE if EXISTS test_e2e_mysql;
 CREATE DATABASE if NOT EXISTS test_e2e_mysql;
 DROP TABLE IF EXISTS test_e2e_mysql.tbl1;
 CREATE TABLE test_e2e_mysql.tbl1 (

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2Doris.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2Doris.txt
@@ -1,4 +1,6 @@
 mysql-sync-database
+    --database test_e2e_mysql
+    --mysql-conf database-name=test_e2e_mysql
     --including-tables "tbl.*"
     --table-conf replication_num=1
     --single-sink true

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisByDefault.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisByDefault.txt
@@ -1,3 +1,5 @@
 mysql-sync-database
+    --database test_e2e_mysql
+    --mysql-conf database-name=test_e2e_mysql
     --including-tables "tbl1|tbl2|tbl3|tbl5"
     --table-conf replication_num=1

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisByDefault_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisByDefault_init.sql
@@ -1,3 +1,4 @@
+DROP DATABASE if EXISTS test_e2e_mysql;
 CREATE DATABASE if NOT EXISTS test_e2e_mysql;
 DROP TABLE IF EXISTS test_e2e_mysql.tbl1;
 CREATE TABLE test_e2e_mysql.tbl1 (

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisCreateTable.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisCreateTable.txt
@@ -1,4 +1,6 @@
 mysql-sync-database
+    --database test_e2e_mysql
+    --mysql-conf database-name=test_e2e_mysql
     --including-tables "create_tbl_.*"
     --create-table-only
     --table-conf table-buckets=create_tbl_uniq:10,create_tbl_from_uniqindex.*:30

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisCreateTable_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisCreateTable_init.sql
@@ -1,3 +1,4 @@
+DROP DATABASE if EXISTS test_e2e_mysql;
 CREATE DATABASE if NOT EXISTS test_e2e_mysql;
 DROP TABLE IF EXISTS test_e2e_mysql.create_tbl_uniq;
 CREATE TABLE test_e2e_mysql.create_tbl_uniq (

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisEnableDelete.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisEnableDelete.txt
@@ -1,4 +1,6 @@
 mysql-sync-database
+    --database test_e2e_mysql
+    --mysql-conf database-name=test_e2e_mysql
     --including-tables "tbl1|tbl2|tbl3|tbl5"
     --table-conf replication_num=1
     --sink-conf sink.enable-delete=false

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisEnableDelete_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisEnableDelete_init.sql
@@ -1,3 +1,4 @@
+DROP DATABASE if EXISTS test_e2e_mysql;
 CREATE DATABASE if NOT EXISTS test_e2e_mysql;
 DROP TABLE IF EXISTS test_e2e_mysql.tbl1;
 CREATE TABLE test_e2e_mysql.tbl1 (

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDb2One.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDb2One.txt
@@ -1,6 +1,6 @@
 mysql-sync-database
     --database test_e2e_mysql
-    --mysql-conf database-name=test_e2e_mysql.*
+    --mysql-conf database-name=test_e2e_mysql_db.*
     --including-tables ".*"
     --multi-to-one-origin "tbl2.*"
     --multi-to-one-target "tbl2_merge"

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDb2One.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDb2One.txt
@@ -1,0 +1,7 @@
+mysql-sync-database
+    --database test_e2e_mysql
+    --mysql-conf database-name=test_e2e_mysql.*
+    --including-tables ".*"
+    --multi-to-one-origin "tbl2.*"
+    --multi-to-one-target "tbl2_merge"
+    --table-conf replication_num=1

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDb2One_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDb2One_init.sql
@@ -1,4 +1,5 @@
 -- tbl1
+DROP DATABASE if EXISTS test_e2e_mysql_db1;
 CREATE DATABASE if NOT EXISTS test_e2e_mysql_db1;
 DROP TABLE IF EXISTS test_e2e_mysql_db1.tbl1;
 CREATE TABLE test_e2e_mysql_db1.tbl1 (
@@ -9,6 +10,7 @@ PRIMARY KEY (`id`) USING BTREE
 );
 insert into test_e2e_mysql_db1.tbl1 values (1,'db1_tb1',18);
 
+DROP DATABASE if EXISTS test_e2e_mysql_db2;
 CREATE DATABASE if NOT EXISTS test_e2e_mysql_db2;
 DROP TABLE IF EXISTS test_e2e_mysql_db2.tbl1;
 CREATE TABLE test_e2e_mysql_db2.tbl1 (

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDb2One_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDb2One_init.sql
@@ -1,0 +1,68 @@
+-- tbl1
+CREATE DATABASE if NOT EXISTS test_e2e_mysql_db1;
+DROP TABLE IF EXISTS test_e2e_mysql_db1.tbl1;
+CREATE TABLE test_e2e_mysql_db1.tbl1 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db1.tbl1 values (1,'db1_tb1',18);
+
+CREATE DATABASE if NOT EXISTS test_e2e_mysql_db2;
+DROP TABLE IF EXISTS test_e2e_mysql_db2.tbl1;
+CREATE TABLE test_e2e_mysql_db2.tbl1 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db2.tbl1 values (2,'db2_tb1',20);
+
+-- tbl2_1 tbl2_2
+DROP TABLE IF EXISTS test_e2e_mysql_db1.tbl2_1;
+CREATE TABLE test_e2e_mysql_db1.tbl2_1 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db1.tbl2_1 values (1,'db1_tb2_1',19);
+
+DROP TABLE IF EXISTS test_e2e_mysql_db1.tbl2_2;
+CREATE TABLE test_e2e_mysql_db1.tbl2_2 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db1.tbl2_2 values (2,'db1_tb2_2',191);
+
+-- db2
+DROP TABLE IF EXISTS test_e2e_mysql_db2.tbl2_1;
+CREATE TABLE test_e2e_mysql_db2.tbl2_1 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db2.tbl2_1 values (3,'db2_tb2_2',21);
+
+DROP TABLE IF EXISTS test_e2e_mysql_db2.tbl2_2;
+CREATE TABLE test_e2e_mysql_db2.tbl2_2 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db2.tbl2_2 values (4,'db2_tbl2_2',211);
+
+
+DROP TABLE IF EXISTS test_e2e_mysql_db2.tbl3;
+CREATE TABLE test_e2e_mysql_db2.tbl3 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db2.tbl3 values (1,'db2_tb3',22);

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync.txt
@@ -1,5 +1,4 @@
 mysql-sync-database
-    --database test_e2e_mysql
     --mysql-conf database-name=test_e2e_mysql.*
     --including-tables ".*"
     --table-conf replication_num=1

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync.txt
@@ -1,0 +1,5 @@
+mysql-sync-database
+    --database test_e2e_mysql
+    --mysql-conf database-name=test_e2e_mysql.*
+    --including-tables ".*"
+    --table-conf replication_num=1

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync.txt
@@ -1,4 +1,4 @@
 mysql-sync-database
-    --mysql-conf database-name=test_e2e_mysql.*
+    --mysql-conf database-name=test_e2e_mysql_db.*
     --including-tables ".*"
     --table-conf replication_num=1

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync_init.sql
@@ -1,4 +1,5 @@
 -- db1
+DROP DATABASE if EXISTS test_e2e_mysql_db1;
 CREATE DATABASE if NOT EXISTS test_e2e_mysql_db1;
 DROP TABLE IF EXISTS test_e2e_mysql_db1.tbl1;
 CREATE TABLE test_e2e_mysql_db1.tbl1 (
@@ -20,6 +21,7 @@ PRIMARY KEY (`id`) USING BTREE
 insert into test_e2e_mysql_db1.tbl2 values (1,'db1_tb2',19);
 
 -- db2
+DROP DATABASE if EXISTS test_e2e_mysql_db2;
 CREATE DATABASE if NOT EXISTS test_e2e_mysql_db2;
 DROP TABLE IF EXISTS test_e2e_mysql_db2.tbl1;
 CREATE TABLE test_e2e_mysql_db2.tbl1 (

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync_init.sql
@@ -1,0 +1,40 @@
+-- db1
+CREATE DATABASE if NOT EXISTS test_e2e_mysql_db1;
+DROP TABLE IF EXISTS test_e2e_mysql_db1.tbl1;
+CREATE TABLE test_e2e_mysql_db1.tbl1 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db1.tbl1 values (1,'db1_tb1',18);
+
+
+DROP TABLE IF EXISTS test_e2e_mysql_db1.tbl2;
+CREATE TABLE test_e2e_mysql_db1.tbl2 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db1.tbl2 values (1,'db1_tb2',19);
+
+-- db2
+CREATE DATABASE if NOT EXISTS test_e2e_mysql_db2;
+DROP TABLE IF EXISTS test_e2e_mysql_db2.tbl1;
+CREATE TABLE test_e2e_mysql_db2.tbl1 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db2.tbl1 values (1,'db2_tb1',20);
+
+DROP TABLE IF EXISTS test_e2e_mysql_db2.tbl2;
+CREATE TABLE test_e2e_mysql_db2.tbl2 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db2.tbl2 values (1,'db2_tb2',21);

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisMultiDbSync_init.sql
@@ -38,3 +38,12 @@ CREATE TABLE test_e2e_mysql_db2.tbl2 (
 PRIMARY KEY (`id`) USING BTREE
 );
 insert into test_e2e_mysql_db2.tbl2 values (1,'db2_tb2',21);
+
+DROP TABLE IF EXISTS test_e2e_mysql_db2.tbl3;
+CREATE TABLE test_e2e_mysql_db2.tbl3 (
+`id` int NOT NULL,
+`name` varchar(255) DEFAULT NULL,
+`age` bigint DEFAULT NULL,
+PRIMARY KEY (`id`) USING BTREE
+);
+insert into test_e2e_mysql_db2.tbl3 values (1,'db2_tb3',22);

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisSQLParse.txt
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisSQLParse.txt
@@ -1,4 +1,6 @@
 mysql-sync-database
+    --database test_e2e_mysql
+    --mysql-conf database-name=test_e2e_mysql
     --including-tables "tbl.*|add_tbl"
     --table-conf replication_num=1
     --schema-change-mode sql_parser

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisSQLParse_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2DorisSQLParse_init.sql
@@ -1,3 +1,4 @@
+DROP DATABASE if EXISTS test_e2e_mysql;
 CREATE DATABASE if NOT EXISTS test_e2e_mysql;
 DROP TABLE IF EXISTS test_e2e_mysql.tbl1;
 CREATE TABLE test_e2e_mysql.tbl1 (

--- a/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2Doris_init.sql
+++ b/flink-doris-connector/src/test/resources/container/e2e/mysql2doris/testMySQL2Doris_init.sql
@@ -1,3 +1,4 @@
+DROP DATABASE if EXISTS test_e2e_mysql;
 CREATE DATABASE if NOT EXISTS test_e2e_mysql;
 DROP TABLE IF EXISTS test_e2e_mysql.tbl1;
 CREATE TABLE test_e2e_mysql.tbl1 (


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When synchronizing multiple databases, not writing --database may cause null pointer errors

When synchronizing multiple databases, there are two scenarios
1. Synchronize multiple upstream databases to one database of doris
```
--database dorisdb
--mysql-conf database-name db.*
```

Note: Currently, if multiple databases have tables with the same name, similar to the scenario of sharding, they will be written to the same downstream table

2. Write multiple upstream databases to multiple downstream databases
No need to specify `--database`
Just specify `--mysql-conf database-name db.*`


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
