### PR TITLE
fix(cdc): skip mysql no-pk tables in initial snapshot unless chunk key configured

### DIFF
--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/CdcTools.java
@@ -143,6 +143,7 @@ public class CdcTools {
         boolean ignoreDefaultValue = params.has(DatabaseSyncConfig.IGNORE_DEFAULT_VALUE);
         boolean ignoreIncompatible = params.has(DatabaseSyncConfig.IGNORE_INCOMPATIBLE);
         boolean singleSink = params.has(DatabaseSyncConfig.SINGLE_SINK);
+        boolean skipNoPkTables = params.has(DatabaseSyncConfig.SKIP_NO_PK_TABLES);
 
         Preconditions.checkArgument(params.has(DatabaseSyncConfig.SINK_CONF));
         Map<String, String> sinkMap = getConfigMap(params, DatabaseSyncConfig.SINK_CONF);
@@ -169,6 +170,7 @@ public class CdcTools {
                 .setTableConfig(tableConfig)
                 .setCreateTableOnly(createTableOnly)
                 .setSingleSink(singleSink)
+                .setSkipNoPkTables(skipNoPkTables)
                 .setIgnoreIncompatible(ignoreIncompatible)
                 .setSchemaChangeMode(schemaChangeMode)
                 .create();

--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -89,6 +89,7 @@ public abstract class DatabaseSync {
     protected String tablePrefix;
     protected String tableSuffix;
     protected boolean singleSink;
+    protected boolean skipNoPkTables;
     protected final Map<String, String> tableMapping = new HashMap<>();
 
     public abstract void registerDriver() throws SQLException;
@@ -575,6 +576,11 @@ public abstract class DatabaseSync {
 
     public DatabaseSync setSingleSink(boolean singleSink) {
         this.singleSink = singleSink;
+        return this;
+    }
+
+    public DatabaseSync setSkipNoPkTables(boolean skipNoPkTables) {
+        this.skipNoPkTables = skipNoPkTables;
         return this;
     }
 

--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSyncConfig.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSyncConfig.java
@@ -67,6 +67,7 @@ public class DatabaseSyncConfig {
     public static final String IGNORE_DEFAULT_VALUE = "ignore-default-value";
     public static final String IGNORE_INCOMPATIBLE = "ignore-incompatible";
     public static final String SINGLE_SINK = "single-sink";
+    public static final String SKIP_NO_PK_TABLES = "skip-no-pk-tables";
     ////////// doris-table-conf //////////
     public static final String TABLE_CONF = "table-conf";
 

--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSync.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSync.java
@@ -49,9 +49,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -100,6 +102,8 @@ public class MysqlDatabaseSync extends DatabaseSync {
     @Override
     public List<SourceSchema> getSchemaList() throws Exception {
         String databaseName = config.get(MySqlSourceOptions.DATABASE_NAME);
+        Set<String> chunkKeyTables = getChunkKeyTables();
+        List<String> skippedNoPrimaryKeyTables = new ArrayList<>();
 
         List<SourceSchema> schemaList = new ArrayList<>();
         try (Connection conn = getConnection()) {
@@ -120,6 +124,14 @@ public class MysqlDatabaseSync extends DatabaseSync {
                                 SourceSchema sourceSchema =
                                         new MysqlSchema(
                                                 metaData, tableCatalog, tableName, tableComment);
+                                if (shouldSkipTableWithoutPrimaryKey(
+                                        tableCatalog,
+                                        tableName,
+                                        sourceSchema.primaryKeys.isEmpty(),
+                                        chunkKeyTables)) {
+                                    skippedNoPrimaryKeyTables.add(tableCatalog + "." + tableName);
+                                    continue;
+                                }
                                 sourceSchema.setModel(
                                         !sourceSchema.primaryKeys.isEmpty()
                                                 ? DataModel.UNIQUE
@@ -131,7 +143,52 @@ public class MysqlDatabaseSync extends DatabaseSync {
                 }
             }
         }
+
+        if (!skippedNoPrimaryKeyTables.isEmpty()) {
+            LOG.warn(
+                    "Skipping MySQL tables without primary key in incremental snapshot mode (no chunk key configured): {}. "
+                            + "Configure '{}' for these tables if snapshot sync is required.",
+                    skippedNoPrimaryKeyTables,
+                    MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN.key());
+        }
+        if (schemaList.isEmpty() && !skippedNoPrimaryKeyTables.isEmpty()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "No MySQL tables left to synchronize: all matched tables are without primary key and no chunk key is configured in initial snapshot mode. "
+                                    + "Skipped tables: %s",
+                            skippedNoPrimaryKeyTables));
+        }
         return schemaList;
+    }
+
+    boolean shouldSkipTableWithoutPrimaryKey(
+            String databaseName,
+            String tableName,
+            boolean hasNoPrimaryKey,
+            Set<String> chunkKeyTables) {
+        if (!hasNoPrimaryKey) {
+            return false;
+        }
+        if (!isInitialSnapshotStartup()) {
+            return false;
+        }
+        return !chunkKeyTables.contains(databaseName + "." + tableName);
+    }
+
+    private boolean isInitialSnapshotStartup() {
+        String startupMode = config.get(MySqlSourceOptions.SCAN_STARTUP_MODE);
+        if (StringUtils.isNullOrWhitespaceOnly(startupMode)) {
+            return true;
+        }
+        return DatabaseSyncConfig.SCAN_STARTUP_MODE_VALUE_INITIAL.equalsIgnoreCase(startupMode);
+    }
+
+    private Set<String> getChunkKeyTables() {
+        Set<String> tables = new HashSet<>();
+        for (ObjectPath objectPath : getChunkColumnMap().keySet()) {
+            tables.add(objectPath.getDatabaseName() + "." + objectPath.getObjectName());
+        }
+        return tables;
     }
 
     @Override

--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSync.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSync.java
@@ -146,17 +146,18 @@ public class MysqlDatabaseSync extends DatabaseSync {
 
         if (!skippedNoPrimaryKeyTables.isEmpty()) {
             LOG.warn(
-                    "Skipping MySQL tables without primary key in incremental snapshot mode (no chunk key configured): {}. "
+                    "Skipping MySQL tables without primary key in incremental snapshot mode because '--{}' is enabled (no chunk key configured): {}. "
                             + "Configure '{}' for these tables if snapshot sync is required.",
+                    DatabaseSyncConfig.SKIP_NO_PK_TABLES,
                     skippedNoPrimaryKeyTables,
                     MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN.key());
         }
         if (schemaList.isEmpty() && !skippedNoPrimaryKeyTables.isEmpty()) {
             throw new IllegalStateException(
                     String.format(
-                            "No MySQL tables left to synchronize: all matched tables are without primary key and no chunk key is configured in initial snapshot mode. "
+                            "No MySQL tables left to synchronize: all matched tables are without primary key and no chunk key is configured in initial snapshot mode, and '--%s' is enabled. "
                                     + "Skipped tables: %s",
-                            skippedNoPrimaryKeyTables));
+                            DatabaseSyncConfig.SKIP_NO_PK_TABLES, skippedNoPrimaryKeyTables));
         }
         return schemaList;
     }
@@ -166,6 +167,9 @@ public class MysqlDatabaseSync extends DatabaseSync {
             String tableName,
             boolean hasNoPrimaryKey,
             Set<String> chunkKeyTables) {
+        if (!skipNoPkTables) {
+            return false;
+        }
         if (!hasNoPrimaryKey) {
             return false;
         }

--- a/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSyncTest.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSyncTest.java
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.tools.cdc.mysql;
+
+import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceOptions;
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class MysqlDatabaseSyncTest {
+
+    @Test
+    public void testSkipTableWithoutPrimaryKeyInInitialSnapshot() throws Exception {
+        MysqlDatabaseSync sync = new MysqlDatabaseSync();
+        Configuration config = new Configuration();
+        config.setString(MySqlSourceOptions.SCAN_STARTUP_MODE.key(), "initial");
+        sync.setConfig(config);
+
+        boolean shouldSkip =
+                sync.shouldSkipTableWithoutPrimaryKey(
+                        "test_db", "no_pk_table", true, Collections.emptySet());
+
+        Assert.assertTrue(shouldSkip);
+    }
+
+    @Test
+    public void testDoNotSkipTableWithoutPrimaryKeyWhenChunkKeyConfigured() throws Exception {
+        MysqlDatabaseSync sync = new MysqlDatabaseSync();
+        Configuration config = new Configuration();
+        config.setString(MySqlSourceOptions.SCAN_STARTUP_MODE.key(), "initial");
+        sync.setConfig(config);
+
+        Set<String> chunkKeyTables = new HashSet<>();
+        chunkKeyTables.add("test_db.no_pk_table");
+
+        boolean shouldSkip =
+                sync.shouldSkipTableWithoutPrimaryKey(
+                        "test_db", "no_pk_table", true, chunkKeyTables);
+
+        Assert.assertFalse(shouldSkip);
+    }
+
+    @Test
+    public void testDoNotSkipTableWithoutPrimaryKeyForNonInitialStartup() throws Exception {
+        MysqlDatabaseSync sync = new MysqlDatabaseSync();
+        Configuration config = new Configuration();
+        config.setString(MySqlSourceOptions.SCAN_STARTUP_MODE.key(), "latest-offset");
+        sync.setConfig(config);
+
+        boolean shouldSkip =
+                sync.shouldSkipTableWithoutPrimaryKey(
+                        "test_db", "no_pk_table", true, Collections.emptySet());
+
+        Assert.assertFalse(shouldSkip);
+    }
+}

--- a/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSyncTest.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/tools/cdc/mysql/MysqlDatabaseSyncTest.java
@@ -30,11 +30,26 @@ import java.util.Set;
 public class MysqlDatabaseSyncTest {
 
     @Test
+    public void testDoNotSkipTableWithoutPrimaryKeyByDefault() throws Exception {
+        MysqlDatabaseSync sync = new MysqlDatabaseSync();
+        Configuration config = new Configuration();
+        config.setString(MySqlSourceOptions.SCAN_STARTUP_MODE.key(), "initial");
+        sync.setConfig(config);
+
+        boolean shouldSkip =
+                sync.shouldSkipTableWithoutPrimaryKey(
+                        "test_db", "no_pk_table", true, Collections.emptySet());
+
+        Assert.assertFalse(shouldSkip);
+    }
+
+    @Test
     public void testSkipTableWithoutPrimaryKeyInInitialSnapshot() throws Exception {
         MysqlDatabaseSync sync = new MysqlDatabaseSync();
         Configuration config = new Configuration();
         config.setString(MySqlSourceOptions.SCAN_STARTUP_MODE.key(), "initial");
         sync.setConfig(config);
+        sync.setSkipNoPkTables(true);
 
         boolean shouldSkip =
                 sync.shouldSkipTableWithoutPrimaryKey(
@@ -49,6 +64,7 @@ public class MysqlDatabaseSyncTest {
         Configuration config = new Configuration();
         config.setString(MySqlSourceOptions.SCAN_STARTUP_MODE.key(), "initial");
         sync.setConfig(config);
+        sync.setSkipNoPkTables(true);
 
         Set<String> chunkKeyTables = new HashSet<>();
         chunkKeyTables.add("test_db.no_pk_table");
@@ -66,6 +82,7 @@ public class MysqlDatabaseSyncTest {
         Configuration config = new Configuration();
         config.setString(MySqlSourceOptions.SCAN_STARTUP_MODE.key(), "latest-offset");
         sync.setConfig(config);
+        sync.setSkipNoPkTables(true);
 
         boolean shouldSkip =
                 sync.shouldSkipTableWithoutPrimaryKey(


### PR DESCRIPTION
# Proposed changes

Issue Number: close #641

## Problem Summary:

In MySQL-to-Doris full-database CDC sync (`mysql-sync-database`), tables without primary keys were not filtered automatically.
When startup mode is `initial` (incremental snapshot phase), these no-PK tables can fail split-based snapshot reading and cause repeated Flink job restarts.

This PR adds an opt-in guard in MySQL schema discovery to improve stability.

### What is changed

1. Add a new CLI option `--skip-no-pk-tables` (default: off), following the existing boolean flag conventions (`--ignore-incompatible`, `--single-sink`). **Default behavior is unchanged**; the guard below only takes effect when this option is enabled.
2. When enabled, in `MysqlDatabaseSync#getSchemaList`, skip tables that meet all of the following:
- table has no primary key
- startup mode is `initial` (or empty, treated as initial)
- no chunk key is configured for that table
3. Keep no-PK tables syncable when chunk key is explicitly configured via:
- `scan.incremental.snapshot.chunk.key.column` (table-level mapping)
4. Add warning logs for skipped tables with clear guidance to configure chunk key.
5. Add fail-fast message when all matched tables are skipped:
- throw explicit exception describing why no table is left for synchronization.
6. Add unit tests:
- `MysqlDatabaseSyncTest`
  - `testDoNotSkipTableWithoutPrimaryKeyByDefault`
  - `testSkipTableWithoutPrimaryKeyInInitialSnapshot`
  - `testDoNotSkipTableWithoutPrimaryKeyWhenChunkKeyConfigured`
  - `testDoNotSkipTableWithoutPrimaryKeyForNonInitialStartup`

### Why

This avoids job instability in common real-world schemas where some source tables do not have primary keys, while keeping the default behavior unchanged and preserving an explicit opt-in path (chunk key) for required no-PK tables.

## Checklist(Required)

1. Does it affect the original behavior: No (the skip behavior is opt-in via the new `--skip-no-pk-tables` option; default behavior is unchanged)
2. Has unit tests been added: Yes
3. Has document been added or modified: No (the new `--skip-no-pk-tables` option needs a follow-up doc update in doris-website)
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

This change is intentionally scoped to MySQL CDC database sync path and does not alter sink logic or other source connectors.
