### PR TITLE
[Improve](sink) Fix problems  may be caused by multi table import and add cases

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -34,7 +34,7 @@ public class DorisExecutionOptions implements Serializable {
 
     private static final long serialVersionUID = 1L;
     // 0 means disable checker thread
-    public static final int DEFAULT_CHECK_INTERVAL = 0;
+    public static final int DEFAULT_CHECK_INTERVAL = 10000;
     public static final int DEFAULT_MAX_RETRY_TIMES = 3;
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 1024;
     private static final int DEFAULT_BUFFER_COUNT = 3;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -216,9 +216,9 @@ public class DorisConfigOptions {
     public static final ConfigOption<Duration> SINK_CHECK_INTERVAL =
             ConfigOptions.key("sink.check-interval")
                     .durationType()
-                    .defaultValue(Duration.ofMillis(0))
+                    .defaultValue(Duration.ofMillis(10000))
                     .withDescription(
-                            "check exception with the interval while loading, The default is 0, disabling the checker thread");
+                            "check exception with the interval while loading, The default is 1s, 0 means disabling the checker thread");
     public static final ConfigOption<Integer> SINK_MAX_RETRIES =
             ConfigOptions.key("sink.max-retries")
                     .intType()

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/container/AbstractITCaseService.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/container/AbstractITCaseService.java
@@ -25,9 +25,18 @@ import org.apache.flink.runtime.highavailability.nonha.embedded.HaLeadershipCont
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.util.function.SupplierWithException;
 
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -39,7 +48,14 @@ public abstract class AbstractITCaseService extends AbstractContainerTestBase {
             JobClient client, List<JobStatus> expectedStatus, Deadline deadline) throws Exception {
         waitUntilCondition(
                 () -> {
-                    JobStatus currentStatus = (JobStatus) client.getJobStatus().get();
+                    JobStatus currentStatus;
+                    try {
+                        currentStatus = (JobStatus) client.getJobStatus().get();
+                    } catch (IllegalStateException e) {
+                        LOG.warn("Failed to get state, cause " + e.getMessage());
+                        currentStatus = JobStatus.FINISHED;
+                    }
+
                     if (expectedStatus.contains(currentStatus)) {
                         return true;
                     } else if (currentStatus.isTerminalState()) {
@@ -138,11 +154,67 @@ public abstract class AbstractITCaseService extends AbstractContainerTestBase {
         try {
             jobStatus = jobClient.getJobStatus().get();
         } catch (IllegalStateException e) {
-            LOG.info("Failed to get state, cause " + e.getMessage());
+            LOG.warn("Failed to get state, cause " + e.getMessage());
             jobStatus = JobStatus.FINISHED;
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }
         return jobStatus;
+    }
+
+    protected void faultInjectionOpen() throws IOException {
+        String pointName = "FlushToken.submit_flush_error";
+        String apiUrl =
+                String.format(
+                        "http://%s/api/debug_point/add/%s",
+                        dorisContainerService.getBenodes(), pointName);
+        HttpPost httpPost = new HttpPost(apiUrl);
+        httpPost.addHeader(
+                HttpHeaders.AUTHORIZATION,
+                auth(dorisContainerService.getUsername(), dorisContainerService.getPassword()));
+        try (CloseableHttpClient httpClient = HttpClients.custom().build()) {
+            try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                String reason = response.getStatusLine().toString();
+                if (statusCode == 200 && response.getEntity() != null) {
+                    LOG.info("Debug point response {}", EntityUtils.toString(response.getEntity()));
+                } else {
+                    LOG.info("Debug point failed, statusCode: {}, reason: {}", statusCode, reason);
+                }
+            }
+        }
+    }
+
+    protected void faultInjectionClear() throws IOException {
+        String apiUrl =
+                String.format(
+                        "http://%s/api/debug_point/clear", dorisContainerService.getBenodes());
+        HttpPost httpPost = new HttpPost(apiUrl);
+        httpPost.addHeader(
+                HttpHeaders.AUTHORIZATION,
+                auth(dorisContainerService.getUsername(), dorisContainerService.getPassword()));
+        try (CloseableHttpClient httpClient = HttpClients.custom().build()) {
+            try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                String reason = response.getStatusLine().toString();
+                if (statusCode == 200 && response.getEntity() != null) {
+                    LOG.info("Debug point response {}", EntityUtils.toString(response.getEntity()));
+                } else {
+                    LOG.info("Debug point failed, statusCode: {}, reason: {}", statusCode, reason);
+                }
+            }
+        }
+    }
+
+    protected String auth(String user, String password) {
+        final String authInfo = user + ":" + password;
+        byte[] encoded = Base64.encodeBase64(authInfo.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + new String(encoded);
+    }
+
+    protected enum FaultType {
+        RESTART_FAILURE,
+        STREAM_LOAD_FAILURE,
+        CHECKPOINT_FAILURE
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkMultiTblFailoverITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkMultiTblFailoverITCase.java
@@ -1,0 +1,277 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.container.AbstractITCaseService;
+import org.apache.doris.flink.container.ContainerUtils;
+import org.apache.doris.flink.sink.batch.RecordWithMeta;
+import org.apache.doris.flink.sink.writer.serializer.RecordWithMetaSerializer;
+import org.apache.doris.flink.utils.MockMultiTableSource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.api.common.JobStatus.RUNNING;
+
+/** DorisSink abnormal case of multi-table writing */
+@RunWith(Parameterized.class)
+public class DorisSinkMultiTblFailoverITCase extends AbstractITCaseService {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(DorisSinkMultiTblFailoverITCase.class);
+    static final String DATABASE = "test_multi_failover_sink";
+    static final String TABLE_MULTI_CSV = "tbl_multi_csv";
+    private final boolean batchMode;
+
+    public DorisSinkMultiTblFailoverITCase(boolean batchMode) {
+        this.batchMode = batchMode;
+    }
+
+    @Parameterized.Parameters(name = "batchMode: {0}")
+    public static Object[] parameters() {
+        return new Object[][] {new Object[] {false}, new Object[] {true}};
+    }
+
+    /**
+     * Four exceptions are simulated in one job 1. Add a table that does not exist 2. flink
+     * checkpoint failed 3. doris cluster restart 4. stream load fail
+     */
+    @Test
+    public void testDorisClusterFailoverSink() throws Exception {
+        int totalTblNum = 3;
+        for (int i = 1; i <= totalTblNum; i++) {
+            String tableName = TABLE_MULTI_CSV + i;
+            initializeTable(tableName);
+        }
+        int newTableIndex = totalTblNum + 1;
+        dropTable(TABLE_MULTI_CSV + newTableIndex);
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(DEFAULT_PARALLELISM);
+        int checkpointIntervalMs = 5000;
+        env.enableCheckpointing(checkpointIntervalMs);
+
+        Properties properties = new Properties();
+        properties.setProperty("column_separator", ",");
+        properties.setProperty("format", "csv");
+        DorisSink.Builder<RecordWithMeta> builder = DorisSink.builder();
+        DorisExecutionOptions.Builder executionBuilder = DorisExecutionOptions.builder();
+        executionBuilder
+                .setLabelPrefix(UUID.randomUUID().toString())
+                .enable2PC()
+                .setBatchMode(batchMode)
+                .setFlushQueueSize(4)
+                .setBufferSize(1024)
+                .setCheckInterval(1000)
+                .setStreamLoadProp(properties);
+        DorisOptions.Builder dorisBuilder = DorisOptions.builder();
+        dorisBuilder
+                .setFenodes(getFenodes())
+                .setTableIdentifier("")
+                .setUsername(getDorisUsername())
+                .setPassword(getDorisPassword());
+
+        builder.setDorisReadOptions(DorisReadOptions.builder().build())
+                .setDorisExecutionOptions(executionBuilder.build())
+                .setSerializer(new RecordWithMetaSerializer())
+                .setDorisOptions(dorisBuilder.build());
+
+        int triggerCkptError = 7;
+        int totalRecords = 20;
+        int addTblCheckpointId = 4;
+        DataStreamSource<RecordWithMeta> mockSource =
+                env.addSource(
+                        new MockMultiTableSource(
+                                totalRecords,
+                                triggerCkptError,
+                                DATABASE,
+                                TABLE_MULTI_CSV,
+                                totalTblNum,
+                                addTblCheckpointId));
+
+        mockSource.sinkTo(builder.build());
+        JobClient jobClient = env.executeAsync();
+        CompletableFuture<JobStatus> jobStatus = jobClient.getJobStatus();
+        LOG.info("Job status: {}", jobStatus);
+
+        waitForJobStatus(
+                jobClient,
+                Collections.singletonList(RUNNING),
+                Deadline.fromNow(Duration.ofSeconds(120)));
+
+        // wait checkpoint failure
+        List<JobStatus> errorStatus =
+                Arrays.asList(
+                        JobStatus.FAILING,
+                        JobStatus.CANCELLING,
+                        JobStatus.CANCELED,
+                        JobStatus.FAILED,
+                        JobStatus.RESTARTING);
+
+        waitForJobStatus(jobClient, errorStatus, Deadline.fromNow(Duration.ofSeconds(300)));
+
+        Random random = new Random();
+        LOG.info("start to create add table");
+        // random sleep to create table
+        Thread.sleep((checkpointIntervalMs / 1000 * random.nextInt(3)) * 1000);
+        // create new add table
+        initializeTable(TABLE_MULTI_CSV + newTableIndex);
+
+        LOG.info("wait job restart success");
+        // wait table restart success
+        waitForJobStatus(
+                jobClient,
+                Collections.singletonList(RUNNING),
+                Deadline.fromNow(Duration.ofSeconds(300)));
+
+        LOG.info("wait job running finished");
+
+        List<String> result = new ArrayList<>();
+        boolean restart = false;
+        boolean faultInjection = false;
+        while (true) {
+            try {
+                // restart may be make query failed
+                String query =
+                        String.format(
+                                "select * from %s",
+                                DATABASE + "." + TABLE_MULTI_CSV + newTableIndex);
+                result =
+                        ContainerUtils.executeSQLStatement(
+                                getDorisQueryConnection(), LOG, query, 2);
+            } catch (Exception ex) {
+                LOG.error("Failed to query result, cause " + ex.getMessage());
+                continue;
+            }
+
+            if (getFlinkJobStatus(jobClient).equals(JobStatus.FINISHED)) {
+                // Batch mode can only achieve at least once
+                break;
+            }
+
+            int randomSleepSec = random.nextInt(10);
+            if (result.size() > 2 && !faultInjection) {
+                faultInjectionOpen();
+                randomSleepSec = randomSleepSec + checkpointIntervalMs / 1000;
+                LOG.info("Injecting fault, sleep {}s before recover", randomSleepSec);
+                Thread.sleep(randomSleepSec * 1000);
+                faultInjectionClear();
+                LOG.info("Injecting fault recover");
+                faultInjection = true;
+            }
+
+            if (result.size() > 6 && !restart) {
+                LOG.info(
+                        "Restarting doris cluster, sleep {}s before next restart",
+                        randomSleepSec + 30);
+                dorisContainerService.restartContainer();
+                Thread.sleep((randomSleepSec + 30) * 1000);
+                restart = true;
+            }
+            Thread.sleep(500);
+        }
+
+        // concat expect value
+        List<String> expected = new ArrayList<>();
+        for (int tb = 1; tb <= newTableIndex; tb++) {
+            for (int i = 1; i <= totalRecords; i++) {
+                if (tb == newTableIndex && i <= addTblCheckpointId) {
+                    continue;
+                }
+                for (int j = 0; j < DEFAULT_PARALLELISM; j++) {
+                    expected.add(TABLE_MULTI_CSV + tb + "," + i + "," + j);
+                }
+            }
+        }
+
+        String queryRes =
+                String.format(
+                        "select * from (select \"%s\" as tbl,id,task_id from %s.%s "
+                                + "union all select \"%s\" as tbl,id,task_id from %s.%s "
+                                + "union all select \"%s\" as tbl,id,task_id from %s.%s "
+                                + "union all select \"%s\" as tbl,id,task_id from %s.%s ) a"
+                                + " order by tbl,id,task_id",
+                        TABLE_MULTI_CSV + 1,
+                        DATABASE,
+                        TABLE_MULTI_CSV + 1,
+                        TABLE_MULTI_CSV + 2,
+                        DATABASE,
+                        TABLE_MULTI_CSV + 2,
+                        TABLE_MULTI_CSV + 3,
+                        DATABASE,
+                        TABLE_MULTI_CSV + 3,
+                        TABLE_MULTI_CSV + 4,
+                        DATABASE,
+                        TABLE_MULTI_CSV + 4);
+
+        if (!batchMode) {
+            ContainerUtils.checkResult(
+                    getDorisQueryConnection(), LOG, expected, queryRes, 3, false);
+        } else {
+            List<String> actualResult =
+                    ContainerUtils.getResult(getDorisQueryConnection(), LOG, expected, queryRes, 3);
+            LOG.info("actual size: {}, expected size: {}", actualResult.size(), expected.size());
+            Assert.assertTrue(
+                    actualResult.size() >= expected.size() && actualResult.containsAll(expected));
+        }
+    }
+
+    private void initializeTable(String table) {
+        ContainerUtils.executeSQLStatement(
+                getDorisQueryConnection(),
+                LOG,
+                String.format("CREATE DATABASE IF NOT EXISTS %s", DATABASE),
+                String.format("DROP TABLE IF EXISTS %s.%s", DATABASE, table),
+                String.format(
+                        "CREATE TABLE %s.%s ( \n"
+                                + "`id` int,\n"
+                                + "`task_id` int\n"
+                                + ") DISTRIBUTED BY HASH(`id`) BUCKETS 1\n"
+                                + "PROPERTIES (\n"
+                                + "\"replication_num\" = \"1\"\n"
+                                + ")\n",
+                        DATABASE, table));
+    }
+
+    private void dropTable(String table) {
+        ContainerUtils.executeSQLStatement(
+                getDorisQueryConnection(),
+                LOG,
+                String.format("DROP TABLE IF EXISTS %s.%s", DATABASE, table));
+    }
+}


### PR DESCRIPTION
# Proposed changes

Previously, when importing multiple tables, check-interval was turned off because the check thread and preparecommit thread might cause conflicts.
However, in extreme cases, this may cause the asynchronous http thread to exit, but the main thread is blocked by the recordBuffer queue until the checkpoint times out and restarts the task.

So this pr mainly solves the following problems:
1. Enable the check-interval thread by default
2. Add a mutex between the check thread and prepareCommit to ensure that the check method is not executed during preparecommit.
3. Add exception cases for multi-table import (dynamically add tables/restart Doris/checkpoint failure/streamload failure)


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
5. Has unit tests been added: (Yes/No/No Need)
6. Has document been added or modified: (Yes/No/No Need)
7. Does it need to update dependencies: (Yes/No)
8. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
