### PR TITLE
[improve] Optimize MongoCDC sampleSize calculation logic

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSync.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSync.java
@@ -68,6 +68,18 @@ public class MongoDBDatabaseSync extends DatabaseSync {
                     .defaultValue(0.2)
                     .withDescription("mongo cdc sample percent");
 
+    public static final ConfigOption<Long> MONGO_CDC_MIN_SAMPLE_SIZE =
+            ConfigOptions.key("schema.min-sample-size")
+                    .longType()
+                    .defaultValue(1000L)
+                    .withDescription("mongo cdc min sample size");
+
+    public static final ConfigOption<Long> MONGO_CDC_MAX_SAMPLE_SIZE =
+            ConfigOptions.key("schema.max-sample-size")
+                    .longType()
+                    .defaultValue(100000L)
+                    .withDescription("mongo cdc max sample size");
+
     public static final ConfigOption<String> TABLE_NAME =
             ConfigOptions.key("table-name")
                     .stringType()
@@ -101,6 +113,8 @@ public class MongoDBDatabaseSync extends DatabaseSync {
 
         MongoClientSettings settings = settingsBuilder.build();
         Double samplePercent = config.get(MONGO_CDC_CREATE_SAMPLE_PERCENT);
+        Long minSampleSize = config.get(MONGO_CDC_MIN_SAMPLE_SIZE);
+        Long maxSampleSize = config.get(MONGO_CDC_MAX_SAMPLE_SIZE);
         try (MongoClient mongoClient = MongoClients.create(settings)) {
             MongoDatabase mongoDatabase = mongoClient.getDatabase(databaseName);
             MongoIterable<String> collectionNames = mongoDatabase.listCollectionNames();
@@ -115,7 +129,10 @@ public class MongoDBDatabaseSync extends DatabaseSync {
                 }
 
                 long totalDocuments = collection.estimatedDocumentCount();
-                long sampleSize = (long) Math.ceil(totalDocuments * samplePercent);
+                long sampleSize =
+                        calculateSampleSize(
+                                totalDocuments, samplePercent, minSampleSize, maxSampleSize);
+
                 ArrayList<Document> documents = sampleData(collection, sampleSize);
                 MongoDBSchema mongoDBSchema =
                         new MongoDBSchema(documents, databaseName, collectionName, null);
@@ -125,6 +142,19 @@ public class MongoDBDatabaseSync extends DatabaseSync {
         }
 
         return schemaList;
+    }
+
+    public long calculateSampleSize(
+            long totalDocuments, Double samplePercent, Long minSampleSize, Long maxSampleSize) {
+        if (totalDocuments < minSampleSize) {
+            return totalDocuments;
+        }
+        long sampleSize = (long) Math.ceil(totalDocuments * samplePercent);
+        // If the number of samples is less than the minimum threshold, the minimum threshold is
+        // used, while ensuring that the number of samples does not exceed the maximum threshold
+        sampleSize = Math.max(sampleSize, minSampleSize);
+        sampleSize = Math.min(sampleSize, maxSampleSize);
+        return sampleSize;
     }
 
     private ArrayList<Document> sampleData(MongoCollection<Document> collection, Long sampleNum) {

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSyncTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSyncTest.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.flink.tools.cdc.mongodb;
 
 import org.junit.Before;

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSyncTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSyncTest.java
@@ -1,0 +1,31 @@
+package org.apache.doris.flink.tools.cdc.mongodb;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+public class MongoDBDatabaseSyncTest {
+    private MongoDBDatabaseSync mongoDBDatabaseSync;
+
+    @Before
+    public void init() throws SQLException {
+        mongoDBDatabaseSync = new MongoDBDatabaseSync();
+    }
+
+    @Test
+    public void testCalculateSampleSize() {
+        long sampleSize1 = mongoDBDatabaseSync.calculateSampleSize(100L, 0.2, 1000L, 100000L);
+        long sampleSize2 = mongoDBDatabaseSync.calculateSampleSize(1000L, 0.2, 1000L, 100000L);
+        long sampleSize3 = mongoDBDatabaseSync.calculateSampleSize(2000L, 0.2, 1000L, 100000L);
+        long sampleSize4 = mongoDBDatabaseSync.calculateSampleSize(10000L, 0.2, 1000L, 100000L);
+        long sampleSize5 = mongoDBDatabaseSync.calculateSampleSize(1000000L, 0.2, 1000L, 100000L);
+        assertEquals(100, sampleSize1);
+        assertEquals(1000, sampleSize2);
+        assertEquals(1000, sampleSize3);
+        assertEquals(2000, sampleSize4);
+        assertEquals(100000, sampleSize5);
+    }
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #541

## Problem Summary:

Add MIN_SAMPLE_SIZE MAX_SAMPLE_SIZE parameters to dynamically adjust the size of sampleSize samples, so that it can sample more accurately when it is a small table, and consume less sampling resources when it is a large table

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
