### PR TITLE
[Feature](mongodb-cdc) Add date.timezone option for MongoDB to Doris time conversion

### DIFF
--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumChangeContext.java
@@ -48,6 +48,7 @@ public class JsonDebeziumChangeContext implements Serializable {
     private final String targetTablePrefix;
     private final String targetTableSuffix;
     private TableNameConverter tableNameConverter;
+    private String timeZone;
 
     public JsonDebeziumChangeContext(
             DorisOptions dorisOptions,
@@ -104,6 +105,38 @@ public class JsonDebeziumChangeContext implements Serializable {
                 targetTableSuffix,
                 enableDelete);
         this.tableNameConverter = tableNameConverter;
+    }
+
+    public JsonDebeziumChangeContext(
+            DorisOptions dorisOptions,
+            Map<String, String> tableMapping,
+            String sourceTableName,
+            String targetDatabase,
+            DorisTableConfig dorisTableConfig,
+            ObjectMapper objectMapper,
+            Pattern pattern,
+            String lineDelimiter,
+            boolean ignoreUpdateBefore,
+            String targetTablePrefix,
+            String targetTableSuffix,
+            boolean enableDelete,
+            TableNameConverter tableNameConverter,
+            String timeZone) {
+        this(
+                dorisOptions,
+                tableMapping,
+                sourceTableName,
+                targetDatabase,
+                dorisTableConfig,
+                objectMapper,
+                pattern,
+                lineDelimiter,
+                ignoreUpdateBefore,
+                targetTablePrefix,
+                targetTableSuffix,
+                enableDelete,
+                tableNameConverter);
+        this.timeZone = timeZone;
     }
 
     public DorisOptions getDorisOptions() {
@@ -168,5 +201,9 @@ public class JsonDebeziumChangeContext implements Serializable {
     @VisibleForTesting
     public void setTableNameConverter(TableNameConverter tableNameConverter) {
         this.tableNameConverter = tableNameConverter;
+    }
+
+    public String getTimeZone() {
+        return timeZone;
     }
 }

--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSync.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDBDatabaseSync.java
@@ -86,6 +86,12 @@ public class MongoDBDatabaseSync extends DatabaseSync {
                     .noDefaultValue()
                     .withDescription("Table name of the Mongo database to monitor.");
 
+    public static final ConfigOption<String> DATE_TIMEZONE =
+            ConfigOptions.key("date.timezone")
+                    .stringType()
+                    .defaultValue("UTC")
+                    .withDescription(
+                            "The time zone used to convert MongoDB date/timestamp fields. Defaults to UTC.");
     public MongoDBDatabaseSync() throws SQLException {}
 
     @Override
@@ -222,6 +228,9 @@ public class MongoDBDatabaseSync extends DatabaseSync {
             default:
                 throw new IllegalArgumentException("Unsupported startup mode: " + startupMode);
         }
+
+        MongoDateConverter.setTimeZone(config.get(DATE_TIMEZONE));
+
         MongoDBSource<String> mongoDBSource = mongoDBSourceBuilder.deserializer(schema).build();
         return env.fromSource(mongoDBSource, WatermarkStrategy.noWatermarks(), "MongoDB Source");
     }
@@ -243,6 +252,7 @@ public class MongoDBDatabaseSync extends DatabaseSync {
                 .setTargetTablePrefix(tablePrefix)
                 .setTargetTableSuffix(tableSuffix)
                 .setTableNameConverter(converter)
+                .setTimeZone(config.get(DATE_TIMEZONE))
                 .build();
     }
 

--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDateConverter.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/MongoDateConverter.java
@@ -17,22 +17,34 @@
 
 package org.apache.doris.flink.tools.cdc.mongodb;
 
-import org.apache.doris.flink.tools.cdc.DatabaseSyncConfig;
-
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 public class MongoDateConverter {
+    private static final String DEFAULT_TIME_ZONE = "UTC";
+    private static volatile String timeZone = DEFAULT_TIME_ZONE;
+
     private static final ThreadLocal<DateTimeFormatter> dateFormatterThreadLocal =
-            ThreadLocal.withInitial(
-                    () -> DateTimeFormatter.ofPattern(DatabaseSyncConfig.DATETIME_MICRO_FORMAT));
+            ThreadLocal.withInitial(() -> DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"));
+
+    public static void setTimeZone(String timeZone) {
+        MongoDateConverter.timeZone = timeZone;
+    }
+
+    public static String getTimeZone() {
+        return timeZone;
+    }
 
     public static String convertTimestampToString(long timestamp) {
+        return convertTimestampToString(timestamp, timeZone);
+    }
+
+    public static String convertTimestampToString(long timestamp, String timeZone) {
         Instant instant = Instant.ofEpochMilli(timestamp);
-        LocalDateTime localDateTime =
-                LocalDateTime.ofInstant(instant, ZoneId.of(DatabaseSyncConfig.TIME_ZONE_SHANGHAI));
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneId.of(timeZone));
         return dateFormatterThreadLocal.get().format(localDateTime);
     }
+
 }

--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoDBJsonDebeziumSchemaSerializer.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoDBJsonDebeziumSchemaSerializer.java
@@ -64,6 +64,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
     private String targetTablePrefix;
     private String targetTableSuffix;
     private TableNameConverter tableNameConverter;
+    private String timeZone;
 
     public MongoDBJsonDebeziumSchemaSerializer(
             DorisOptions dorisOptions,
@@ -75,7 +76,8 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
             String targetDatabase,
             String targetTablePrefix,
             String targetTableSuffix,
-            TableNameConverter tableNameConverter) {
+            TableNameConverter tableNameConverter,
+            String timeZone) {
         this.dorisOptions = dorisOptions;
         this.pattern = pattern;
         this.sourceTableName = sourceTableName;
@@ -89,6 +91,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
         this.targetTablePrefix = targetTablePrefix;
         this.targetTableSuffix = targetTableSuffix;
         this.tableNameConverter = tableNameConverter;
+        this.timeZone = timeZone;
         if (executionOptions != null) {
             this.lineDelimiter =
                     executionOptions
@@ -114,8 +117,9 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
                         ignoreUpdateBefore,
                         targetTablePrefix,
                         targetTableSuffix,
-                        enableDelete);
-        changeContext.setTableNameConverter(tableNameConverter);
+                        enableDelete,
+                        tableNameConverter,
+                        timeZone);
         this.dataChange = new MongoJsonDebeziumDataChange(changeContext);
         this.schemaChange = new MongoJsonDebeziumSchemaChange(changeContext);
     }
@@ -149,6 +153,7 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
         private String targetTablePrefix = "";
         private String targetTableSuffix = "";
         private TableNameConverter tableNameConverter;
+        private String timeZone;
 
         public MongoDBJsonDebeziumSchemaSerializer.Builder setDorisOptions(
                 DorisOptions dorisOptions) {
@@ -216,6 +221,11 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
             return this;
         }
 
+        public MongoDBJsonDebeziumSchemaSerializer.Builder setTimeZone(String timeZone) {
+            this.timeZone = timeZone;
+            return this;
+        }
+
         public MongoDBJsonDebeziumSchemaSerializer build() {
             return new MongoDBJsonDebeziumSchemaSerializer(
                     dorisOptions,
@@ -227,7 +237,8 @@ public class MongoDBJsonDebeziumSchemaSerializer implements DorisRecordSerialize
                     targetDatabase,
                     targetTablePrefix,
                     targetTableSuffix,
-                    tableNameConverter);
+                    tableNameConverter,
+                    timeZone);
         }
     }
 }

--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoJsonDebeziumSchemaChange.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/mongodb/serializer/MongoJsonDebeziumSchemaChange.java
@@ -43,6 +43,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -174,7 +176,8 @@ public class MongoJsonDebeziumSchemaChange extends CdcSchemaChange {
                                                             : jsonNode.asLong();
                                             String formattedDate =
                                                     MongoDateConverter.convertTimestampToString(
-                                                            timestamp);
+                                                            timestamp,
+                                                            changeContext.getTimeZone());
                                             ((ObjectNode) logData).put(fieldName, formattedDate);
                                             break;
                                         case DECIMAL_FIELD:
@@ -188,6 +191,18 @@ public class MongoJsonDebeziumSchemaChange extends CdcSchemaChange {
                                             ((ObjectNode) logData).put(fieldName, longFiled);
                                             break;
                                     }
+                                }
+                            } else if (fieldNode.isTextual()) {
+                                String text = fieldNode.asText();
+                                try {
+                                    Instant instant = Instant.parse(text);
+                                    String formattedDate =
+                                            MongoDateConverter.convertTimestampToString(
+                                                    instant.toEpochMilli(),
+                                                    changeContext.getTimeZone());
+                                    ((ObjectNode) logData).put(fieldName, formattedDate);
+                                } catch (DateTimeParseException e) {
+                                    // not an ISO date string, ignore
                                 }
                             }
                         });


### PR DESCRIPTION
## Problem Summary

`MongoDateConverter` hardcodes `Asia/Shanghai`, making it impossible to configure the target timezone. Additionally:

1. Debezium serializes BSON Date as ISO 8601 strings (e.g. `\"2024-06-04T08:03:37Z\"`) instead of `{\"$date\": ...}` objects. The existing `formatSpecialFieldData()` only handles the object form.

2. `MongoDateConverter.timeZone` is a static variable that resets to default `\"UTC\"` after serializer deserialization to TaskManagers.

## Changes

1. Add `date.timezone` ConfigOption (default `UTC`).
2. Add ISO 8601 string parsing in `formatSpecialFieldData()`.
3. Pass timezone through `JsonDebeziumChangeContext` (Serializable) to TaskManagers.
4. Remove hardcoded `Asia/Shanghai` from `MongoDateConverter`.

Fixes #666