### PR TITLE
[Featuer] support auto create table for shard table

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSchemaFactory.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSchemaFactory.java
@@ -255,10 +255,12 @@ public class DorisSchemaFactory {
     }
 
     public static String quoteDefaultValue(String defaultValue) {
-        // DEFAULT current_timestamp not need quote
-        if (defaultValue.equalsIgnoreCase("current_timestamp")) {
+        // DEFAULT current_timestamp or null not need quote
+        if (defaultValue.equalsIgnoreCase("current_timestamp")
+                || defaultValue.equalsIgnoreCase("null")) {
             return defaultValue;
         }
+
         return "'" + defaultValue + "'";
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/JsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/JsonDebeziumSchemaSerializer.java
@@ -38,6 +38,7 @@ import org.apache.doris.flink.sink.writer.serializer.jsondebezium.JsonDebeziumSc
 import org.apache.doris.flink.sink.writer.serializer.jsondebezium.JsonDebeziumSchemaChangeImplV2;
 import org.apache.doris.flink.sink.writer.serializer.jsondebezium.SQLParserSchemaChange;
 import org.apache.doris.flink.tools.cdc.DorisTableConfig;
+import org.apache.doris.flink.tools.cdc.converter.TableNameConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,6 +82,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
     private JsonDebeziumDataChange dataChange;
     private JsonDebeziumSchemaChange schemaChange;
     private SchemaChangeMode schemaChangeMode;
+    private TableNameConverter tableNameConverter;
     private final Set<String> initTableSet = new HashSet<>();
 
     public JsonDebeziumSchemaSerializer(
@@ -127,7 +129,8 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
             String targetDatabase,
             String targetTablePrefix,
             String targetTableSuffix,
-            SchemaChangeMode schemaChangeMode) {
+            SchemaChangeMode schemaChangeMode,
+            TableNameConverter tableNameConverter) {
         this(dorisOptions, pattern, sourceTableName, newSchemaChange, executionOptions);
         this.tableMapping = tableMapping;
         this.targetDatabase = targetDatabase;
@@ -135,6 +138,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         this.targetTableSuffix = targetTableSuffix;
         this.schemaChangeMode = schemaChangeMode;
         this.dorisTableConfig = dorisTableConfig;
+        this.tableNameConverter = tableNameConverter;
         init();
     }
 
@@ -152,7 +156,8 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
                         ignoreUpdateBefore,
                         targetTablePrefix,
                         targetTableSuffix,
-                        enableDelete);
+                        enableDelete,
+                        tableNameConverter);
         initSchemaChangeInstance(changeContext);
         this.dataChange = new JsonDebeziumDataChange(changeContext);
     }
@@ -233,6 +238,7 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
         private String targetDatabase;
         private String targetTablePrefix = "";
         private String targetTableSuffix = "";
+        private TableNameConverter tableNameConverter;
 
         public JsonDebeziumSchemaSerializer.Builder setDorisOptions(DorisOptions dorisOptions) {
             this.dorisOptions = dorisOptions;
@@ -302,6 +308,11 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
             return this;
         }
 
+        public Builder setTableNameConverter(TableNameConverter tableNameConverter) {
+            this.tableNameConverter = tableNameConverter;
+            return this;
+        }
+
         public JsonDebeziumSchemaSerializer build() {
             return new JsonDebeziumSchemaSerializer(
                     dorisOptions,
@@ -314,7 +325,8 @@ public class JsonDebeziumSchemaSerializer implements DorisRecordSerializer<Strin
                     targetDatabase,
                     targetTablePrefix,
                     targetTableSuffix,
-                    schemaChangeMode);
+                    schemaChangeMode,
+                    tableNameConverter);
         }
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
@@ -17,9 +17,12 @@
 
 package org.apache.doris.flink.sink.writer.serializer.jsondebezium;
 
+import org.apache.flink.annotation.VisibleForTesting;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.tools.cdc.DorisTableConfig;
+import org.apache.doris.flink.tools.cdc.converter.TableNameConverter;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -44,6 +47,7 @@ public class JsonDebeziumChangeContext implements Serializable {
     private final boolean enableDelete;
     private final String targetTablePrefix;
     private final String targetTableSuffix;
+    private TableNameConverter tableNameConverter;
 
     public JsonDebeziumChangeContext(
             DorisOptions dorisOptions,
@@ -70,6 +74,36 @@ public class JsonDebeziumChangeContext implements Serializable {
         this.enableDelete = enableDelete;
         this.targetTablePrefix = targetTablePrefix;
         this.targetTableSuffix = targetTableSuffix;
+    }
+
+    public JsonDebeziumChangeContext(
+            DorisOptions dorisOptions,
+            Map<String, String> tableMapping,
+            String sourceTableName,
+            String targetDatabase,
+            DorisTableConfig dorisTableConfig,
+            ObjectMapper objectMapper,
+            Pattern pattern,
+            String lineDelimiter,
+            boolean ignoreUpdateBefore,
+            String targetTablePrefix,
+            String targetTableSuffix,
+            boolean enableDelete,
+            TableNameConverter tableNameConverter) {
+        this(
+                dorisOptions,
+                tableMapping,
+                sourceTableName,
+                targetDatabase,
+                dorisTableConfig,
+                objectMapper,
+                pattern,
+                lineDelimiter,
+                ignoreUpdateBefore,
+                targetTablePrefix,
+                targetTableSuffix,
+                enableDelete);
+        this.tableNameConverter = tableNameConverter;
     }
 
     public DorisOptions getDorisOptions() {
@@ -119,11 +153,20 @@ public class JsonDebeziumChangeContext implements Serializable {
         return targetTableSuffix;
     }
 
+    public TableNameConverter getTableNameConverter() {
+        return tableNameConverter;
+    }
+
     public boolean enableDelete() {
         return enableDelete;
     }
 
     public DorisTableConfig getDorisTableConf() {
         return dorisTableConfig;
+    }
+
+    @VisibleForTesting
+    public void setTableNameConverter(TableNameConverter tableNameConverter) {
+        this.tableNameConverter = tableNameConverter;
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumSchemaChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumSchemaChange.java
@@ -33,6 +33,7 @@ import org.apache.doris.flink.sink.writer.EventType;
 import org.apache.doris.flink.tools.cdc.DorisTableConfig;
 import org.apache.doris.flink.tools.cdc.SourceConnector;
 import org.apache.doris.flink.tools.cdc.SourceSchema;
+import org.apache.doris.flink.tools.cdc.converter.TableNameConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +72,7 @@ public abstract class JsonDebeziumSchemaChange extends CdcSchemaChange {
     protected String targetTablePrefix;
     protected String targetTableSuffix;
     protected DorisTableConfig dorisTableConfig;
+    protected TableNameConverter tableNameConverter;
 
     public abstract boolean schemaChange(JsonNode recordRoot);
 
@@ -196,7 +198,13 @@ public abstract class JsonDebeziumSchemaChange extends CdcSchemaChange {
 
     protected String getCreateTableIdentifier(JsonNode record) {
         String table = extractJsonNode(record.get("source"), "table");
-        return targetDatabase + "." + targetTablePrefix + table + targetTableSuffix;
+        String createTblName;
+        if (tableNameConverter != null) {
+            createTblName = tableNameConverter.convert(table);
+        } else {
+            createTblName = targetTablePrefix + table + targetTableSuffix;
+        }
+        return targetDatabase + "." + createTblName;
     }
 
     public Map<String, String> getTableMapping() {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumSchemaChangeImplV2.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumSchemaChangeImplV2.java
@@ -88,6 +88,7 @@ public class JsonDebeziumSchemaChangeImplV2 extends JsonDebeziumSchemaChange {
                 changeContext.getTargetTableSuffix() == null
                         ? ""
                         : changeContext.getTargetTableSuffix();
+        this.tableNameConverter = changeContext.getTableNameConverter();
     }
 
     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/SQLParserSchemaChange.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/SQLParserSchemaChange.java
@@ -53,6 +53,7 @@ public class SQLParserSchemaChange extends JsonDebeziumSchemaChange {
                 changeContext.getTargetTableSuffix() == null
                         ? ""
                         : changeContext.getTargetTableSuffix();
+        this.tableNameConverter = changeContext.getTableNameConverter();
     }
 
     @Override

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/ParsingProcessFunction.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/ParsingProcessFunction.java
@@ -26,6 +26,7 @@ import org.apache.flink.util.StringUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.doris.flink.tools.cdc.converter.TableNameConverter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,10 +34,10 @@ import java.util.Map;
 public class ParsingProcessFunction extends ProcessFunction<String, Void> {
     protected ObjectMapper objectMapper = new ObjectMapper();
     private transient Map<String, OutputTag<String>> recordOutputTags;
-    private DatabaseSync.TableNameConverter converter;
+    private TableNameConverter converter;
     private String database;
 
-    public ParsingProcessFunction(String database, DatabaseSync.TableNameConverter converter) {
+    public ParsingProcessFunction(String database, TableNameConverter converter) {
         this.database = database;
         this.converter = converter;
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/converter/TableNameConverter.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/converter/TableNameConverter.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.tools.cdc.converter;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/*
+ * Convert the table name of the upstream data source to the table name of the doris database.
+ * */
+public class TableNameConverter implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private final String prefix;
+    private final String suffix;
+
+    // tbl_.*, tbl
+    private Map<Pattern, String> routeRules;
+
+    public TableNameConverter() {
+        this("", "");
+    }
+
+    public TableNameConverter(String prefix, String suffix) {
+        this.prefix = prefix == null ? "" : prefix;
+        this.suffix = suffix == null ? "" : suffix;
+    }
+
+    public TableNameConverter(String prefix, String suffix, Map<Pattern, String> routeRules) {
+        this.prefix = prefix == null ? "" : prefix;
+        this.suffix = suffix == null ? "" : suffix;
+        this.routeRules = routeRules;
+    }
+
+    public String convert(String tableName) {
+        if (routeRules == null) {
+            return prefix + tableName + suffix;
+        }
+
+        String target = null;
+
+        for (Map.Entry<Pattern, String> patternStringEntry : routeRules.entrySet()) {
+            if (patternStringEntry.getKey().matcher(tableName).matches()) {
+                target = patternStringEntry.getValue();
+            }
+        }
+        /**
+         * If routeRules is not null and target is not assigned, then the synchronization task
+         * contains both multi to one and one to one , prefixes and suffixes are added to common
+         * one-to-one mapping tables
+         */
+        if (target == null) {
+            return prefix + tableName + suffix;
+        }
+        return target;
+    }
+}

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoParsingProcessFunction.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoParsingProcessFunction.java
@@ -19,8 +19,8 @@ package org.apache.doris.flink.tools.cdc.mongodb;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
-import org.apache.doris.flink.tools.cdc.DatabaseSync.TableNameConverter;
 import org.apache.doris.flink.tools.cdc.ParsingProcessFunction;
+import org.apache.doris.flink.tools.cdc.converter.TableNameConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
# Proposed changes

In the current scenario of database and table sharding, when single-sink is enabled, 
the configurations for MultiToOneOrigin and MultiToOneTarget cannot be utilized during automatic table creation.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
