### PR TITLE
[Fix] improve batch mode when streamload failed

### DIFF
--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
@@ -45,7 +45,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.doris.flink.sink.batch.TestBatchBufferStream.mergeByteArrays;
 import static org.mockito.ArgumentMatchers.any;
@@ -124,17 +123,10 @@ public class TestDorisBatchStreamLoad {
         when(httpClientBuilder.build()).thenReturn(httpClient);
         when(httpClient.execute(any())).thenReturn(response);
         loader.writeRecord("db", "tbl", "1,data".getBytes());
-        loader.checkpointFlush();
 
-        TestUtil.waitUntilCondition(
-                () -> !loader.isLoadThreadAlive(),
-                Deadline.fromNow(Duration.ofSeconds(20)),
-                100L,
-                "testLoadFail wait loader exit failed." + loader.isLoadThreadAlive());
-        AtomicReference<Throwable> exception = loader.getException();
-        Assert.assertTrue(exception.get() instanceof Exception);
-        Assert.assertTrue(exception.get().getMessage().contains("stream load error"));
-        LOG.info("testLoadFail end");
+        thrown.expect(Exception.class);
+        thrown.expectMessage("stream load error");
+        loader.checkpointFlush();
     }
 
     @Test
@@ -175,17 +167,10 @@ public class TestDorisBatchStreamLoad {
         when(httpClientBuilder.build()).thenReturn(httpClient);
         when(httpClient.execute(any())).thenReturn(response);
         loader.writeRecord("db", "tbl", "1,data".getBytes());
-        loader.checkpointFlush();
 
-        TestUtil.waitUntilCondition(
-                () -> !loader.isLoadThreadAlive(),
-                Deadline.fromNow(Duration.ofSeconds(20)),
-                100L,
-                "testLoadError wait loader exit failed." + loader.isLoadThreadAlive());
-        AtomicReference<Throwable> exception = loader.getException();
-        Assert.assertTrue(exception.get() instanceof Exception);
-        Assert.assertTrue(exception.get().getMessage().contains("stream load error"));
-        LOG.info("testLoadError end");
+        thrown.expect(Exception.class);
+        thrown.expectMessage("stream load error");
+        loader.checkpointFlush();
     }
 
     @After

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchWriter.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchWriter.java
@@ -57,7 +57,8 @@ public class TestDorisBatchWriter {
                         .build();
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("tableIdentifier input error");
-        DorisBatchWriter batchWriter = new DorisBatchWriter(null, null, options, null, null);
+        Sink.InitContext initContext = mock(Sink.InitContext.class);
+        DorisBatchWriter batchWriter = new DorisBatchWriter(initContext, null, options, null, null);
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1. When the checkpoint is flushed, the buffermap may be empty, but it is also necessary to wait for the load thread to complete.

2. When the streamload fails, before the flushqueue is cleared. The main thread is blocked at flushQueue.put(buffer); if the streamload fails at this time, the flushqueue will be cleared, and the main thread will be unblocked. Since there is no checkFlushException at this time, the checkpoint may be considered normal, and data may be lost later.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
