### PR TITLE
[Fix](mongodb-cdc) Fix fullDocument JSON string parsing error

### DIFF
--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoJsonDebeziumDataChange.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoJsonDebeziumDataChange.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
 import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.exception.DorisRuntimeException;
 import org.apache.doris.flink.sink.writer.ChangeEvent;
 import org.apache.doris.flink.sink.writer.serializer.DorisRecord;
 import org.apache.doris.flink.sink.writer.serializer.jsondebezium.CdcDataChange;
@@ -127,6 +128,13 @@ public class MongoJsonDebeziumDataChange extends CdcDataChange implements Change
     @Override
     public Map<String, Object> extractAfterRow(JsonNode recordRoot) {
         JsonNode dataNode = recordRoot.get(FIELD_DATA);
+        if (dataNode != null && dataNode.isTextual()) {
+            try {
+                dataNode = objectMapper.readTree(dataNode.asText());
+            } catch (IOException e) {
+                throw new DorisRuntimeException("Failed to parse fullDocument JSON", e);
+            }
+        }
         return JsonNodeExtractUtil.extractAfterRow(dataNode, objectMapper);
     }
 


### PR DESCRIPTION
## Problem Summary

Debezium may serialize `fullDocument` as a JSON string (TextNode) instead of an ObjectNode. The current `extractAfterRow()` directly passes this TextNode to `JsonNodeExtractUtil.extractAfterRow()`, causing `ClassCastException` or deserialization errors.

## Changes

Add a check in `MongoJsonDebeziumDataChange.extractAfterRow()`: if `dataNode` is textual, parse it with `ObjectMapper.readTree()` before extracting row data.

Fixes #663