### PR TITLE
[Improve](Stream) Optimize the situation where Flink may get stuck after the streamload thread exits abnormally

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/cfg/DorisExecutionOptions.java
@@ -34,7 +34,7 @@ public class DorisExecutionOptions implements Serializable {
 
     private static final long serialVersionUID = 1L;
     // 0 means disable checker thread
-    public static final int DEFAULT_CHECK_INTERVAL = 10000;
+    public static final int DEFAULT_CHECK_INTERVAL = 0;
     public static final int DEFAULT_MAX_RETRY_TIMES = 3;
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 1024;
     private static final int DEFAULT_BUFFER_COUNT = 3;

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/LabelAlreadyExistsException.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/exception/LabelAlreadyExistsException.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.flink.exception;
 
-public class LabelAlreadyExistsException extends RuntimeException {
+public class LabelAlreadyExistsException extends DorisRuntimeException {
     public LabelAlreadyExistsException() {
         super();
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -268,6 +268,7 @@ public class DorisStreamLoad implements Serializable {
             }
             recordStream.write(record);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             if (httpException != null) {
                 throw new DorisRuntimeException(httpException.getMessage(), httpException);
             } else {
@@ -325,6 +326,7 @@ public class DorisStreamLoad implements Serializable {
             Preconditions.checkState(pendingLoadFuture != null);
             return pendingLoadFuture.get();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             if (httpException != null) {
                 throw new DorisRuntimeException(httpException.getMessage(), httpException);
             } else {

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LoadConstants.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/LoadConstants.java
@@ -17,6 +17,13 @@
 
 package org.apache.doris.flink.sink.writer;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.doris.flink.sink.LoadStatus.PUBLISH_TIMEOUT;
+import static org.apache.doris.flink.sink.LoadStatus.SUCCESS;
+
 /** Constants for load. */
 public class LoadConstants {
     public static final String COLUMNS_KEY = "columns";
@@ -35,4 +42,6 @@ public class LoadConstants {
     public static final String GROUP_COMMIT_OFF_MODE = "off_mode";
     public static final String COMPRESS_TYPE = "compress_type";
     public static final String COMPRESS_TYPE_GZ = "gz";
+    public static final List<String> DORIS_SUCCESS_STATUS =
+            new ArrayList<>(Arrays.asList(SUCCESS, PUBLISH_TIMEOUT));
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/RecordBuffer.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/RecordBuffer.java
@@ -64,25 +64,21 @@ public class RecordBuffer {
         }
     }
 
-    public void stopBufferData() throws IOException {
-        try {
-            // add Empty buffer as finish flag.
-            boolean isEmpty = false;
-            if (currentWriteBuffer != null) {
-                currentWriteBuffer.flip();
-                // check if the current write buffer is empty.
-                isEmpty = currentWriteBuffer.limit() == 0;
-                readQueue.put(currentWriteBuffer);
-                currentWriteBuffer = null;
-            }
-            if (!isEmpty) {
-                ByteBuffer byteBuffer = writeQueue.take();
-                byteBuffer.flip();
-                Preconditions.checkState(byteBuffer.limit() == 0);
-                readQueue.put(byteBuffer);
-            }
-        } catch (Exception e) {
-            throw new IOException(e);
+    public void stopBufferData() throws InterruptedException {
+        // add Empty buffer as finish flag.
+        boolean isEmpty = false;
+        if (currentWriteBuffer != null) {
+            currentWriteBuffer.flip();
+            // check if the current write buffer is empty.
+            isEmpty = currentWriteBuffer.limit() == 0;
+            readQueue.put(currentWriteBuffer);
+            currentWriteBuffer = null;
+        }
+        if (!isEmpty) {
+            ByteBuffer byteBuffer = writeQueue.take();
+            byteBuffer.flip();
+            Preconditions.checkState(byteBuffer.limit() == 0);
+            readQueue.put(byteBuffer);
         }
     }
 

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/RecordStream.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/RecordStream.java
@@ -45,7 +45,7 @@ public class RecordStream extends InputStream {
         recordBuffer.startBufferData();
     }
 
-    public void endInput() throws IOException {
+    public void endInput() throws InterruptedException {
         recordBuffer.stopBufferData();
     }
 
@@ -58,11 +58,11 @@ public class RecordStream extends InputStream {
         }
     }
 
-    public void write(byte[] buff) throws IOException {
+    public void write(byte[] buff) throws InterruptedException {
         try {
             recordBuffer.write(buff);
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            throw e;
         }
     }
 }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/RecordStream.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/writer/RecordStream.java
@@ -54,6 +54,7 @@ public class RecordStream extends InputStream {
         try {
             return recordBuffer.read(buff);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }

--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -216,9 +216,9 @@ public class DorisConfigOptions {
     public static final ConfigOption<Duration> SINK_CHECK_INTERVAL =
             ConfigOptions.key("sink.check-interval")
                     .durationType()
-                    .defaultValue(Duration.ofMillis(10000))
+                    .defaultValue(Duration.ofMillis(0))
                     .withDescription(
-                            "check exception with the interval while loading, The default is 1s, 0 means disabling the checker thread");
+                            "check exception with the interval while loading, 0 means disabling the checker thread");
     public static final ConfigOption<Integer> SINK_MAX_RETRIES =
             ConfigOptions.key("sink.max-retries")
                     .intType()

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkMultiTblFailoverITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkMultiTblFailoverITCase.java
@@ -172,7 +172,7 @@ public class DorisSinkMultiTblFailoverITCase extends AbstractITCaseService {
                     getDorisQueryConnection(), LOG, expected, queryRes, 2, false);
         } else {
             List<String> actualResult =
-                    ContainerUtils.getResult(getDorisQueryConnection(), LOG, expected, queryRes, 3);
+                    ContainerUtils.getResult(getDorisQueryConnection(), LOG, expected, queryRes, 2);
             LOG.info("actual size: {}, expected size: {}", actualResult.size(), expected.size());
             Assert.assertTrue(
                     actualResult.size() >= expected.size() && actualResult.containsAll(expected));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkMultiTblFailoverITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkMultiTblFailoverITCase.java
@@ -77,6 +77,7 @@ public class DorisSinkMultiTblFailoverITCase extends AbstractITCaseService {
     @Test
     public void testTableNotExistCornerCase() throws Exception {
         LOG.info("Start to testTableNotExistCornerCase");
+        dropDatabase();
         dropTable(TABLE_MULTI_CSV_NO_EXIST_TBL);
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getCheckpointConfig().setCheckpointTimeout(300 * 1000);
@@ -384,5 +385,12 @@ public class DorisSinkMultiTblFailoverITCase extends AbstractITCaseService {
                 getDorisQueryConnection(),
                 LOG,
                 String.format("DROP TABLE IF EXISTS %s.%s", DATABASE, table));
+    }
+
+    private void dropDatabase(){
+        ContainerUtils.executeSQLStatement(
+                getDorisQueryConnection(),
+                LOG,
+                String.format("CREATE DATABASE IF NOT EXISTS %s", DATABASE));
     }
 }

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkMultiTblFailoverITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/DorisSinkMultiTblFailoverITCase.java
@@ -387,7 +387,7 @@ public class DorisSinkMultiTblFailoverITCase extends AbstractITCaseService {
                 String.format("DROP TABLE IF EXISTS %s.%s", DATABASE, table));
     }
 
-    private void dropDatabase(){
+    private void dropDatabase() {
         ContainerUtils.executeSQLStatement(
                 getDorisQueryConnection(),
                 LOG,


### PR DESCRIPTION
# Proposed changes

Currently, we rely on the check-interval thread to periodically check whether the http thread of streamload is alive.
This will cause the following problems:
In corner cases, if the data of a checkpoint is exactly equal to the size of `bufferCount*bufferSize`, the flink program will be stuck. 
like this case `DorisSinkMultiTblFailoverITCase.testTableNotExistCornerCase`, If [here](https://github.com/apache/doris-flink-connector/pull/578/files#diff-a152da68177535d9c8bbe156405cf32674f8a629a42ccf9906c5ac099d46993eL370-L374) is not interrupted, it will continue to be blocked until the checkpoint times out and is restarted.

jstack is as follows. At this time, the checkdone thread detects that it has entered prepareCommit and will not check.

```java
"stream-load-upload-0-test_multi_failover_sink_tbl_multi_csv4-thread-1" Id=121 WAITING on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@4f4e02f1
	at sun.misc.Unsafe.park(Native Method)
	-  waiting on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@4f4e02f1
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2044)
	at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
	at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1074)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1134)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)

Sink: Writer -> Sink: Committer (2/2)#0" Id=79 WAITING on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@56ce1949
	at sun.misc.Unsafe.park(Native Method)
	-  waiting on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@56ce1949
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2044)
	at java.util.concurrent.ArrayBlockingQueue.take(ArrayBlockingQueue.java:403)
	at org.apache.doris.flink.sink.writer.RecordBuffer.stopBufferData(RecordBuffer.java:79)
	at org.apache.doris.flink.sink.writer.RecordStream.endInput(RecordStream.java:49)
	at org.apache.doris.flink.sink.writer.DorisStreamLoad.stopLoad(DorisStreamLoad.java:296)
	at org.apache.doris.flink.sink.writer.DorisWriter.prepareCommit(DorisWriter.java:256)
```

Modification method:
1. When the http thread is initiated, when an error occurs, explicitly report the error. Immediately interrupt the thread to let the error be thrown
2. At the same time, close the check-interval thread, because there is no need for regular verification

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
