### PR TITLE
[Fix] fix copy&paste typo in BackendClient

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/backend/BackendClient.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/backend/BackendClient.java
@@ -71,7 +71,7 @@ public class BackendClient {
                         ? ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT
                         : readOptions.getRequestRetries();
         this.thriftMaxMessageSize =
-                readOptions.getRequestRetries() == null
+                readOptions.getThriftMaxMessageSize() == null
                         ? ConfigurationOptions.DORIS_THRIFT_MAX_MESSAGE_SIZE_DEFAULT
                         : readOptions.getThriftMaxMessageSize();
         logger.trace(


### PR DESCRIPTION
## Problem Summary:

fix copy&paste typo in BackendClient
null check should be performed on `readOptions.getThriftMaxMessageSize()`

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No Need
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No