### PR TITLE
修复doris.filter.query 无法使用字符串及新增分区过滤

### DIFF
--- a/flink-doris-connector/pom.xml
+++ b/flink-doris-connector/pom.xml
@@ -68,8 +68,8 @@ under the License.
 
     <properties>
         <revision>24.0.0-SNAPSHOT</revision>
-        <flink.version>1.18.0</flink.version>
-        <flink.major.version>1.18</flink.major.version>
+        <flink.version>1.16.2</flink.version>
+        <flink.major.version>1.16</flink.major.version>
         <flink.sql.cdc.version>3.1.1</flink.sql.cdc.version>
         <flink.python.id>flink-python</flink.python.id>
         <libthrift.version>0.16.0</libthrift.version>

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/ConfigurationOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/ConfigurationOptions.java
@@ -26,6 +26,8 @@ public interface ConfigurationOptions {
     String TABLE_IDENTIFIER = "table.identifier";
     String DORIS_READ_FIELD = "doris.read.field";
     String DORIS_FILTER_QUERY = "doris.filter.query";
+    // filter partition
+    String DORIS_FILTER_PARTITION = "doris.filter.partition";
     String DORIS_USER = "username";
     String DORIS_PASSWORD = "password";
     String DORIS_REQUEST_RETRIES = "doris.request.retries";

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisReadOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisReadOptions.java
@@ -27,6 +27,8 @@ public class DorisReadOptions implements Serializable {
 
     private String readFields;
     private String filterQuery;
+    // 增加分区过滤功能，减少查询数据量
+    private String filterPartition;
     private Integer requestTabletSize;
     private Integer requestConnectTimeoutMs;
     private Integer requestReadTimeoutMs;
@@ -43,6 +45,7 @@ public class DorisReadOptions implements Serializable {
     public DorisReadOptions(
             String readFields,
             String filterQuery,
+            String filterPartition,
             Integer requestTabletSize,
             Integer requestConnectTimeoutMs,
             Integer requestReadTimeoutMs,
@@ -57,6 +60,7 @@ public class DorisReadOptions implements Serializable {
             Integer flightSqlPort) {
         this.readFields = readFields;
         this.filterQuery = filterQuery;
+        this.filterPartition = filterPartition;
         this.requestTabletSize = requestTabletSize;
         this.requestConnectTimeoutMs = requestConnectTimeoutMs;
         this.requestReadTimeoutMs = requestReadTimeoutMs;
@@ -77,6 +81,10 @@ public class DorisReadOptions implements Serializable {
 
     public String getFilterQuery() {
         return filterQuery;
+    }
+
+    public String getFilterPartition() {
+        return filterPartition;
     }
 
     public Integer getRequestTabletSize() {
@@ -127,6 +135,10 @@ public class DorisReadOptions implements Serializable {
         this.filterQuery = filterQuery;
     }
 
+    public void setFilterPartition(String filterPartition) {
+        this.filterPartition = filterPartition;
+    }
+
     public boolean getUseFlightSql() {
         return useFlightSql;
     }
@@ -155,6 +167,7 @@ public class DorisReadOptions implements Serializable {
         return useOldApi == that.useOldApi
                 && Objects.equals(readFields, that.readFields)
                 && Objects.equals(filterQuery, that.filterQuery)
+                && Objects.equals(filterPartition, that.filterPartition)
                 && Objects.equals(requestTabletSize, that.requestTabletSize)
                 && Objects.equals(requestConnectTimeoutMs, that.requestConnectTimeoutMs)
                 && Objects.equals(requestReadTimeoutMs, that.requestReadTimeoutMs)
@@ -173,6 +186,7 @@ public class DorisReadOptions implements Serializable {
         return Objects.hash(
                 readFields,
                 filterQuery,
+                filterPartition,
                 requestTabletSize,
                 requestConnectTimeoutMs,
                 requestReadTimeoutMs,
@@ -191,6 +205,7 @@ public class DorisReadOptions implements Serializable {
         return new DorisReadOptions(
                 readFields,
                 filterQuery,
+                filterPartition,
                 requestTabletSize,
                 requestConnectTimeoutMs,
                 requestReadTimeoutMs,
@@ -210,6 +225,7 @@ public class DorisReadOptions implements Serializable {
 
         private String readFields;
         private String filterQuery;
+        private String filterPartition;
         private Integer requestTabletSize;
         private Integer requestConnectTimeoutMs;
         private Integer requestReadTimeoutMs;
@@ -242,6 +258,17 @@ public class DorisReadOptions implements Serializable {
          */
         public Builder setFilterQuery(String filterQuery) {
             this.filterQuery = filterQuery;
+            return this;
+        }
+
+        /**
+         * Sets the filterPartition for doris table to filter partition.
+         *
+         * @param filterPartition
+         * @return this DorisReadOptions.builder.
+         */
+        public Builder setFilterPartition(String filterPartition) {
+            this.filterPartition = filterPartition;
             return this;
         }
 
@@ -390,6 +417,7 @@ public class DorisReadOptions implements Serializable {
             return new DorisReadOptions(
                     readFields,
                     filterQuery,
+                    filterPartition,
                     requestTabletSize,
                     requestConnectTimeoutMs,
                     requestReadTimeoutMs,

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -573,9 +573,15 @@ public class RestService implements Serializable {
                         + "`.`"
                         + tableIdentifiers[1]
                         + "`";
+        // 将partition 拼接上去
+        if (!StringUtils.isEmpty(readOptions.getFilterPartition())) {
+            sql = sql + " partition (" + readOptions.getFilterPartition() + ")";
+        }
+
         if (!StringUtils.isEmpty(readOptions.getFilterQuery())) {
             sql += " where " + readOptions.getFilterQuery();
         }
+
         logger.info("Query SQL Sending to Doris FE is: '{}'.", sql);
         String[] tableIdentifier = parseIdentifier(options.getTableIdentifier(), logger);
         String queryPlanUri =

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -93,6 +93,14 @@ public class DorisConfigOptions {
                     .withDescription(
                             "Filter expression of the query, which is transparently transmitted to Doris. Doris uses this expression to complete source-side data filtering");
 
+    public static final ConfigOption<String> DORIS_FILTER_PARTITION =
+            ConfigOptions.key("doris.filter.partition")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Filter expression of partition, which is transparently transmitted to Doris. Doris uses "
+                                    + "this expression to complete source-side data partition filtering,example ``p20241201000000`,`p20241202000000``");
+
     @Deprecated
     public static final ConfigOption<String> DORIS_READ_FIELD =
             ConfigOptions.key("doris.read.field")

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
@@ -38,53 +38,7 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
-import static org.apache.doris.flink.table.DorisConfigOptions.AUTO_REDIRECT;
-import static org.apache.doris.flink.table.DorisConfigOptions.BENODES;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_BATCH_SIZE;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_ARROW_ASYNC;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_QUEUE_SIZE;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_EXEC_MEM_LIMIT;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_FILTER_QUERY;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_READ_FIELD;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_QUERY_TIMEOUT_S;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_READ_TIMEOUT_MS;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_RETRIES;
-import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_TABLET_SIZE;
-import static org.apache.doris.flink.table.DorisConfigOptions.FENODES;
-import static org.apache.doris.flink.table.DorisConfigOptions.FLIGHT_SQL_PORT;
-import static org.apache.doris.flink.table.DorisConfigOptions.IDENTIFIER;
-import static org.apache.doris.flink.table.DorisConfigOptions.JDBC_URL;
-import static org.apache.doris.flink.table.DorisConfigOptions.LOOKUP_CACHE_MAX_ROWS;
-import static org.apache.doris.flink.table.DorisConfigOptions.LOOKUP_CACHE_TTL;
-import static org.apache.doris.flink.table.DorisConfigOptions.LOOKUP_JDBC_ASYNC;
-import static org.apache.doris.flink.table.DorisConfigOptions.LOOKUP_JDBC_READ_BATCH_QUEUE_SIZE;
-import static org.apache.doris.flink.table.DorisConfigOptions.LOOKUP_JDBC_READ_BATCH_SIZE;
-import static org.apache.doris.flink.table.DorisConfigOptions.LOOKUP_JDBC_READ_THREAD_SIZE;
-import static org.apache.doris.flink.table.DorisConfigOptions.LOOKUP_MAX_RETRIES;
-import static org.apache.doris.flink.table.DorisConfigOptions.PASSWORD;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_BUFFER_COUNT;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_BUFFER_FLUSH_INTERVAL;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_BUFFER_FLUSH_MAX_BYTES;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_BUFFER_SIZE;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_CHECK_INTERVAL;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_ENABLE_2PC;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_ENABLE_BATCH_MODE;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_ENABLE_DELETE;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_FLUSH_QUEUE_SIZE;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_IGNORE_COMMIT_ERROR;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_IGNORE_UPDATE_BEFORE;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_LABEL_PREFIX;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_MAX_RETRIES;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_PARALLELISM;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_USE_CACHE;
-import static org.apache.doris.flink.table.DorisConfigOptions.SINK_WRITE_MODE;
-import static org.apache.doris.flink.table.DorisConfigOptions.SOURCE_USE_OLD_API;
-import static org.apache.doris.flink.table.DorisConfigOptions.STREAM_LOAD_PROP_PREFIX;
-import static org.apache.doris.flink.table.DorisConfigOptions.TABLE_IDENTIFIER;
-import static org.apache.doris.flink.table.DorisConfigOptions.USERNAME;
-import static org.apache.doris.flink.table.DorisConfigOptions.USE_FLIGHT_SQL;
+import static org.apache.doris.flink.table.DorisConfigOptions.*;
 
 /**
  * The {@link DorisDynamicTableFactory} translates the catalog table to a table source.
@@ -121,6 +75,7 @@ public final class DorisDynamicTableFactory
 
         options.add(DORIS_READ_FIELD);
         options.add(DORIS_FILTER_QUERY);
+        options.add(DORIS_FILTER_PARTITION);
         options.add(DORIS_TABLET_SIZE);
         options.add(DORIS_REQUEST_CONNECT_TIMEOUT_MS);
         options.add(DORIS_REQUEST_READ_TIMEOUT_MS);
@@ -210,7 +165,10 @@ public final class DorisDynamicTableFactory
         builder.setDeserializeArrowAsync(readableConfig.get(DORIS_DESERIALIZE_ARROW_ASYNC))
                 .setDeserializeQueueSize(readableConfig.get(DORIS_DESERIALIZE_QUEUE_SIZE))
                 .setExecMemLimit(readableConfig.get(DORIS_EXEC_MEM_LIMIT).getBytes())
-                .setFilterQuery(readableConfig.get(DORIS_FILTER_QUERY))
+                // 将filter中的双引号替换为单引
+                .setFilterQuery(readableConfig.get(DORIS_FILTER_QUERY).replaceAll("\"", "'"))
+                // 将partition filter传递下去
+                .setFilterPartition(readableConfig.get(DORIS_FILTER_PARTITION))
                 .setReadFields(readableConfig.get(DORIS_READ_FIELD))
                 .setRequestQueryTimeoutS(
                         (int) readableConfig.get(DORIS_REQUEST_QUERY_TIMEOUT_S).getSeconds())

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
@@ -165,9 +165,7 @@ public final class DorisDynamicTableFactory
         builder.setDeserializeArrowAsync(readableConfig.get(DORIS_DESERIALIZE_ARROW_ASYNC))
                 .setDeserializeQueueSize(readableConfig.get(DORIS_DESERIALIZE_QUEUE_SIZE))
                 .setExecMemLimit(readableConfig.get(DORIS_EXEC_MEM_LIMIT).getBytes())
-                // 将filter中的双引号替换为单引
-                .setFilterQuery(readableConfig.get(DORIS_FILTER_QUERY).replaceAll("\"", "'"))
-                // 将partition filter传递下去
+                 // 将partition filter传递下去
                 .setFilterPartition(readableConfig.get(DORIS_FILTER_PARTITION))
                 .setReadFields(readableConfig.get(DORIS_READ_FIELD))
                 .setRequestQueryTimeoutS(
@@ -182,6 +180,10 @@ public final class DorisDynamicTableFactory
                 .setUseOldApi(readableConfig.get(SOURCE_USE_OLD_API))
                 .setUseFlightSql(readableConfig.get(USE_FLIGHT_SQL))
                 .setFlightSqlPort(readableConfig.get(FLIGHT_SQL_PORT));
+        if(readableConfig.get(DORIS_FILTER_QUERY)!=null){
+            // 将filter中的双引号替换为单引
+            builder.setFilterQuery(readableConfig.get(DORIS_FILTER_QUERY).replaceAll("\"", "'"));
+        }
         return builder.build();
     }
 


### PR DESCRIPTION

1、修复无法使用doris.filter.query对字符串类型字段过滤；
'doris.filter.query' = 'other_info=\"step_01\" and comments=\"query\"'
2、增加doris.filter.partition对分区数据进行筛选。
'doris.filter.partition' = '`p20241201000000`,`p20241202000000`'
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
   No
3. Has unit tests been added: (Yes/No/No Need)
 No
5. Has document been added or modified: (Yes/No/No Need)
 No,
6. Does it need to update dependencies: (Yes/No)
No
7. Are there any changes that cannot be rolled back: (Yes/No)
 No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
