### PR TITLE
[Fix](cdc) Fix BE data loss caused by invalid checkpoint recovery during Flink CDC Stream Load with BE unavailable scenario

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -334,6 +334,7 @@ public class DorisBatchStreamLoad implements Serializable {
             BatchRecordBuffer empty = new BatchRecordBuffer();
             putRecordToFlushQueue(empty);
         }
+        checkFlushException();
     }
 
     private String getTableIdentifier(String database, String table) {


### PR DESCRIPTION
[Fix](cdc) Fix BE data loss caused by invalid checkpoint recovery during Flink CDC Stream Load with BE unavailable scenario

## Problem Summary:

Fix data loss on BE after Flink job recovery: When performing Stream Load to BE via Flink CDC direct connection, Flink still succeeds in checkpointing even if BE is unavailable. After reaching the maximum retry count due to BE connection exceptions, the Flink job restarts and recovers from the previous checkpoint (which is actually invalid), leading to data loss on BE.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)
