### PR TITLE
[Improve] add partial limit push down

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisReadOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisReadOptions.java
@@ -39,6 +39,8 @@ public class DorisReadOptions implements Serializable {
     private boolean useOldApi;
     private boolean useFlightSql;
     private Integer flightSqlPort;
+    // for flink sql limit push down
+    private Long rowLimit;
 
     public DorisReadOptions(
             String readFields,
@@ -54,7 +56,8 @@ public class DorisReadOptions implements Serializable {
             Boolean deserializeArrowAsync,
             boolean useOldApi,
             boolean useFlightSql,
-            Integer flightSqlPort) {
+            Integer flightSqlPort,
+            Long rowLimit) {
         this.readFields = readFields;
         this.filterQuery = filterQuery;
         this.requestTabletSize = requestTabletSize;
@@ -69,6 +72,7 @@ public class DorisReadOptions implements Serializable {
         this.useOldApi = useOldApi;
         this.useFlightSql = useFlightSql;
         this.flightSqlPort = flightSqlPort;
+        this.rowLimit = rowLimit;
     }
 
     public String getReadFields() {
@@ -135,6 +139,14 @@ public class DorisReadOptions implements Serializable {
         return flightSqlPort;
     }
 
+    public Long getRowLimit() {
+        return rowLimit;
+    }
+
+    public void setRowLimit(Long rowLimit) {
+        this.rowLimit = rowLimit;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -165,7 +177,8 @@ public class DorisReadOptions implements Serializable {
                 && Objects.equals(deserializeQueueSize, that.deserializeQueueSize)
                 && Objects.equals(deserializeArrowAsync, that.deserializeArrowAsync)
                 && Objects.equals(useFlightSql, that.useFlightSql)
-                && Objects.equals(flightSqlPort, that.flightSqlPort);
+                && Objects.equals(flightSqlPort, that.flightSqlPort)
+                && Objects.equals(rowLimit, that.rowLimit);
     }
 
     @Override
@@ -184,7 +197,8 @@ public class DorisReadOptions implements Serializable {
                 deserializeArrowAsync,
                 useOldApi,
                 useFlightSql,
-                flightSqlPort);
+                flightSqlPort,
+                rowLimit);
     }
 
     public DorisReadOptions copy() {
@@ -202,7 +216,8 @@ public class DorisReadOptions implements Serializable {
                 deserializeArrowAsync,
                 useOldApi,
                 useFlightSql,
-                flightSqlPort);
+                flightSqlPort,
+                rowLimit);
     }
 
     /** Builder of {@link DorisReadOptions}. */
@@ -227,6 +242,7 @@ public class DorisReadOptions implements Serializable {
         private Boolean useOldApi = false;
         private Boolean useFlightSql = ConfigurationOptions.USE_FLIGHT_SQL_DEFAULT;
         private Integer flightSqlPort;
+        private Long rowLimit;
 
         /**
          * Sets the readFields for doris table to push down projection, such as name,age.
@@ -406,7 +422,8 @@ public class DorisReadOptions implements Serializable {
                     deserializeArrowAsync,
                     useOldApi,
                     useFlightSql,
-                    flightSqlPort);
+                    flightSqlPort,
+                    rowLimit);
         }
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/DorisFlightValueReader.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/DorisFlightValueReader.java
@@ -132,6 +132,11 @@ public class DorisFlightValueReader extends ValueReader implements AutoCloseable
         if (!StringUtils.isEmpty(readOptions.getFilterQuery())) {
             sql += " WHERE " + readOptions.getFilterQuery();
         }
+
+        if (readOptions.getRowLimit() != null) {
+            sql += " LIMIT " + readOptions.getRowLimit();
+        }
+
         logger.info("Query SQL Sending to Doris FE is: '{}'.", sql);
         return sql;
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/DorisValueReader.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/source/reader/DorisValueReader.java
@@ -74,6 +74,7 @@ public class DorisValueReader extends ValueReader implements AutoCloseable {
     protected String contextId;
     protected Schema schema;
     protected boolean asyncThreadStarted;
+    private long readRowCount = 0L;
 
     public DorisValueReader(
             PartitionDefinition partition, DorisOptions options, DorisReadOptions readOptions) {
@@ -210,6 +211,10 @@ public class DorisValueReader extends ValueReader implements AutoCloseable {
      * @return true if hax next value
      */
     public boolean hasNext() {
+        if (readOptions.getRowLimit() != null && readRowCount >= readOptions.getRowLimit()) {
+            return false;
+        }
+
         boolean hasNext = false;
         if (deserializeArrowToRowBatchAsync && asyncThreadStarted) {
             // support deserialize Arrow to RowBatch asynchronously
@@ -275,6 +280,7 @@ public class DorisValueReader extends ValueReader implements AutoCloseable {
             LOG.error(SHOULD_NOT_HAPPEN_MESSAGE);
             throw new ShouldNeverHappenException();
         }
+        readRowCount++;
         return rowBatch.next();
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSource.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisDynamicTableSource.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.SourceProvider;
 import org.apache.flink.table.connector.source.TableFunctionProvider;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
@@ -58,7 +59,8 @@ public final class DorisDynamicTableSource
         implements ScanTableSource,
                 LookupTableSource,
                 SupportsFilterPushDown,
-                SupportsProjectionPushDown {
+                SupportsProjectionPushDown,
+                SupportsLimitPushDown {
 
     private static final Logger LOG = LoggerFactory.getLogger(DorisDynamicTableSource.class);
     private final DorisOptions options;
@@ -252,5 +254,11 @@ public final class DorisDynamicTableSource
                 physicalSchema,
                 resolvedFilterQuery,
                 physicalRowDataType);
+    }
+
+    @Override
+    public void applyLimit(long limit) {
+        // partial limit push down to reduce the amount of data scanned
+        readOptions.setRowLimit(limit);
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

There is the following flinksql
```select * from table limit 10```

When doris has a large data table, it will first scan all the data in the table, and then make a limit.

Here you can push the limit down to reduce the amount of data scanned.

Note that this is only partially pushed down, so the scanned data and the limit value may not be equal (For example, under multiple tablets, the scanned data will be greater than the limit value), and it will eventually rely on the upper-level Limit of FlinkSQL to do it

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
