### PR TITLE
[fix] cloud mode backend discovery with specified compute group

### DIFF
--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -91,8 +91,11 @@ public class RestService implements Serializable {
     private static final String UNIQUE_KEYS_TYPE = "UNIQUE_KEYS";
     @Deprecated private static final String BACKENDS = "/rest/v1/system?path=//backends";
     private static final String BACKENDS_V2 = "/api/backends?is_alive=true";
+    private static final String MANAGER_BACKENDS = "/rest/v2/manager/node/backends";
     private static final String FE_LOGIN = "/rest/v1/login";
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String COMPUTE_GROUP_NAME = "compute_group_name";
+    private static final String CLOUD_CLUSTER_NAME = "cloud_cluster_name";
     private static final String TABLE_SCHEMA_API = "http://%s/api/%s/%s/_schema";
     private static final String CATALOG_TABLE_SCHEMA_API = "http://%s/api/%s/%s/%s/_schema";
     private static final String QUERY_PLAN_API = "http://%s/api/%s/%s/_query_plan";
@@ -113,6 +116,16 @@ public class RestService implements Serializable {
             DorisReadOptions readOptions,
             HttpRequestBase request,
             Logger logger)
+            throws ConnectedFailedException {
+        return send(options, readOptions, request, logger, true);
+    }
+
+    private static String send(
+            DorisOptions options,
+            DorisReadOptions readOptions,
+            HttpRequestBase request,
+            Logger logger,
+            boolean unwrapData)
             throws ConnectedFailedException {
         int connectTimeout =
                 readOptions.getRequestConnectTimeoutMs() == null
@@ -169,7 +182,7 @@ public class RestService implements Serializable {
                 // Handle the problem of inconsistent data format returned by http v1 and v2
                 ObjectMapper mapper = new ObjectMapper();
                 Map map = mapper.readValue(response, Map.class);
-                if (map.containsKey("code") && map.containsKey("msg")) {
+                if (unwrapData && map.containsKey("code") && map.containsKey("msg")) {
                     Object data = map.get("data");
                     return mapper.writeValueAsString(data);
                 } else {
@@ -324,11 +337,25 @@ public class RestService implements Serializable {
     @VisibleForTesting
     public static List<BackendRowV2> getBackendsV2(
             DorisOptions options, DorisReadOptions readOptions, Logger logger) {
+        return getBackendsV2(options, readOptions, null, logger);
+    }
+
+    @VisibleForTesting
+    public static List<BackendRowV2> getBackendsV2(
+            DorisOptions options,
+            DorisReadOptions readOptions,
+            String computeGroupName,
+            Logger logger) {
         String feNodes = options.getFenodes();
         List<String> feNodeList = allEndpoints(feNodes, logger);
 
         if (options.isAutoRedirect() && !feNodeList.isEmpty()) {
             return convert(feNodeList);
+        }
+
+        if (StringUtils.isNotBlank(computeGroupName)) {
+            return getManagerBackendsByComputeGroup(
+                    options, readOptions, feNodeList, computeGroupName, logger);
         }
 
         for (String feNode : feNodeList) {
@@ -347,6 +374,34 @@ public class RestService implements Serializable {
             }
         }
         String errMsg = "No Doris FE is available, please check configuration";
+        logger.error(errMsg);
+        throw new DorisRuntimeException(errMsg);
+    }
+
+    private static List<BackendRowV2> getManagerBackendsByComputeGroup(
+            DorisOptions options,
+            DorisReadOptions readOptions,
+            List<String> feNodeList,
+            String computeGroupName,
+            Logger logger) {
+        for (String feNode : feNodeList) {
+            try {
+                String beUrl = "http://" + feNode + MANAGER_BACKENDS;
+                HttpGet httpGet = new HttpGet(beUrl);
+                String response = send(options, readOptions, httpGet, logger, false);
+                logger.info("Manager backend info:{}", response);
+                return parseManagerBackends(response, logger, computeGroupName);
+            } catch (ConnectedFailedException e) {
+                logger.info(
+                        "Doris FE node {} is unavailable: {}, Request the next Doris FE node",
+                        feNode,
+                        e.getMessage());
+            }
+        }
+        String errMsg =
+                String.format(
+                        "No Doris FE is available to request %s for compute group '%s'.",
+                        MANAGER_BACKENDS, computeGroupName);
         logger.error(errMsg);
         throw new DorisRuntimeException(errMsg);
     }
@@ -387,6 +442,184 @@ public class RestService implements Serializable {
         List<BackendRowV2> backendRows = backend.getBackends();
         logger.debug("Parsing schema result is '{}'.", backendRows);
         return backendRows;
+    }
+
+    @VisibleForTesting
+    static List<BackendRowV2> parseManagerBackends(
+            String response, Logger logger, String computeGroupName) {
+        if (StringUtils.isBlank(computeGroupName)) {
+            throw managerBackendsException(computeGroupName, "compute group is empty");
+        }
+
+        JsonNode rootNode = parseJsonResponse(response, computeGroupName, logger);
+        JsonNode dataNode = unwrapManagerBackendData(rootNode, computeGroupName);
+        JsonNode columnNode = dataNode.path("columnNames");
+        if (!columnNode.isArray()) {
+            columnNode = dataNode.path("column_names");
+        }
+        JsonNode rowNode = dataNode.path("rows");
+        if (!columnNode.isArray() || !rowNode.isArray()) {
+            throw managerBackendsException(
+                    computeGroupName,
+                    "response does not contain columnNames/column_names and rows");
+        }
+
+        Map<String, Integer> columnIndexes = getColumnIndexes(columnNode, computeGroupName);
+        int hostIndex = requireColumn(columnIndexes, "Host", computeGroupName);
+        int httpPortIndex = requireColumn(columnIndexes, "HttpPort", computeGroupName);
+        int aliveIndex = requireColumn(columnIndexes, "Alive", computeGroupName);
+        int tagIndex = requireColumn(columnIndexes, "Tag", computeGroupName);
+
+        List<BackendRowV2> backends = new ArrayList<>();
+        for (JsonNode row : rowNode) {
+            if (!row.isArray()) {
+                throw managerBackendsException(computeGroupName, "backend row is not an array");
+            }
+            if (!Boolean.parseBoolean(getManagerBackendCell(row, aliveIndex))) {
+                continue;
+            }
+            String tag = getManagerBackendCell(row, tagIndex);
+            String rowComputeGroupName = getComputeGroupNameFromTag(tag);
+            if (!computeGroupName.equals(rowComputeGroupName)) {
+                continue;
+            }
+
+            String host = getManagerBackendCell(row, hostIndex);
+            String httpPort = getManagerBackendCell(row, httpPortIndex);
+            try {
+                BackendRowV2 backend = BackendRowV2.of(host, Integer.parseInt(httpPort), true);
+                backends.add(backend);
+            } catch (NumberFormatException e) {
+                throw managerBackendsException(
+                        computeGroupName, "backend HttpPort is invalid: " + httpPort);
+            }
+        }
+
+        if (backends.isEmpty()) {
+            throw managerBackendsException(
+                    computeGroupName,
+                    "no alive backend found. If the target is a virtual compute group, configure its physical active compute group");
+        }
+        logger.debug("Parsing manager backend result is '{}'.", backends);
+        return backends;
+    }
+
+    private static JsonNode parseJsonResponse(
+            String response, String computeGroupName, Logger logger) {
+        try {
+            return objectMapper.readTree(response);
+        } catch (IOException e) {
+            String errMsg = "Parse Doris manager backend response to json failed. res: " + response;
+            logger.error(errMsg, e);
+            throw managerBackendsException(computeGroupName, errMsg);
+        }
+    }
+
+    private static JsonNode unwrapManagerBackendData(JsonNode rootNode, String computeGroupName) {
+        if (rootNode.has("code") && rootNode.has("msg")) {
+            if (rootNode.path("code").asInt() != REST_RESPONSE_CODE_OK) {
+                throw managerBackendsException(
+                        computeGroupName,
+                        rootNode.path("msg").asText() + ": " + rootNode.path("data").asText());
+            }
+            return rootNode.path("data");
+        }
+        return rootNode;
+    }
+
+    private static Map<String, Integer> getColumnIndexes(
+            JsonNode columnNode, String computeGroupName) {
+        Map<String, Integer> columnIndexes = new HashMap<>();
+        for (int i = 0; i < columnNode.size(); i++) {
+            String columnName = columnNode.get(i).asText();
+            if (StringUtils.isNotBlank(columnName)) {
+                columnIndexes.put(columnName.toLowerCase(), i);
+            }
+        }
+        if (columnIndexes.isEmpty()) {
+            throw managerBackendsException(computeGroupName, "backend columns are empty");
+        }
+        return columnIndexes;
+    }
+
+    private static int requireColumn(
+            Map<String, Integer> columnIndexes, String columnName, String computeGroupName) {
+        Integer index = columnIndexes.get(columnName.toLowerCase());
+        if (index == null) {
+            throw managerBackendsException(
+                    computeGroupName, "backend response missing required column " + columnName);
+        }
+        return index;
+    }
+
+    private static String getManagerBackendCell(JsonNode row, int index) {
+        JsonNode cell = row.get(index);
+        if (cell == null || cell.isNull()) {
+            return "";
+        }
+        return cell.asText();
+    }
+
+    @VisibleForTesting
+    static String getComputeGroupNameFromTag(String tag) {
+        Map<String, String> tagMap = parseBackendTag(tag);
+        String computeGroupName = tagMap.get(COMPUTE_GROUP_NAME);
+        if (StringUtils.isNotBlank(computeGroupName)) {
+            return computeGroupName;
+        }
+        return tagMap.get(CLOUD_CLUSTER_NAME);
+    }
+
+    private static Map<String, String> parseBackendTag(String tag) {
+        Map<String, String> tagMap = new HashMap<>();
+        if (StringUtils.isBlank(tag)) {
+            return tagMap;
+        }
+
+        try {
+            JsonNode tagNode = objectMapper.readTree(tag);
+            if (tagNode.isObject()) {
+                tagNode.fields()
+                        .forEachRemaining(
+                                entry -> tagMap.put(entry.getKey(), entry.getValue().asText()));
+                return tagMap;
+            }
+        } catch (IOException e) {
+            // Fall through to parse Doris PrintableMap style tag strings.
+        }
+
+        String tagContent = tag.trim();
+        if (tagContent.startsWith("{") && tagContent.endsWith("}")) {
+            tagContent = tagContent.substring(1, tagContent.length() - 1);
+        }
+        for (String entry : tagContent.split(",")) {
+            String[] keyValue = entry.split(":", 2);
+            if (keyValue.length != 2) {
+                continue;
+            }
+            tagMap.put(stripQuote(keyValue[0]), stripQuote(keyValue[1]));
+        }
+        return tagMap;
+    }
+
+    private static String stripQuote(String value) {
+        String result = value.trim();
+        if (result.length() >= 2) {
+            char first = result.charAt(0);
+            char last = result.charAt(result.length() - 1);
+            if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
+                return result.substring(1, result.length() - 1);
+            }
+        }
+        return result;
+    }
+
+    private static DorisRuntimeException managerBackendsException(
+            String computeGroupName, String reason) {
+        return new DorisRuntimeException(
+                String.format(
+                        "Failed to get backends for compute group '%s' from %s: %s. Required privileges: information_schema SELECT on Doris 3.x/4.x, or ADMIN on Doris 2.1.",
+                        computeGroupName, MANAGER_BACKENDS, reason));
     }
 
     /**

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -354,8 +354,18 @@ public class RestService implements Serializable {
         }
 
         if (StringUtils.isNotBlank(computeGroupName)) {
-            return getManagerBackendsByComputeGroup(
-                    options, readOptions, feNodeList, computeGroupName, logger);
+            try {
+                return getManagerBackendsByComputeGroup(
+                        options, readOptions, feNodeList, computeGroupName, logger);
+            } catch (Exception e) {
+                logger.warn(
+                        "Failed to get backends via manager API for compute group '{}', "
+                                + "the endpoint {} may not be supported on older Doris versions. "
+                                + "Falling back to regular backend discovery: {}",
+                        computeGroupName,
+                        MANAGER_BACKENDS,
+                        e.getMessage());
+            }
         }
 
         for (String feNode : feNodeList) {
@@ -391,8 +401,8 @@ public class RestService implements Serializable {
                 String response = send(options, readOptions, httpGet, logger, false);
                 logger.info("Manager backend info:{}", response);
                 return parseManagerBackends(response, logger, computeGroupName);
-            } catch (ConnectedFailedException e) {
-                logger.info(
+            } catch (Exception e) {
+                logger.warn(
                         "Doris FE node {} is unavailable: {}, Request the next Doris FE node",
                         feNode,
                         e.getMessage());

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
@@ -20,6 +20,7 @@ package org.apache.doris.flink.sink;
 import org.apache.flink.annotation.VisibleForTesting;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisRuntimeException;
@@ -34,9 +35,12 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 
 public class BackendUtil {
     private static final Logger LOG = LoggerFactory.getLogger(BackendUtil.class);
+    private static final String CLOUD_CLUSTER = "cloud_cluster";
+    private static final String COMPUTE_GROUP = "compute_group";
     private final List<BackendV2.BackendRowV2> backends;
     private long pos;
 
@@ -71,11 +75,38 @@ public class BackendUtil {
 
     public static BackendUtil getInstance(
             DorisOptions dorisOptions, DorisReadOptions readOptions, Logger logger) {
+        return getInstance(dorisOptions, readOptions, null, logger);
+    }
+
+    public static BackendUtil getInstance(
+            DorisOptions dorisOptions,
+            DorisReadOptions readOptions,
+            DorisExecutionOptions executionOptions,
+            Logger logger) {
         if (StringUtils.isNotEmpty(dorisOptions.getBenodes())) {
             return new BackendUtil(dorisOptions.getBenodes());
         } else {
-            return new BackendUtil(RestService.getBackendsV2(dorisOptions, readOptions, logger));
+            Properties loadProps =
+                    executionOptions == null ? null : executionOptions.getStreamLoadProp();
+            return new BackendUtil(
+                    RestService.getBackendsV2(
+                            dorisOptions,
+                            readOptions,
+                            getLoadTargetComputeGroup(loadProps),
+                            logger));
         }
+    }
+
+    @VisibleForTesting
+    static String getLoadTargetComputeGroup(Properties loadProps) {
+        if (loadProps == null) {
+            return null;
+        }
+        String computeGroup = loadProps.getProperty(COMPUTE_GROUP);
+        if (StringUtils.isNotBlank(computeGroup)) {
+            return computeGroup;
+        }
+        return loadProps.getProperty(CLOUD_CLUSTER);
     }
 
     public String getAvailableBackend() {

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -27,7 +27,6 @@ import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisBatchLoadException;
 import org.apache.doris.flink.exception.DorisRuntimeException;
-import org.apache.doris.flink.rest.RestService;
 import org.apache.doris.flink.rest.models.RespContent;
 import org.apache.doris.flink.sink.BackendUtil;
 import org.apache.doris.flink.sink.EscapeHandler;
@@ -122,10 +121,7 @@ public class DorisBatchStreamLoad implements Serializable {
             LabelGenerator labelGenerator,
             int subTaskId) {
         this.backendUtil =
-                StringUtils.isNotEmpty(dorisOptions.getBenodes())
-                        ? new BackendUtil(dorisOptions.getBenodes())
-                        : new BackendUtil(
-                                RestService.getBackendsV2(dorisOptions, dorisReadOptions, LOG));
+                BackendUtil.getInstance(dorisOptions, dorisReadOptions, executionOptions, LOG);
         this.hostPort = backendUtil.getAvailableBackend();
         this.username = dorisOptions.getUsername();
         this.password = dorisOptions.getPassword();

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
@@ -22,12 +22,10 @@ import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisRuntimeException;
-import org.apache.doris.flink.rest.RestService;
 import org.apache.doris.flink.sink.BackendUtil;
 import org.apache.doris.flink.sink.DorisCommittable;
 import org.apache.doris.flink.sink.HttpPutBuilder;
@@ -86,10 +84,7 @@ public class DorisCommitter implements Committer<DorisCommittable>, Closeable {
         this.ignoreCommitError = executionOptions.ignoreCommitError();
         this.httpClient = client;
         this.backendUtil =
-                StringUtils.isNotEmpty(dorisOptions.getBenodes())
-                        ? new BackendUtil(dorisOptions.getBenodes())
-                        : new BackendUtil(
-                                RestService.getBackendsV2(dorisOptions, dorisReadOptions, LOG));
+                BackendUtil.getInstance(dorisOptions, dorisReadOptions, executionOptions, LOG);
     }
 
     @Override

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -118,7 +118,8 @@ public class DorisWriter<IN> {
     }
 
     public void initializeLoad(Collection<DorisWriterState> state) {
-        this.backendUtil = BackendUtil.getInstance(dorisOptions, dorisReadOptions, LOG);
+        this.backendUtil =
+                BackendUtil.getInstance(dorisOptions, dorisReadOptions, executionOptions, LOG);
         try {
             if (executionOptions.enabled2PC()) {
                 abortLingeringTransactions(state);

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/rest/TestRestService.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/rest/TestRestService.java
@@ -411,6 +411,79 @@ public class TestRestService {
     }
 
     @Test
+    public void testParseManagerBackendsFilterComputeGroup() {
+        String response =
+                "{\"columnNames\":[\"BackendId\",\"Host\",\"HttpPort\",\"Alive\",\"Tag\"],"
+                        + "\"rows\":["
+                        + "[\"1\",\"192.168.1.1\",\"8042\",\"true\",\"{\\\"compute_group_name\\\":\\\"cluster_a\\\"}\"],"
+                        + "[\"2\",\"192.168.1.2\",\"8042\",\"true\",\"{\\\"compute_group_name\\\":\\\"cluster_b\\\"}\"],"
+                        + "[\"3\",\"192.168.1.3\",\"8042\",\"false\",\"{\\\"compute_group_name\\\":\\\"cluster_a\\\"}\"]"
+                        + "]}";
+
+        List<BackendV2.BackendRowV2> backendRows =
+                RestService.parseManagerBackends(response, logger, "cluster_a");
+
+        Assert.assertEquals(1, backendRows.size());
+        Assert.assertEquals("192.168.1.1:8042", backendRows.get(0).toBackendString());
+    }
+
+    @Test
+    public void testParseManagerBackendsColumnNamesAndCloudCluster() {
+        String response =
+                "{\"code\":0,\"msg\":\"success\",\"data\":{"
+                        + "\"column_names\":[\"BackendId\",\"Host\",\"HttpPort\",\"Alive\",\"Tag\"],"
+                        + "\"rows\":["
+                        + "[\"1\",\"192.168.1.1\",\"8042\",\"true\",\"{\\\"cloud_cluster_name\\\":\\\"cluster_a\\\"}\"]"
+                        + "]}}";
+
+        List<BackendV2.BackendRowV2> backendRows =
+                RestService.parseManagerBackends(response, logger, "cluster_a");
+
+        Assert.assertEquals(1, backendRows.size());
+        Assert.assertEquals("192.168.1.1:8042", backendRows.get(0).toBackendString());
+    }
+
+    @Test
+    public void testParseManagerBackendsPrintableTag() {
+        String tag = "{compute_group_name:cluster_a, location:default}";
+        Assert.assertEquals("cluster_a", RestService.getComputeGroupNameFromTag(tag));
+    }
+
+    @Test
+    public void testParseManagerBackendsNoTargetBackend() {
+        String response =
+                "{\"columnNames\":[\"BackendId\",\"Host\",\"HttpPort\",\"Alive\",\"Tag\"],"
+                        + "\"rows\":["
+                        + "[\"1\",\"192.168.1.1\",\"8042\",\"true\",\"{\\\"compute_group_name\\\":\\\"cluster_a\\\"}\"],"
+                        + "[\"2\",\"192.168.1.2\",\"8042\",\"false\",\"{\\\"compute_group_name\\\":\\\"cluster_b\\\"}\"]"
+                        + "]}";
+
+        thrown.expect(DorisRuntimeException.class);
+        thrown.expectMessage("no alive backend found");
+        RestService.parseManagerBackends(response, logger, "cluster_b");
+    }
+
+    @Test
+    public void testParseManagerBackendsMissingColumn() {
+        String response =
+                "{\"columnNames\":[\"BackendId\",\"Host\",\"HttpPort\",\"Alive\"],"
+                        + "\"rows\":[[\"1\",\"192.168.1.1\",\"8042\",\"true\"]]}";
+
+        thrown.expect(DorisRuntimeException.class);
+        thrown.expectMessage("missing required column Tag");
+        RestService.parseManagerBackends(response, logger, "cluster_a");
+    }
+
+    @Test
+    public void testParseManagerBackendsErrorResponse() {
+        String response = "{\"code\":1,\"msg\":\"Error\",\"data\":\"Access denied\"}";
+
+        thrown.expect(DorisRuntimeException.class);
+        thrown.expectMessage("Error: Access denied");
+        RestService.parseManagerBackends(response, logger, "cluster_a");
+    }
+
+    @Test
     public void testParseBackendV2Error() {
         String response =
                 "{\"backends\":[{\"ip_error_key\":\"192.168.1.1\",\"http_port\":8042,\"is_alive\":true}, {\"ip\":\"192.168.1.2\",\"http_port\":8042,\"is_alive\":true}]}";

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/TestBackendUtil.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/TestBackendUtil.java
@@ -17,7 +17,11 @@
 
 package org.apache.doris.flink.sink;
 
+import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisRuntimeException;
+import org.apache.doris.flink.rest.RestService;
 import org.apache.doris.flink.rest.models.BackendV2;
 import org.junit.After;
 import org.junit.Assert;
@@ -27,8 +31,10 @@ import org.mockito.MockedStatic;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 
 public class TestBackendUtil {
@@ -38,6 +44,9 @@ public class TestBackendUtil {
     @Before
     public void setUp() throws Exception {
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.getLoadTargetComputeGroup(any()))
+                .thenCallRealMethod();
     }
 
     @Test
@@ -84,6 +93,44 @@ public class TestBackendUtil {
     public void testInitBackends() {
         BackendUtil backendUtil = new BackendUtil("127.0.0.1:1");
         Assert.assertTrue(backendUtil.getBackends().isEmpty());
+    }
+
+    @Test
+    public void testGetLoadTargetComputeGroup() {
+        Properties loadProps = new Properties();
+        loadProps.setProperty("cloud_cluster", "cluster_a");
+        Assert.assertEquals("cluster_a", BackendUtil.getLoadTargetComputeGroup(loadProps));
+
+        loadProps.setProperty("compute_group", "cluster_b");
+        Assert.assertEquals("cluster_b", BackendUtil.getLoadTargetComputeGroup(loadProps));
+    }
+
+    @Test
+    public void testGetInstanceUsesLoadTargetComputeGroup() {
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.getInstance(any(), any(), any(), any()))
+                .thenCallRealMethod();
+
+        DorisOptions dorisOptions = DorisOptions.builder().setFenodes("127.0.0.1:8030").build();
+        DorisReadOptions readOptions = DorisReadOptions.defaults();
+        Properties loadProps = new Properties();
+        loadProps.setProperty("cloud_cluster", "cluster_a");
+        loadProps.setProperty("compute_group", "cluster_b");
+        DorisExecutionOptions executionOptions =
+                DorisExecutionOptions.builder().setStreamLoadProp(loadProps).build();
+
+        try (MockedStatic<RestService> restServiceMockedStatic = mockStatic(RestService.class)) {
+            restServiceMockedStatic
+                    .when(() -> RestService.getBackendsV2(any(), any(), any(), any()))
+                    .thenReturn(Arrays.asList(newBackend("127.0.0.1", 8040)));
+
+            BackendUtil backendUtil =
+                    BackendUtil.getInstance(dorisOptions, readOptions, executionOptions, null);
+
+            Assert.assertEquals(1, backendUtil.getBackends().size());
+            restServiceMockedStatic.verify(
+                    () -> RestService.getBackendsV2(any(), any(), eq("cluster_b"), any()));
+        }
     }
 
     private BackendV2.BackendRowV2 newBackend(String host, int port) {

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Deadline;
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.rest.models.BackendV2;
 import org.apache.doris.flink.sink.BackendUtil;
 import org.apache.doris.flink.sink.HttpTestUtil;
 import org.apache.doris.flink.sink.TestUtil;
@@ -47,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
@@ -69,6 +71,12 @@ public class TestDorisBatchStreamLoad {
     @Before
     public void setUp() throws Exception {
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.getInstance(any(), any(), any(), any()))
+                .thenReturn(
+                        new BackendUtil(
+                                Collections.singletonList(
+                                        BackendV2.BackendRowV2.of("127.0.0.1", 8040, true))));
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
     }
 

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchWriter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchWriter.java
@@ -20,6 +20,7 @@ package org.apache.doris.flink.sink.batch;
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.rest.models.BackendV2;
 import org.apache.doris.flink.sink.BackendUtil;
 import org.apache.doris.flink.sink.writer.serializer.DorisRecord;
 import org.apache.doris.flink.sink.writer.serializer.SimpleStringSerializer;
@@ -29,6 +30,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.MockedStatic;
+
+import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
@@ -42,6 +45,12 @@ public class TestDorisBatchWriter {
     @Before
     public void setUp() throws Exception {
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.getInstance(any(), any(), any(), any()))
+                .thenReturn(
+                        new BackendUtil(
+                                Collections.singletonList(
+                                        BackendV2.BackendRowV2.of("127.0.0.1", 8040, true))));
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
     }
 

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/committer/TestDorisCommitter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/committer/TestDorisCommitter.java
@@ -80,6 +80,12 @@ public class TestDorisCommitter {
                 .thenReturn(
                         Collections.singletonList(
                                 BackendV2.BackendRowV2.of("127.0.0.1", 8040, true)));
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.getInstance(any(), any(), any(), any()))
+                .thenReturn(
+                        new BackendUtil(
+                                Collections.singletonList(
+                                        BackendV2.BackendRowV2.of("127.0.0.1", 8040, true))));
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
 
         dorisCommitter =

--- a/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
@@ -41,6 +41,7 @@ import java.util.OptionalLong;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -51,8 +52,15 @@ public class DorisSinkTest {
 
     @Before
     public void setUp() throws Exception {
+        BackendUtil mockBackendUtil = mock(BackendUtil.class);
+        when(mockBackendUtil.getAvailableBackend()).thenReturn("127.0.0.1:8040");
+        when(mockBackendUtil.getAvailableBackend(anyInt())).thenReturn("127.0.0.1:8040");
+
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.getInstance(any(), any(), any(), any()))
+                .thenReturn(mockBackendUtil);
     }
 
     @Test

--- a/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 public class DorisSinkTest {
 

--- a/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
@@ -36,6 +36,9 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 
 import java.util.Collections;
+import java.util.OptionalLong;
+
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -57,6 +60,9 @@ public class DorisSinkTest {
         DorisReadOptions dorisReadOptions = OptionUtils.buildDorisReadOptions();
         DorisRecordSerializer<String> serializer = new SimpleStringSerializer();
         Sink.InitContext initContext = mock(Sink.InitContext.class);
+        when(initContext.metricGroup()).thenReturn(mock(SinkWriterMetricGroup.class));
+        when(initContext.getRestoredCheckpointId()).thenReturn(OptionalLong.empty());
+        when(initContext.getSubtaskId()).thenReturn(0);
 
         DorisExecutionOptions dorisExecutionOptions =
                 DorisExecutionOptions.builder().disable2PC().build();

--- a/flink-doris-connector/flink-doris-connector-flink2/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
+++ b/flink-doris-connector/flink-doris-connector-flink2/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
@@ -39,6 +39,7 @@ import org.mockito.MockedStatic;
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -49,8 +50,15 @@ public class DorisSinkTest {
 
     @Before
     public void setUp() throws Exception {
+        BackendUtil mockBackendUtil = mock(BackendUtil.class);
+        when(mockBackendUtil.getAvailableBackend()).thenReturn("127.0.0.1:8040");
+        when(mockBackendUtil.getAvailableBackend(anyInt())).thenReturn("127.0.0.1:8040");
+
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.getInstance(any(), any(), any(), any()))
+                .thenReturn(mockBackendUtil);
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

In cloud mode, when FE redirect is not used and `benodes` is not configured, the connector discovers backends through the normal backend API. That API returns alive BE nodes
  across all clusters / compute groups.

As a result, stream load may be sent to any BE in the global backend list instead of only the BE nodes that belong to the target compute group. This can cause stream load
  requests to be routed to the wrong compute group.

This PR makes backend discovery compute-group aware:

  - Read the target compute group from stream load properties:
    - `compute_group`
    - fallback to legacy `cloud_cluster`
  - When a target compute group is configured, discover backends from `/rest/v2/manager/node/backends`.
  - Parse backend tags and keep only alive BE nodes whose `compute_group_name` or `cloud_cluster_name` matches the target group.
  - Keep existing behavior when:
    - `benodes` is explicitly configured
    - FE redirect is enabled
    - no compute group is configured
  - Centralize this logic in `BackendUtil` and reuse it in writer, batch stream load, and committer paths.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
