### PR TITLE
fix: When a doris field has default value '' (empty str), the ddl to modify the column type is incorrectly

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeHelper.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeHelper.java
@@ -175,7 +175,7 @@ public class SchemaChangeHelper {
                                 DorisSchemaFactory.quoteTableIdentifier(tableIdentifier),
                                 DorisSchemaFactory.identifier(columnName),
                                 dataType));
-        if (StringUtils.isNotBlank(defaultValue)) {
+        if (defaultValue != null) {
             modifyDDL
                     .append(" DEFAULT ")
                     .append(DorisSchemaFactory.quoteDefaultValue(defaultValue));

--- a/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SchemaManagerITCase.java
+++ b/flink-doris-connector/src/test/java/org/apache/doris/flink/sink/schema/SchemaManagerITCase.java
@@ -292,6 +292,37 @@ public class SchemaManagerITCase extends AbstractITCaseService {
     }
 
     @Test
+    public void testModifyColumnTypeWithDefault2()
+            throws IOException, IllegalArgumentException, InterruptedException {
+        String modifyColumnTbls = "modify_column_type_with_default_value2";
+        ContainerUtils.executeSQLStatement(
+                getDorisQueryConnection(),
+                LOG,
+                String.format("CREATE DATABASE IF NOT EXISTS %s", DATABASE),
+                String.format("DROP TABLE IF EXISTS %s.%s", DATABASE, modifyColumnTbls),
+                String.format(
+                        "CREATE TABLE %s.%s ( \n"
+                                + "`id` int not null,\n"
+                                + "`cname` varchar(10) NOT NULL DEFAULT ''\n"
+                                + ")"
+                                + "UNIQUE KEY(`id`)\n"
+                                + "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n"
+                                + "PROPERTIES (\n"
+                                + "\"replication_num\" = \"1\"\n"
+                                + ")\n",
+                        DATABASE, modifyColumnTbls));
+
+        String columnName = "cname";
+        String newColumnType = "varchar(11)";
+        FieldSchema field = new FieldSchema(columnName, newColumnType, "");
+        schemaChangeManager.modifyColumnDataType(DATABASE, modifyColumnTbls, field);
+
+        Thread.sleep(3_000);
+        String columnType = getColumnType(modifyColumnTbls, columnName);
+        Assert.assertEquals("varchar", columnType.toLowerCase());
+    }
+
+    @Test
     public void testModifyColumnTypeWithDefaultAndChange()
             throws IOException, IllegalArgumentException, InterruptedException {
         String modifyColumnTbls = "modify_column_type_with_default_value_and_change";


### PR DESCRIPTION
# Proposed changes



## Problem Summary:

```sql
CREATE TABLE `modify_column_type_with_default_value2` (
  `id` int NOT NULL,
  `cname` varchar(10) NOT NULL DEFAULT ""
)
UNIQUE KEY(`id`)
DISTRIBUTED BY HASH(`id`) BUCKETS 1
PROPERTIES (
"replication_num" = "1"
);
```

call api to change cname column:  varchar(10) -> varchar(11)
```
        String columnName = "cname";
        String newColumnType = "varchar(11)";
        FieldSchema field = new FieldSchema(columnName, newColumnType, "");
        schemaChangeManager.modifyColumnDataType(DATABASE, modifyColumnTbls, field);
```

doris throw exception
```
org.apache.doris.flink.exception.DorisSchemaChangeException: Failed to schemaChange, response: {"msg":"Error","code":1,"data":"Failed to execute sql: java.sql.SQLException: (conn=1786844) errCode = 2, detailMessage = Can not change default value","count":0}
```

The actual generated ddl is
```sql
ALTER TABLE `test_sc_db`.`modify_column_type_with_default_value2` MODIFY COLUMN `cname` varchar(11)
```

Expected generated ddl is
```sql
ALTER TABLE `test_sc_db`.`modify_column_type_with_default_value2` MODIFY COLUMN `cname` varchar(11) DEFAULT ''
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (Yes)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

n/a
