### PR TITLE
[Improvement] add resposne ignore field config

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/BackendV2.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/BackendV2.java
@@ -37,6 +37,7 @@ public class BackendV2 {
         this.backends = backends;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class BackendRowV2 {
         @JsonProperty("ip")
         public String ip;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Field.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Field.java
@@ -17,8 +17,10 @@
 
 package org.apache.doris.flink.rest.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Field {
     @JsonProperty(value = "name")
     private String name;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/QueryPlan.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/QueryPlan.java
@@ -17,10 +17,12 @@
 
 package org.apache.doris.flink.rest.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class QueryPlan {
     @JsonProperty(value = "status")
     private int status;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Schema.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Schema.java
@@ -17,9 +17,12 @@
 
 package org.apache.doris.flink.rest.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Schema {
     private int status = 0;
     private String keysType;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Tablet.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/models/Tablet.java
@@ -17,8 +17,11 @@
 
 package org.apache.doris.flink.rest.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Tablet {
     private List<String> routings;
     private int version;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

In some cases, the API will return more fields, like https://github.com/apache/doris/pull/46557. In this case, strict validation may result in errors. We can set it to ignore.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
