### PR TITLE
[Improve] support postgresql regclass type in cdc sync

### DIFF
--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/tools/cdc/postgres/PostgresType.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/tools/cdc/postgres/PostgresType.java
@@ -55,6 +55,7 @@ public class PostgresType {
     private static final String VARBIT = "varbit";
     private static final String UUID = "uuid";
     private static final String BYTEA = "bytea";
+    private static final String REGCLASS = "regclass";
     private static final String JSON = "json";
     private static final String JSONB = "jsonb";
     private static final String _INT2 = "_int2";
@@ -127,6 +128,7 @@ public class PostgresType {
             case VARBIT:
             case UUID:
             case BYTEA:
+            case REGCLASS:
                 return DorisType.STRING;
             case JSON:
             case JSONB:

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManagerTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/schema/SQLParserSchemaManagerTest.java
@@ -81,6 +81,17 @@ public class SQLParserSchemaManagerTest {
     }
 
     @Test
+    public void testParserPostgresAlterDDLsAddRegclass() {
+        String ddl = "ALTER TABLE access_control_device ADD COLUMN relation_id regclass";
+        List<String> actualDDLs =
+                schemaManager.parseAlterDDLs(SourceConnector.POSTGRES, ddl, dorisTable);
+
+        Assert.assertEquals(1, actualDDLs.size());
+        Assert.assertEquals(
+                "ALTER TABLE `doris`.`tab` ADD COLUMN `relation_id` STRING", actualDDLs.get(0));
+    }
+
+    @Test
     public void testParserAlterDDLsChange() {
         List<String> expectDDLs = new ArrayList<>();
         expectDDLs.add(

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumSchemaChangeImplV2.java
@@ -386,6 +386,12 @@ public class TestJsonDebeziumSchemaChangeImplV2 extends TestJsonDebeziumChangeBa
         JsonNode columns = objectMapper.readTree(columnInfo);
         String dorisTypeName = schemaChange.buildDorisTypeName(columns);
         Assert.assertEquals(dorisTypeName, "VARCHAR(384)");
+
+        columnInfo =
+                "{\"name\":\"RELATION_ID\",\"jdbcType\":1111,\"nativeType\":null,\"typeName\":\"regclass\",\"typeExpression\":\"regclass\",\"charsetName\":null,\"position\":3,\"optional\":true,\"autoIncremented\":false,\"generated\":false,\"comment\":null}";
+        columns = objectMapper.readTree(columnInfo);
+        dorisTypeName = schemaChange.buildDorisTypeName(columns);
+        Assert.assertEquals(dorisTypeName, "STRING");
     }
 
     @Test

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/tools/cdc/postgres/PostgresTypeTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/tools/cdc/postgres/PostgresTypeTest.java
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.tools.cdc.postgres;
+
+import org.apache.doris.flink.catalog.doris.DorisType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PostgresTypeTest {
+    @Test
+    public void regclassTypeTest() {
+        assertEquals(DorisType.STRING, PostgresType.toDorisType("regclass", null, null));
+        assertEquals(DorisType.STRING, PostgresType.toDorisType("REGCLASS", null, null));
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds support for PostgreSQL `regclass` columns in CDC database sync.

Previously, PostgreSQL whole-database sync could fail during schema conversion with:

```text
Unsupported Postgres Type: regclass
