### PR TITLE
[improve] Concat doris.filter.query option when push down 

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -615,12 +615,12 @@ public class RestService implements Serializable {
         }
 
         if (queryPlan == null) {
-            logger.error(SHOULD_NOT_HAPPEN_MESSAGE);
+            logger.error(SHOULD_NOT_HAPPEN_MESSAGE + " res: " + response);
             throw new ShouldNeverHappenException();
         }
 
         if (queryPlan.getStatus() != REST_RESPONSE_STATUS_OK) {
-            String errMsg = "Doris FE's response is not OK, status is " + queryPlan.getStatus();
+            String errMsg = "Doris FE's response is not OK, res: " + response;
             logger.error(errMsg);
             throw new DorisException(errMsg);
         }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSource.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSource.java
@@ -90,8 +90,12 @@ public final class DorisDynamicTableSource
 
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
-        if (StringUtils.isNullOrWhitespaceOnly(readOptions.getFilterQuery())) {
+        if (!resolvedFilterQuery.isEmpty()) {
             String filterQuery = resolvedFilterQuery.stream().collect(Collectors.joining(" AND "));
+            if (!StringUtils.isNullOrWhitespaceOnly(readOptions.getFilterQuery())) {
+                filterQuery =
+                        String.format("(%s) AND (%s)", readOptions.getFilterQuery(), filterQuery);
+            }
             readOptions.setFilterQuery(filterQuery);
         }
 
@@ -195,8 +199,7 @@ public final class DorisDynamicTableSource
         DorisExpressionVisitor expressionVisitor = new DorisExpressionVisitor();
         for (ResolvedExpression filter : filters) {
             String filterQuery = filter.accept(expressionVisitor);
-            if (StringUtils.isNullOrWhitespaceOnly(readOptions.getFilterQuery())
-                    && !StringUtils.isNullOrWhitespaceOnly(filterQuery)) {
+            if (!StringUtils.isNullOrWhitespaceOnly(filterQuery)) {
                 acceptedFilters.add(filter);
                 this.resolvedFilterQuery.add(filterQuery);
             } else {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #545 

## Problem Summary:

Currently, pushdown can only push down predicates.
For example, the calculation of complex functions also needs to be pushed down, but such functions cannot be exhaustive, so you can use the previous doris.filter.query option to splice the pushed down and the user-input to complete the function pushdown.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
