### PR TITLE
fix filed mapping error when use where in sql

### DIFF
--- a/flink-doris-connector/src/main/java/org/apache/doris/flink/serialization/RowBatch.java
+++ b/flink-doris-connector/src/main/java/org/apache/doris/flink/serialization/RowBatch.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.flink.serialization;
 
+import org.apache.doris.flink.rest.models.Field;
 import org.apache.flink.annotation.VisibleForTesting;
 
 import org.apache.arrow.memory.RootAllocator;
@@ -216,10 +217,14 @@ public class RowBatch {
 
     public void convertArrowToRowBatch() throws DorisException {
         try {
+            Map<String, Field> schemaMap = new HashMap<>();
+            for (int i = 0; i < schema.size(); i++) {
+                schemaMap.put(schema.get(i).getName(), schema.get(i));
+            }
             for (int col = 0; col < fieldVectors.size(); col++) {
                 FieldVector fieldVector = fieldVectors.get(col);
                 MinorType minorType = fieldVector.getMinorType();
-                final String currentType = schema.get(col).getType();
+                String currentType = schemaMap.get(fieldVector.getField().getName()).getType();
                 final String colName = schema.get(col).getName();
                 for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
                     boolean passed = doConvert(col, rowIndex, minorType, currentType, fieldVector);


### PR DESCRIPTION
# Proposed changes

Exception:FLINK type is INT, but arrow type is VARCHAR.
FlinkSql Code

`

    public static void main(String[] args) throws Exception {

        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
        env.setParallelism(1);

        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);

        String sql = "CREATE  TABLE product_order_qrcode_info (\n" +
                "  `id` STRING, " +
                "  `dimension_type` INT ," +
                "  `material_code` STRING ," +
                "  `product_fac` STRING ," +
                "  `create_time` TIMESTAMP," +
                "  PRIMARY KEY (id) NOT ENFORCED\n" +
                ")\n" +
                "WITH (\n" +
                "  'connector' = 'doris',\n" +
                "  'fenodes' = 'xx.xx.xx.xx:xx',\n" +
                "  'table.identifier' = 'xx.xx',\n" +
                "  'username' = 'xxx',\n" +
                "  'password' = 'xx'" +
                ");";

        // register a table in the catalog
        tEnv.executeSql(sql);

        // define a dynamic aggregating query
        final Table result = tEnv.sqlQuery("SELECT * from product_order_qrcode_info where dimension_type=1");

        // print the result to the console
        tEnv.toDataStream(result).print();
        env.execute();
    }

`

Code
<img width="825" height="507" alt="image" src="https://github.com/user-attachments/assets/05ee834c-b2cb-4498-9113-b432188cd760" />
field dimension_type in where not in fieldVectors

## Problem Summary:

<img width="874" height="606" alt="image" src="https://github.com/user-attachments/assets/8a696cea-224f-4e4e-b4dc-8d9b56a82bda" />
create scheamMap and get field by name

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No/)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
