### PR TITLE
[fix-585] fixed the issue of not handle negative values when process the accuracy range of datetime

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/serialization/RowBatch.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/serialization/RowBatch.java
@@ -582,9 +582,9 @@ public class RowBatch {
     public static LocalDateTime longToLocalDateTime(long time) {
         Instant instant;
         // Determine the timestamp accuracy and process it
-        if (time < 10_000_000_000L) { // Second timestamp
+        if (time > -10_000_000_000L && time < 10_000_000_000L) { // Second timestamp
             instant = Instant.ofEpochSecond(time);
-        } else if (time < 10_000_000_000_000L) { // milli second
+        } else if (time > -10_000_000_000_000L && time < 10_000_000_000_000L) { // milli second
             instant = Instant.ofEpochMilli(time);
         } else { // micro second
             instant = Instant.ofEpochSecond(time / 1_000_000, (time % 1_000_000) * 1_000);


### PR DESCRIPTION
…e accuracy range of timestamp

# Proposed changes

Issue Number: close #585 

## Problem Summary:

fixed the issue of not handling negative values when process the accuracy range of timestamp

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
