### PR TITLE
[Fix](batch) Prevent writer deadlock from currentCacheBytes drift

### DIFF
--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -202,6 +202,18 @@ public class DorisBatchStreamLoad implements Serializable {
         currentCacheBytes.addAndGet(bytes);
         getLock(bufferKey).readLock().unlock();
 
+        if (flushQueue.size() < executionOptions.getFlushQueueSize()
+                && (buffer.getBufferSizeBytes() >= executionOptions.getBufferFlushMaxBytes()
+                        || buffer.getNumOfRecords() >= executionOptions.getBufferFlushMaxRows())) {
+            boolean flush = bufferFullFlush(bufferKey);
+            LOG.info("trigger flush by buffer full, flush: {}", flush);
+        } else if (buffer.getBufferSizeBytes() >= STREAM_LOAD_MAX_BYTES
+                || buffer.getNumOfRecords() >= STREAM_LOAD_MAX_ROWS) {
+            // The buffer capacity exceeds the stream load limit, flush
+            boolean flush = bufferFullFlush(bufferKey);
+            LOG.info("trigger flush by buffer exceeding the limit, flush: {}", flush);
+        }
+
         if (currentCacheBytes.get() > maxBlockedBytes) {
             lock.lock();
             try {
@@ -219,20 +231,6 @@ public class DorisBatchStreamLoad implements Serializable {
             } finally {
                 lock.unlock();
             }
-        }
-
-        // queue has space, flush according to the bufferMaxRows/bufferMaxBytes
-        if (flushQueue.size() < executionOptions.getFlushQueueSize()
-                && (buffer.getBufferSizeBytes() >= executionOptions.getBufferFlushMaxBytes()
-                        || buffer.getNumOfRecords() >= executionOptions.getBufferFlushMaxRows())) {
-            boolean flush = bufferFullFlush(bufferKey);
-            LOG.info("trigger flush by buffer full, flush: {}", flush);
-
-        } else if (buffer.getBufferSizeBytes() >= STREAM_LOAD_MAX_BYTES
-                || buffer.getNumOfRecords() >= STREAM_LOAD_MAX_ROWS) {
-            // The buffer capacity exceeds the stream load limit, flush
-            boolean flush = bufferFullFlush(bufferKey);
-            LOG.info("trigger flush by buffer exceeding the limit, flush: {}", flush);
         }
     }
 
@@ -499,7 +497,7 @@ public class DorisBatchStreamLoad implements Serializable {
                                     OBJECT_MAPPER.readValue(loadResult, RespContent.class);
                             if (DORIS_SUCCESS_STATUS.contains(respContent.getStatus())) {
                                 long cacheByteBeforeFlush =
-                                        currentCacheBytes.getAndAdd(-respContent.getLoadBytes());
+                                        currentCacheBytes.getAndAdd(-buffer.getBufferSizeBytes());
                                 LOG.info(
                                         "load success, cacheBeforeFlushBytes: {}, currentCacheBytes : {}",
                                         cacheByteBeforeFlush,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #614

## Problem Summary:

`DorisBatchStreamLoad` increments `currentCacheBytes` by the client-side record bytes on insert, but decrements it by `respContent.getLoadBytes()` on a successful load. Whenever the BE-reported value is smaller than what the client buffered, either by `partial_columns=true`, `compress_type=gz`, etc, each load leaks a few bytes from the counter.

Over time the leak accumulates above `maxBlockedBytes`, so `writeRecord` parks on `block.await()` forever even though `bufferMap` and `flushQueue` are empty. The job freezes with no exception, only repeating `Cache full, waiting for flush` and `bufferMap is empty, no need to flush null` logs.

Two changes:

1. Decrement `currentCacheBytes` by `buffer.getBufferSizeBytes()` so the add and subtract are symmetric regardless of compression / projection.
2. Move the per-buffer flush check above the global cache-pressure await loop so a buffer that just crossed `bufferFlushMaxBytes` actually gets flushed instead of being stranded behind backpressure.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No Need
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

Same root cause was independently reported in #614 (gz compression trigger). The fix is config-agnostic, it covers `partial_columns`, gz, and any future source of client-vs-BE byte asymmetry.