### PR TITLE
[Improve]:(MongoDB)optimize type inference to avoid unnecessary decimal conversion

### DIFF
--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchemaTest.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBSchemaTest.java
@@ -189,4 +189,49 @@ public class MongoDBSchemaTest {
             }
         }
     }
+
+    @Test
+    public void testIntFieldNotConvertedToDecimal() throws Exception {
+        ArrayList<Document> documents = new ArrayList<>();
+        documents.add(new Document("fields1", Integer.MAX_VALUE));
+        documents.add(new Document("fields1", 1234567));
+        documents.add(new Document("fields1", Integer.MIN_VALUE));
+
+        MongoDBSchema mongoDBSchema = new MongoDBSchema(documents, "db_TEST", "test_table", "");
+        FieldSchema fieldSchema = mongoDBSchema.getFields().get("fields1");
+
+        assertEquals("INT", fieldSchema.getTypeString());
+    }
+
+    @Test
+    public void testBigIntFieldNotConvertedToDecimal() throws Exception {
+        ArrayList<Document> documents = new ArrayList<>();
+        documents.add(new Document("fields1", Long.MAX_VALUE));
+        documents.add(new Document("fields1", 12233720368541346L));
+        documents.add(new Document("fields1", Long.MIN_VALUE));
+
+        MongoDBSchema mongoDBSchema = new MongoDBSchema(documents, "db_TEST", "test_table", "");
+        Map<String, FieldSchema> fields = mongoDBSchema.getFields();
+
+        for (Map.Entry<String, FieldSchema> entry : fields.entrySet()) {
+            String fieldName = entry.getKey();
+            FieldSchema fieldSchema = entry.getValue();
+            if (fieldName.equals("fields1")) {
+                assertEquals("BIGINT", fieldSchema.getTypeString());
+            }
+        }
+    }
+
+    @Test
+    public void testMixedIntAndBigIntFieldsShouldConvertToBigInt() throws Exception {
+        ArrayList<Document> documents = new ArrayList<>();
+        documents.add(new Document("fields1", 2147483647));
+        documents.add(new Document("fields1", 9223372036854775807L));
+        documents.add(new Document("fields1", 12234));
+
+        MongoDBSchema mongoDBSchema = new MongoDBSchema(documents, "db_TEST", "test_table", "");
+        FieldSchema fieldSchema = mongoDBSchema.getFields().get("fields1");
+
+        assertEquals("BIGINT", fieldSchema.getTypeString());
+    }
 }


### PR DESCRIPTION
# Proposed changes

Previously, all numeric types were converted to Decimal to prevent precision loss when syncing mixed-type fields from MongoDB to Doris. This caused unnecessary precision degradation for single-type fields. For example, if the initial table has a small amount of data and an INT-type field with all values below 1000, after conversion to DECIMAL, the numeric precision will be limited to 3 digits. If the data evolves with business growth and the field value later exceeds 1000 (e.g., becomes a 4-digit number), it will lose precision due to the previously inferred limited length.

## Problem Summary:

This commit improves the type inference logic:
- Only convert to Decimal if multiple types are present in the sampled data;
- Retain original types (e.g., INT, BIGINT) for fields with consistent data types;

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (Yes)

## Further comments

