### PR TITLE
[optimize](load) optimize force flush threshold

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -84,8 +84,14 @@ public class DorisBatchStreamLoad implements Serializable {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final List<String> DORIS_SUCCESS_STATUS =
             new ArrayList<>(Arrays.asList(SUCCESS, PUBLISH_TIMEOUT));
-    private static final long STREAM_LOAD_MAX_BYTES = 10 * 1024 * 1024 * 1024L; // 10 GB
-    private static final long STREAM_LOAD_MAX_ROWS = Integer.MAX_VALUE;
+    // Set the force flush threshold to 0.85 to prevent stream load tasks from failing when the data
+    // size exceeds 10GB.
+    private static final double STREAM_LOAD_FORCE_FLUSH_THRESHOLD_RATIO = 0.85;
+    private static final long STREAM_LOAD_MAX_BYTES =
+            (long) (10 * 1024 * 1024 * 1024L * STREAM_LOAD_FORCE_FLUSH_THRESHOLD_RATIO);
+    private static final long STREAM_LOAD_MAX_ROWS =
+            (long) (Integer.MAX_VALUE * STREAM_LOAD_FORCE_FLUSH_THRESHOLD_RATIO);
+
     private final LabelGenerator labelGenerator;
     private final byte[] lineDelimiter;
     private static final String LOAD_URL_PATTERN = "http://%s/api/%s/%s/_stream_load";
@@ -224,7 +230,7 @@ public class DorisBatchStreamLoad implements Serializable {
                 || buffer.getNumOfRecords() >= STREAM_LOAD_MAX_ROWS) {
             // The buffer capacity exceeds the stream load limit, flush
             boolean flush = bufferFullFlush(bufferKey);
-            LOG.info("trigger flush by buffer exceeding the limit, flush: {}", flush);
+            LOG.info("trigger flush by buffer exceeding the threshold limit, flush: {}", flush);
         }
     }
 
@@ -244,11 +250,9 @@ public class DorisBatchStreamLoad implements Serializable {
             String bufferKey, boolean waitUtilDone, boolean bufferFull) {
         checkFlushException();
         if (waitUtilDone || bufferFull) {
-            boolean flush = flush(bufferKey, waitUtilDone);
-            return flush;
+            return flush(bufferKey, waitUtilDone);
         } else if (flushQueue.size() < executionOptions.getFlushQueueSize()) {
-            boolean flush = flush(bufferKey, false);
-            return flush;
+            return flush(bufferKey, false);
         }
         return false;
     }


### PR DESCRIPTION
# Proposed changes
The maximum stream load data is limited to 10GB by default in Apache Doris. If the data exceeds the `streaming_load_max_mb` limit, the task will fail. To prevent this issue, we can set a threshold for the stream load task to force a flush.

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
