### PR TITLE
[Improve] DorisSource use arrowflightsql read type default

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/ConfigurationOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/ConfigurationOptions.java
@@ -54,8 +54,8 @@ public interface ConfigurationOptions {
     Integer DORIS_DESERIALIZE_QUEUE_SIZE_DEFAULT = 64;
 
     String USE_FLIGHT_SQL = "source.use-flight-sql";
-    Boolean USE_FLIGHT_SQL_DEFAULT = false;
+    Boolean USE_FLIGHT_SQL_DEFAULT = true;
 
     String FLIGHT_SQL_PORT = "source.flight-sql-port";
-    Integer FLIGHT_SQL_PORT_DEFAULT = 9040;
+    Integer FLIGHT_SQL_PORT_DEFAULT = -1;
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisReadOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisReadOptions.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.flink.cfg;
 
-import org.apache.flink.util.Preconditions;
-
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -141,6 +139,10 @@ public class DorisReadOptions implements Serializable {
         return flightSqlPort;
     }
 
+    public void setFlightSqlPort(Integer flightSqlPort) {
+        this.flightSqlPort = flightSqlPort;
+    }
+
     public Long getRowLimit() {
         return rowLimit;
     }
@@ -243,7 +245,7 @@ public class DorisReadOptions implements Serializable {
                 ConfigurationOptions.DORIS_DESERIALIZE_ARROW_ASYNC_DEFAULT;
         private Boolean useOldApi = false;
         private Boolean useFlightSql = ConfigurationOptions.USE_FLIGHT_SQL_DEFAULT;
-        private Integer flightSqlPort;
+        private Integer flightSqlPort = ConfigurationOptions.FLIGHT_SQL_PORT_DEFAULT;
         private Long rowLimit;
 
         /**
@@ -410,12 +412,6 @@ public class DorisReadOptions implements Serializable {
          * @return a DorisReadOptions with the settings made for this builder.
          */
         public DorisReadOptions build() {
-
-            if (useFlightSql) {
-                Preconditions.checkNotNull(
-                        flightSqlPort, "flight sql port must be set when use flight sql to read.");
-            }
-
             return new DorisReadOptions(
                     readFields,
                     filterQuery,

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -310,12 +310,12 @@ public class DorisConfigOptions {
     public static final ConfigOption<Boolean> USE_FLIGHT_SQL =
             ConfigOptions.key("source.use-flight-sql")
                     .booleanType()
-                    .defaultValue(Boolean.FALSE)
-                    .withDescription("use flight sql flag");
+                    .defaultValue(Boolean.TRUE)
+                    .withDescription("use arrow flight sql read");
     public static final ConfigOption<Integer> FLIGHT_SQL_PORT =
             ConfigOptions.key("source.flight-sql-port")
                     .intType()
-                    .defaultValue(9040)
+                    .defaultValue(-1)
                     .withDescription("flight sql port");
     // Prefix for Doris StreamLoad specific properties.
     public static final String STREAM_LOAD_PROP_PREFIX = "sink.properties.";

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/source/DorisSourceITCase.java
@@ -292,15 +292,13 @@ public class DorisSourceITCase extends AbstractITCaseService {
                                 + " 'doris.exec.mem.limit' = '2048mb',"
                                 + " 'doris.deserialize.arrow.async' = 'true',"
                                 + " 'doris.deserialize.queue.size' = '32',"
-                                + " 'source.use-flight-sql' = '%s',"
-                                + " 'source.flight-sql-port' = '%s'"
+                                + " 'source.use-flight-sql' = '%s'"
                                 + ")",
                         getFenodes(),
                         DATABASE + "." + TABLE_READ_TBL_ALL_OPTIONS,
                         getDorisUsername(),
                         getDorisPassword(),
-                        useFlightSql,
-                        flightSqlPort);
+                        useFlightSql);
         tEnv.executeSql(sourceDDL);
         TableResult tableResult = tEnv.executeSql("SELECT * FROM doris_source_all_options");
 
@@ -334,15 +332,13 @@ public class DorisSourceITCase extends AbstractITCaseService {
                                 + " 'table.identifier' = '%s',"
                                 + " 'username' = '%s',"
                                 + " 'password' = '%s',"
-                                + " 'source.use-flight-sql' = '%s',"
-                                + " 'source.flight-sql-port' = '%s'"
+                                + " 'source.use-flight-sql' = '%s'"
                                 + ")",
                         getFenodes(),
                         DATABASE + "." + TABLE_READ_TBL_PUSH_DOWN,
                         getDorisUsername(),
                         getDorisPassword(),
-                        useFlightSql,
-                        flightSqlPort);
+                        useFlightSql);
         tEnv.executeSql(sourceDDL);
         TableResult tableResult =
                 tEnv.executeSql(
@@ -516,15 +512,13 @@ public class DorisSourceITCase extends AbstractITCaseService {
                                 + " 'table.identifier' = '%s',"
                                 + " 'username' = '%s',"
                                 + " 'password' = '%s',"
-                                + " 'source.use-flight-sql' = '%s',"
-                                + " 'source.flight-sql-port' = '%s'"
+                                + " 'source.use-flight-sql' = '%s'"
                                 + ")",
                         getFenodes(),
                         DATABASE + "." + TABLE_READ_TBL_PUSH_DOWN_WITH_UNION_ALL,
                         getDorisUsername(),
                         getDorisPassword(),
-                        useFlightSql,
-                        flightSqlPort);
+                        useFlightSql);
         tEnv.executeSql(sourceDDL);
         String querySql =
                 "  SELECT * FROM doris_source_filter_with_union_all where age = '18'"

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableFactoryTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/table/DorisDynamicTableFactoryTest.java
@@ -40,6 +40,8 @@ import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_QUER
 import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT;
 import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT;
 import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_TABLET_SIZE_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.FLIGHT_SQL_PORT_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.USE_FLIGHT_SQL_DEFAULT;
 import static org.apache.doris.flink.utils.FactoryMocks.SCHEMA;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
@@ -65,8 +67,8 @@ public class DorisDynamicTableFactoryTest {
         properties.put("lookup.jdbc.read.batch.size", "16");
         properties.put("lookup.jdbc.read.batch.queue-size", "16");
         properties.put("lookup.jdbc.read.thread-size", "1");
-        properties.put("source.use-flight-sql", "false");
-        properties.put("source.flight-sql-port", "9040");
+        properties.put("source.use-flight-sql", "true");
+        properties.put("source.flight-sql-port", "-1");
         DynamicTableSource actual = createTableSource(SCHEMA, properties);
         DorisOptions options =
                 DorisOptions.builder()
@@ -100,8 +102,8 @@ public class DorisDynamicTableFactoryTest {
                 .setRequestReadTimeoutMs(DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT)
                 .setRequestRetries(DORIS_REQUEST_RETRIES_DEFAULT)
                 .setRequestTabletSize(DORIS_TABLET_SIZE_DEFAULT)
-                .setUseFlightSql(false)
-                .setFlightSqlPort(9040);
+                .setUseFlightSql(USE_FLIGHT_SQL_DEFAULT)
+                .setFlightSqlPort(FLIGHT_SQL_PORT_DEFAULT);
         DorisDynamicTableSource expected =
                 new DorisDynamicTableSource(
                         options,
@@ -186,8 +188,8 @@ public class DorisDynamicTableFactoryTest {
                 .setRequestReadTimeoutMs(DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT)
                 .setRequestRetries(DORIS_REQUEST_RETRIES_DEFAULT)
                 .setRequestTabletSize(DORIS_TABLET_SIZE_DEFAULT)
-                .setUseFlightSql(false)
-                .setFlightSqlPort(9040);
+                .setUseFlightSql(USE_FLIGHT_SQL_DEFAULT)
+                .setFlightSqlPort(FLIGHT_SQL_PORT_DEFAULT);
         DorisDynamicTableSink expected =
                 new DorisDynamicTableSink(
                         options,


### PR DESCRIPTION
# Proposed changes

By default, the reading method is changed to arrowflightsql. If the port is not obtained, it will degenerate to thrift reading.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
