### PR TITLE
[Feature] Support HTTPS for Doris HTTP requests

### DIFF
--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/cfg/DorisConnectionOptions.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/cfg/DorisConnectionOptions.java
@@ -31,6 +31,7 @@ public class DorisConnectionOptions implements Serializable {
     protected final String password;
     protected String jdbcUrl;
     protected String benodes;
+    protected DorisHttpOptions httpOptions = DorisHttpOptions.defaults();
 
     /**
      * Used to enable automatic redirection of fe, When it is not enabled, it will actively request
@@ -57,10 +58,29 @@ public class DorisConnectionOptions implements Serializable {
             String password,
             String jdbcUrl,
             boolean autoRedirect) {
+        this(
+                fenodes,
+                benodes,
+                username,
+                password,
+                jdbcUrl,
+                autoRedirect,
+                DorisHttpOptions.defaults());
+    }
+
+    public DorisConnectionOptions(
+            String fenodes,
+            String benodes,
+            String username,
+            String password,
+            String jdbcUrl,
+            boolean autoRedirect,
+            DorisHttpOptions httpOptions) {
         this(fenodes, username, password);
         this.benodes = benodes;
         this.jdbcUrl = jdbcUrl;
         this.autoRedirect = autoRedirect;
+        this.httpOptions = httpOptions == null ? DorisHttpOptions.defaults() : httpOptions;
     }
 
     public String getFenodes() {
@@ -87,6 +107,14 @@ public class DorisConnectionOptions implements Serializable {
         return autoRedirect;
     }
 
+    public DorisHttpOptions getHttpOptions() {
+        return httpOptions;
+    }
+
+    public boolean isEnableHttps() {
+        return httpOptions.isEnableHttps();
+    }
+
     /** Builder for {@link DorisConnectionOptions}. */
     public static class DorisConnectionOptionsBuilder {
         private String fenodes;
@@ -95,6 +123,7 @@ public class DorisConnectionOptions implements Serializable {
         private String password;
         private String jdbcUrl;
         private boolean autoRedirect;
+        private DorisHttpOptions httpOptions = DorisHttpOptions.defaults();
 
         public DorisConnectionOptionsBuilder withFenodes(String fenodes) {
             this.fenodes = fenodes;
@@ -126,9 +155,14 @@ public class DorisConnectionOptions implements Serializable {
             return this;
         }
 
+        public DorisConnectionOptionsBuilder withHttpOptions(DorisHttpOptions httpOptions) {
+            this.httpOptions = httpOptions;
+            return this;
+        }
+
         public DorisConnectionOptions build() {
             return new DorisConnectionOptions(
-                    fenodes, benodes, username, password, jdbcUrl, autoRedirect);
+                    fenodes, benodes, username, password, jdbcUrl, autoRedirect, httpOptions);
         }
     }
 }

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/cfg/DorisHttpOptions.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/cfg/DorisHttpOptions.java
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.cfg;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** HTTP protocol options shared by Doris REST requests. */
+public class DorisHttpOptions implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private static final String DEFAULT_KEY_STORE_TYPE = "JKS";
+
+    private final boolean enableHttps;
+    private final String httpsKeyStorePath;
+    private final String httpsKeyStoreType;
+    private final String httpsKeyStorePassword;
+
+    public DorisHttpOptions(
+            boolean enableHttps,
+            String httpsKeyStorePath,
+            String httpsKeyStoreType,
+            String httpsKeyStorePassword) {
+        this.enableHttps = enableHttps;
+        this.httpsKeyStorePath = httpsKeyStorePath;
+        this.httpsKeyStoreType =
+                httpsKeyStoreType == null ? DEFAULT_KEY_STORE_TYPE : httpsKeyStoreType;
+        this.httpsKeyStorePassword = httpsKeyStorePassword;
+    }
+
+    public static DorisHttpOptions defaults() {
+        return of(false);
+    }
+
+    public static DorisHttpOptions of(boolean enableHttps) {
+        return new DorisHttpOptions(enableHttps, null, DEFAULT_KEY_STORE_TYPE, null);
+    }
+
+    public boolean isEnableHttps() {
+        return enableHttps;
+    }
+
+    public String getHttpsKeyStorePath() {
+        return httpsKeyStorePath;
+    }
+
+    public String getHttpsKeyStoreType() {
+        return httpsKeyStoreType;
+    }
+
+    public String getHttpsKeyStorePassword() {
+        return httpsKeyStorePassword;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DorisHttpOptions that = (DorisHttpOptions) o;
+        return enableHttps == that.enableHttps
+                && Objects.equals(httpsKeyStorePath, that.httpsKeyStorePath)
+                && Objects.equals(httpsKeyStoreType, that.httpsKeyStoreType)
+                && Objects.equals(httpsKeyStorePassword, that.httpsKeyStorePassword);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                enableHttps, httpsKeyStorePath, httpsKeyStoreType, httpsKeyStorePassword);
+    }
+}

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/cfg/DorisOptions.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/cfg/DorisOptions.java
@@ -51,7 +51,27 @@ public class DorisOptions extends DorisConnectionOptions {
             String tableIdentifier,
             String jdbcUrl,
             boolean redirect) {
-        super(fenodes, beNodes, username, password, jdbcUrl, redirect);
+        this(
+                fenodes,
+                beNodes,
+                username,
+                password,
+                tableIdentifier,
+                jdbcUrl,
+                redirect,
+                DorisHttpOptions.defaults());
+    }
+
+    public DorisOptions(
+            String fenodes,
+            String beNodes,
+            String username,
+            String password,
+            String tableIdentifier,
+            String jdbcUrl,
+            boolean redirect,
+            DorisHttpOptions httpOptions) {
+        super(fenodes, beNodes, username, password, jdbcUrl, redirect, httpOptions);
         this.tableIdentifier = tableIdentifier;
     }
 
@@ -82,13 +102,21 @@ public class DorisOptions extends DorisConnectionOptions {
                 && Objects.equals(username, that.username)
                 && Objects.equals(password, that.password)
                 && Objects.equals(jdbcUrl, that.jdbcUrl)
-                && Objects.equals(benodes, that.benodes);
+                && Objects.equals(benodes, that.benodes)
+                && Objects.equals(httpOptions, that.httpOptions);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
-                fenodes, username, password, jdbcUrl, benodes, autoRedirect, tableIdentifier);
+                fenodes,
+                username,
+                password,
+                jdbcUrl,
+                benodes,
+                autoRedirect,
+                tableIdentifier,
+                httpOptions);
     }
 
     /** Builder of {@link DorisOptions}. */
@@ -99,6 +127,7 @@ public class DorisOptions extends DorisConnectionOptions {
         private String username;
         private String password;
         private boolean autoRedirect = true;
+        private DorisHttpOptions httpOptions = DorisHttpOptions.defaults();
         private String tableIdentifier;
 
         /**
@@ -179,6 +208,11 @@ public class DorisOptions extends DorisConnectionOptions {
             return this;
         }
 
+        public Builder setHttpOptions(DorisHttpOptions httpOptions) {
+            this.httpOptions = httpOptions;
+            return this;
+        }
+
         /**
          * Build the {@link DorisOptions}.
          *
@@ -189,7 +223,14 @@ public class DorisOptions extends DorisConnectionOptions {
             // multi table load, don't need check
             // checkNotNull(tableIdentifier, "No tableIdentifier supplied.");
             return new DorisOptions(
-                    fenodes, benodes, username, password, tableIdentifier, jdbcUrl, autoRedirect);
+                    fenodes,
+                    benodes,
+                    username,
+                    password,
+                    tableIdentifier,
+                    jdbcUrl,
+                    autoRedirect,
+                    httpOptions);
         }
     }
 }

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/rest/DorisUrlBuilder.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/rest/DorisUrlBuilder.java
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.rest;
+
+/** Builds Doris HTTP REST URLs with a shared protocol switch. */
+public class DorisUrlBuilder {
+    private final boolean enableHttps;
+
+    public DorisUrlBuilder(boolean enableHttps) {
+        this.enableHttps = enableHttps;
+    }
+
+    public String baseUrl(String hostPort) {
+        return scheme() + "://" + hostPort;
+    }
+
+    public String streamLoad(String hostPort, String db, String table) {
+        return String.format("%s/api/%s/%s/_stream_load", baseUrl(hostPort), db, table);
+    }
+
+    public String streamLoad2pc(String hostPort, String db) {
+        return String.format("%s/api/%s/_stream_load_2pc", baseUrl(hostPort), db);
+    }
+
+    public String tableSchema(String hostPort, String db, String table) {
+        return String.format("%s/api/%s/%s/_schema", baseUrl(hostPort), db, table);
+    }
+
+    public String catalogTableSchema(String hostPort, String catalog, String db, String table) {
+        return String.format("%s/api/%s/%s/%s/_schema", baseUrl(hostPort), catalog, db, table);
+    }
+
+    public String queryPlan(String hostPort, String db, String table) {
+        return String.format("%s/api/%s/%s/_query_plan", baseUrl(hostPort), db, table);
+    }
+
+    public String informationSchemaQuery(String hostPort) {
+        return baseUrl(hostPort) + "/api/query/default_cluster/information_schema";
+    }
+
+    public String schemaChange(String hostPort, String database) {
+        return String.format("%s/api/query/default_cluster/%s", baseUrl(hostPort), database);
+    }
+
+    public String lightSchemaChange(String hostPort, String database, String table) {
+        return String.format(
+                "%s/api/enable_light_schema_change/%s/%s", baseUrl(hostPort), database, table);
+    }
+
+    public String backends(String hostPort) {
+        return baseUrl(hostPort) + "/api/backends?is_alive=true";
+    }
+
+    public String copyUpload(String hostPort) {
+        return baseUrl(hostPort) + "/copy/upload";
+    }
+
+    public String copyQuery(String hostPort) {
+        return baseUrl(hostPort) + "/copy/query";
+    }
+
+    private String scheme() {
+        return enableHttps ? "https" : "http";
+    }
+}

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/rest/RestService.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/rest/RestService.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.flink.cfg.ConfigurationOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
@@ -43,6 +42,7 @@ import org.apache.doris.flink.rest.models.Schema;
 import org.apache.doris.flink.rest.models.Tablet;
 import org.apache.doris.flink.sink.BackendUtil;
 import org.apache.doris.flink.sink.HttpGetWithEntity;
+import org.apache.doris.flink.sink.HttpUtil;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.config.RequestConfig;
@@ -51,6 +51,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -58,11 +59,8 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -89,15 +87,7 @@ public class RestService implements Serializable {
     public static final int REST_RESPONSE_CODE_OK = 0;
     private static final String REST_RESPONSE_BE_ROWS_KEY = "rows";
     private static final String UNIQUE_KEYS_TYPE = "UNIQUE_KEYS";
-    @Deprecated private static final String BACKENDS = "/rest/v1/system?path=//backends";
-    private static final String BACKENDS_V2 = "/api/backends?is_alive=true";
-    private static final String FE_LOGIN = "/rest/v1/login";
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final String TABLE_SCHEMA_API = "http://%s/api/%s/%s/_schema";
-    private static final String CATALOG_TABLE_SCHEMA_API = "http://%s/api/%s/%s/%s/_schema";
-    private static final String QUERY_PLAN_API = "http://%s/api/%s/%s/_query_plan";
-    private static final String STATEMENT_EXEC_API =
-            "http://%s/api/query/default_cluster/information_schema";
 
     /**
      * send request to Doris FE and get response json string.
@@ -187,37 +177,22 @@ public class RestService implements Serializable {
 
     private static String getConnectionPost(
             HttpRequestBase request, DorisOptions dorisOptions, Logger logger) throws IOException {
-        URL url = new URL(request.getURI().toString());
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        conn.setInstanceFollowRedirects(false);
-        conn.setRequestMethod(request.getMethod());
-        conn.setRequestProperty("Authorization", authHeader(dorisOptions));
-        InputStream content = ((HttpPost) request).getEntity().getContent();
-        String res = IOUtils.toString(content);
-        conn.setDoOutput(true);
-        conn.setDoInput(true);
-        conn.setConnectTimeout(request.getConfig().getConnectTimeout());
-        conn.setReadTimeout(request.getConfig().getSocketTimeout());
-        PrintWriter out = new PrintWriter(conn.getOutputStream());
-        // send request params
-        out.print(res);
-        // flush
-        out.flush();
-        // read response
-        return parseResponse(conn, logger);
+        request.setHeader(HttpHeaders.AUTHORIZATION, authHeader(dorisOptions));
+        try (CloseableHttpClient httpClient =
+                        HttpUtil.buildHttpClientBuilder(dorisOptions.getHttpOptions()).build();
+                CloseableHttpResponse response = httpClient.execute(request)) {
+            return parseResponse(response, logger);
+        }
     }
 
     private static String getConnectionGet(
             HttpRequestBase request, DorisOptions dorisOptions, Logger logger) throws IOException {
-        URL realUrl = new URL(request.getURI().toString());
-        // open connection
-        HttpURLConnection connection = (HttpURLConnection) realUrl.openConnection();
-        connection.setRequestProperty("Authorization", authHeader(dorisOptions));
-
-        connection.setConnectTimeout(request.getConfig().getConnectTimeout());
-        connection.setReadTimeout(request.getConfig().getSocketTimeout());
-        connection.connect();
-        return parseResponse(connection, logger);
+        request.setHeader(HttpHeaders.AUTHORIZATION, authHeader(dorisOptions));
+        try (CloseableHttpClient httpClient =
+                        HttpUtil.buildHttpClientBuilder(dorisOptions.getHttpOptions()).build();
+                CloseableHttpResponse response = httpClient.execute(request)) {
+            return parseResponse(response, logger);
+        }
     }
 
     @VisibleForTesting
@@ -237,6 +212,18 @@ public class RestService implements Serializable {
             }
             return result.toString();
         }
+    }
+
+    private static String parseResponse(CloseableHttpResponse response, Logger logger)
+            throws IOException {
+        if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK
+                || response.getEntity() == null) {
+            logger.warn(
+                    "Failed to get response from Doris, http code is {}",
+                    response.getStatusLine().getStatusCode());
+            throw new IOException("Failed to get response from Doris");
+        }
+        return EntityUtils.toString(new BufferedHttpEntity(response.getEntity()));
     }
 
     /**
@@ -275,6 +262,12 @@ public class RestService implements Serializable {
     @VisibleForTesting
     public static String randomEndpoint(String feNodes, Logger logger)
             throws IllegalArgumentException {
+        return randomEndpoint(feNodes, false, logger);
+    }
+
+    @VisibleForTesting
+    public static String randomEndpoint(String feNodes, boolean enableHttps, Logger logger)
+            throws IllegalArgumentException {
         logger.trace("Parse fenodes '{}'.", feNodes);
         if (StringUtils.isEmpty(feNodes)) {
             logger.error(ILLEGAL_ARGUMENT_MESSAGE, "fenodes", feNodes);
@@ -284,7 +277,27 @@ public class RestService implements Serializable {
         Collections.shuffle(nodes);
         for (String feNode : nodes) {
             String host = feNode.trim();
-            if (BackendUtil.tryHttpConnection(host)) {
+            if (BackendUtil.tryHttpConnection(host, enableHttps)) {
+                return host;
+            }
+        }
+        throw new DorisRuntimeException(
+                "No Doris FE is available, please check configuration or cluster status.");
+    }
+
+    @VisibleForTesting
+    public static String randomEndpoint(DorisOptions options, Logger logger)
+            throws IllegalArgumentException {
+        logger.trace("Parse fenodes '{}'.", options.getFenodes());
+        if (StringUtils.isEmpty(options.getFenodes())) {
+            logger.error(ILLEGAL_ARGUMENT_MESSAGE, "fenodes", options.getFenodes());
+            throw new IllegalArgumentException("fenodes", options.getFenodes());
+        }
+        List<String> nodes = Arrays.asList(options.getFenodes().split(","));
+        Collections.shuffle(nodes);
+        for (String feNode : nodes) {
+            String host = feNode.trim();
+            if (BackendUtil.tryHttpConnection(host, options.getHttpOptions())) {
                 return host;
             }
         }
@@ -333,7 +346,7 @@ public class RestService implements Serializable {
 
         for (String feNode : feNodeList) {
             try {
-                String beUrl = "http://" + feNode + BACKENDS_V2;
+                String beUrl = new DorisUrlBuilder(options.isEnableHttps()).backends(feNode);
                 HttpGet httpGet = new HttpGet(beUrl);
                 String response = send(options, readOptions, httpGet, logger);
                 logger.info("Backend Info:{}", response);
@@ -402,22 +415,16 @@ public class RestService implements Serializable {
             throws DorisException {
         logger.trace("Finding schema.");
         String[] tableIdentifier = parseIdentifier(options.getTableIdentifier(), logger);
+        DorisUrlBuilder urlBuilder = new DorisUrlBuilder(options.isEnableHttps());
+        String feEndpoint = randomEndpoint(options, logger);
         String tableSchemaUri;
         if (tableIdentifier.length == 2) {
             tableSchemaUri =
-                    String.format(
-                            TABLE_SCHEMA_API,
-                            randomEndpoint(options.getFenodes(), logger),
-                            tableIdentifier[0],
-                            tableIdentifier[1]);
+                    urlBuilder.tableSchema(feEndpoint, tableIdentifier[0], tableIdentifier[1]);
         } else if (tableIdentifier.length == 3) {
             tableSchemaUri =
-                    String.format(
-                            CATALOG_TABLE_SCHEMA_API,
-                            randomEndpoint(options.getFenodes(), logger),
-                            tableIdentifier[0],
-                            tableIdentifier[1],
-                            tableIdentifier[2]);
+                    urlBuilder.catalogTableSchema(
+                            feEndpoint, tableIdentifier[0], tableIdentifier[1], tableIdentifier[2]);
         } else {
             throw new IllegalArgumentException(
                     "table identifier is illegal, should be db.table or catalog.db.table");
@@ -435,14 +442,11 @@ public class RestService implements Serializable {
         Object responseData = null;
         try {
             String tableSchemaUri =
-                    String.format(
-                            TABLE_SCHEMA_API,
-                            randomEndpoint(dorisOptions.getFenodes(), logger),
-                            db,
-                            table);
+                    new DorisUrlBuilder(dorisOptions.isEnableHttps())
+                            .tableSchema(randomEndpoint(dorisOptions, logger), db, table);
             HttpGetWithEntity httpGet = new HttpGetWithEntity(tableSchemaUri);
             httpGet.setHeader(HttpHeaders.AUTHORIZATION, authHeader(dorisOptions));
-            JsonNode response = handleResponse(httpGet, logger);
+            JsonNode response = handleResponse(httpGet, dorisOptions, logger);
             responseData = response.path("data");
             String schemaStr = objectMapper.writeValueAsString(responseData);
             return objectMapper.readValue(schemaStr, Schema.class);
@@ -454,7 +458,16 @@ public class RestService implements Serializable {
 
     @VisibleForTesting
     public static JsonNode handleResponse(HttpUriRequest request, Logger logger) {
-        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+        return handleResponse(request, null, logger);
+    }
+
+    @VisibleForTesting
+    public static JsonNode handleResponse(
+            HttpUriRequest request, DorisOptions dorisOptions, Logger logger) {
+        try (CloseableHttpClient httpclient =
+                dorisOptions == null
+                        ? HttpClients.createDefault()
+                        : HttpUtil.buildHttpClientBuilder(dorisOptions.getHttpOptions()).build()) {
             CloseableHttpResponse response = httpclient.execute(request);
             final int statusCode = response.getStatusLine().getStatusCode();
             final String reasonPhrase = response.getStatusLine().getReasonPhrase();
@@ -484,7 +497,8 @@ public class RestService implements Serializable {
             Map<String, String> param = new HashMap<>();
             param.put("stmt", "show frontends");
             String requestUrl =
-                    String.format(STATEMENT_EXEC_API, randomEndpoint(options.getFenodes(), logger));
+                    new DorisUrlBuilder(options.isEnableHttps())
+                            .informationSchemaQuery(randomEndpoint(options, logger));
             HttpPost httpPost = new HttpPost(requestUrl);
             httpPost.setHeader(HttpHeaders.AUTHORIZATION, authHeader(options));
             httpPost.setHeader(
@@ -492,7 +506,7 @@ public class RestService implements Serializable {
                     String.format("application/json;charset=%s", "UTF-8"));
             httpPost.setEntity(new StringEntity(objectMapper.writeValueAsString(param), "UTF-8"));
 
-            JsonNode response = handleResponse(httpPost, logger);
+            JsonNode response = handleResponse(httpPost, options, logger);
             logger.info("Get ArrowFlightSqlPort response is '{}'.", response);
             return getArrowFlightSqlPort(response);
         } catch (Exception ex) {
@@ -621,11 +635,11 @@ public class RestService implements Serializable {
         String[] tableIdentifier = parseIdentifier(options.getTableIdentifier(), logger);
 
         String queryPlanUri =
-                String.format(
-                        QUERY_PLAN_API,
-                        randomEndpoint(options.getFenodes(), logger),
-                        tableIdentifier[0],
-                        tableIdentifier[1]);
+                new DorisUrlBuilder(options.isEnableHttps())
+                        .queryPlan(
+                                randomEndpoint(options, logger),
+                                tableIdentifier[0],
+                                tableIdentifier[1]);
         HttpPost httpPost = new HttpPost(queryPlanUri);
         String entity = "{\"sql\": \"" + sql + "\"}";
         logger.debug("Post body Sending to Doris FE is: '{}'.", entity);

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/BackendUtil.java
@@ -20,6 +20,7 @@ package org.apache.doris.flink.sink;
 import org.apache.flink.annotation.VisibleForTesting;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisRuntimeException;
@@ -29,8 +30,6 @@ import org.apache.doris.flink.rest.models.BackendV2.BackendRowV2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -38,14 +37,33 @@ import java.util.List;
 public class BackendUtil {
     private static final Logger LOG = LoggerFactory.getLogger(BackendUtil.class);
     private final List<BackendV2.BackendRowV2> backends;
+    private final DorisHttpOptions httpOptions;
     private long pos;
 
     public BackendUtil(List<BackendV2.BackendRowV2> backends) {
+        this(backends, DorisHttpOptions.defaults());
+    }
+
+    public BackendUtil(List<BackendV2.BackendRowV2> backends, boolean enableHttps) {
+        this(backends, DorisHttpOptions.of(enableHttps));
+    }
+
+    public BackendUtil(List<BackendV2.BackendRowV2> backends, DorisHttpOptions httpOptions) {
         this.backends = backends;
+        this.httpOptions = httpOptions == null ? DorisHttpOptions.defaults() : httpOptions;
         this.pos = 0;
     }
 
     public BackendUtil(String beNodes) {
+        this(beNodes, DorisHttpOptions.defaults());
+    }
+
+    public BackendUtil(String beNodes, boolean enableHttps) {
+        this(beNodes, DorisHttpOptions.of(enableHttps));
+    }
+
+    public BackendUtil(String beNodes, DorisHttpOptions httpOptions) {
+        this.httpOptions = httpOptions == null ? DorisHttpOptions.defaults() : httpOptions;
         this.backends = initBackends(beNodes);
         this.pos = 0;
     }
@@ -55,7 +73,7 @@ public class BackendUtil {
         List<String> nodes = Arrays.asList(beNodes.split(","));
         nodes.forEach(
                 node -> {
-                    if (tryHttpConnection(node)) {
+                    if (tryHttpConnection(node, httpOptions)) {
                         LOG.info("{} backend http connection success.", node);
                         node = node.trim();
                         String[] ipAndPort = node.split(":");
@@ -72,9 +90,11 @@ public class BackendUtil {
     public static BackendUtil getInstance(
             DorisOptions dorisOptions, DorisReadOptions readOptions, Logger logger) {
         if (StringUtils.isNotEmpty(dorisOptions.getBenodes())) {
-            return new BackendUtil(dorisOptions.getBenodes());
+            return new BackendUtil(dorisOptions.getBenodes(), dorisOptions.getHttpOptions());
         } else {
-            return new BackendUtil(RestService.getBackendsV2(dorisOptions, readOptions, logger));
+            return new BackendUtil(
+                    RestService.getBackendsV2(dorisOptions, readOptions, logger),
+                    dorisOptions.getHttpOptions());
         }
     }
 
@@ -89,7 +109,7 @@ public class BackendUtil {
                     backends.get((int) ((pos + subtaskId) % backends.size()));
             pos++;
             String res = backend.toBackendString();
-            if (tryHttpConnection(res)) {
+            if (tryHttpConnection(res, httpOptions)) {
                 return res;
             }
         }
@@ -97,31 +117,15 @@ public class BackendUtil {
     }
 
     public static boolean tryHttpConnection(String host) {
-        try {
-            LOG.debug("try to connect host {}", host);
-            host = "http://" + host;
-            URL url = new URL(host);
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
-            connection.setConnectTimeout(60000);
-            connection.setReadTimeout(60000);
-            int responseCode = connection.getResponseCode();
-            String responseMessage = connection.getResponseMessage();
-            connection.disconnect();
-            if (responseCode < 500) {
-                // code greater than 500 means a server-side exception.
-                return true;
-            }
-            LOG.warn(
-                    "Failed to connect host {}, responseCode={}, msg={}",
-                    host,
-                    responseCode,
-                    responseMessage);
-            return false;
-        } catch (Exception ex) {
-            LOG.warn("Failed to connect to host:{}", host, ex);
-            return false;
-        }
+        return tryHttpConnection(host, false);
+    }
+
+    public static boolean tryHttpConnection(String host, boolean enableHttps) {
+        return tryHttpConnection(host, DorisHttpOptions.of(enableHttps));
+    }
+
+    public static boolean tryHttpConnection(String host, DorisHttpOptions httpOptions) {
+        return HttpUtil.tryHttpConnection(host, httpOptions);
     }
 
     @VisibleForTesting

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/HttpUtil.java
@@ -17,9 +17,15 @@
 
 package org.apache.doris.flink.sink;
 
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.exception.DorisRuntimeException;
+import org.apache.http.client.RedirectStrategy;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.config.ConnectionConfig;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
@@ -27,31 +33,56 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.protocol.HttpRequestExecutor;
 import org.apache.http.protocol.RequestContent;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.FileInputStream;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
 
 import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT;
 import static org.apache.doris.flink.cfg.ConfigurationOptions.SINK_HTTP_UTF8_CHARSET_DEFAULT;
 
 /** util to build http client. */
 public class HttpUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(HttpUtil.class);
     private final int connectTimeout;
     private final int waitForContinueTimeout;
     private final boolean httpUtf8Charset;
+    private final DorisHttpOptions httpOptions;
     private HttpClientBuilder httpClientBuilder;
+    private static final RedirectStrategy REDIRECT_PUT_STRATEGY =
+            new DefaultRedirectStrategy() {
+                @Override
+                protected boolean isRedirectable(String method) {
+                    return true;
+                }
+            };
 
     public HttpUtil() {
+        this(DorisHttpOptions.defaults());
+    }
+
+    public HttpUtil(DorisHttpOptions httpOptions) {
         this.connectTimeout = DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT;
         this.waitForContinueTimeout = DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT;
         this.httpUtf8Charset = SINK_HTTP_UTF8_CHARSET_DEFAULT;
+        this.httpOptions = httpOptions == null ? DorisHttpOptions.defaults() : httpOptions;
         settingStreamHttpClientBuilder();
     }
 
     public HttpUtil(DorisReadOptions readOptions, boolean httpUtf8Charset) {
+        this(readOptions, httpUtf8Charset, DorisHttpOptions.defaults());
+    }
+
+    public HttpUtil(
+            DorisReadOptions readOptions, boolean httpUtf8Charset, DorisHttpOptions httpOptions) {
         this.connectTimeout = readOptions.getRequestConnectTimeoutMs();
         this.waitForContinueTimeout = readOptions.getRequestConnectTimeoutMs();
         this.httpUtf8Charset = httpUtf8Charset;
+        this.httpOptions = httpOptions == null ? DorisHttpOptions.defaults() : httpOptions;
         settingStreamHttpClientBuilder();
     }
 
@@ -66,17 +97,11 @@ public class HttpUtil {
                             .build();
         }
         this.httpClientBuilder =
-                HttpClients.custom()
+                configureSsl(HttpClients.custom())
                         .setDefaultConnectionConfig(connectionConfig)
                         // default timeout 3s, maybe report 307 error when fe busy
                         .setRequestExecutor(new HttpRequestExecutor(waitForContinueTimeout))
-                        .setRedirectStrategy(
-                                new DefaultRedirectStrategy() {
-                                    @Override
-                                    protected boolean isRedirectable(String method) {
-                                        return true;
-                                    }
-                                })
+                        .setRedirectStrategy(REDIRECT_PUT_STRATEGY)
                         .setRetryHandler((exception, executionCount, context) -> false)
                         .setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE)
                         .setDefaultRequestConfig(
@@ -111,15 +136,9 @@ public class HttpUtil {
                             .setUnmappableInputAction(CodingErrorAction.REPLACE)
                             .build();
         }
-        return HttpClients.custom()
+        return configureSsl(HttpClients.custom())
                 .setDefaultConnectionConfig(connectionConfig)
-                .setRedirectStrategy(
-                        new DefaultRedirectStrategy() {
-                            @Override
-                            protected boolean isRedirectable(String method) {
-                                return true;
-                            }
-                        })
+                .setRedirectStrategy(REDIRECT_PUT_STRATEGY)
                 .setDefaultRequestConfig(
                         RequestConfig.custom()
                                 .setConnectTimeout(connectTimeout)
@@ -131,7 +150,7 @@ public class HttpUtil {
     }
 
     public HttpClientBuilder getHttpClientBuilderForCopyBatch() {
-        return HttpClients.custom()
+        return configureSsl(HttpClients.custom())
                 .disableRedirectHandling()
                 .setDefaultRequestConfig(
                         RequestConfig.custom()
@@ -141,5 +160,71 @@ public class HttpUtil {
                                 // default checkpoint timeout is 10min
                                 .setSocketTimeout(9 * 60 * 1000)
                                 .build());
+    }
+
+    public static HttpClientBuilder buildHttpClientBuilder(DorisHttpOptions httpOptions) {
+        return new HttpUtil(httpOptions).newHttpClientBuilder();
+    }
+
+    public static RedirectStrategy getRedirectPutStrategy() {
+        return REDIRECT_PUT_STRATEGY;
+    }
+
+    public static boolean tryHttpConnection(String host, DorisHttpOptions httpOptions) {
+        DorisHttpOptions options = httpOptions == null ? DorisHttpOptions.defaults() : httpOptions;
+        String url = (options.isEnableHttps() ? "https://" : "http://") + host;
+        try (CloseableHttpClient httpClient = buildHttpClientBuilder(options).build()) {
+            LOG.debug("try to connect host {}", url);
+            HttpGet httpGet = new HttpGet(url);
+            httpGet.setConfig(
+                    RequestConfig.custom()
+                            .setConnectTimeout(60000)
+                            .setSocketTimeout(60000)
+                            .build());
+            try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+                int responseCode = response.getStatusLine().getStatusCode();
+                String responseMessage = response.getStatusLine().getReasonPhrase();
+                if (responseCode < 500) {
+                    // code greater than 500 means a server-side exception.
+                    return true;
+                }
+                LOG.warn(
+                        "Failed to connect host {}, responseCode={}, msg={}",
+                        url,
+                        responseCode,
+                        responseMessage);
+                return false;
+            }
+        } catch (Exception ex) {
+            LOG.warn("Failed to connect to host:{}", url, ex);
+            return false;
+        }
+    }
+
+    private HttpClientBuilder newHttpClientBuilder() {
+        return configureSsl(HttpClients.custom());
+    }
+
+    private HttpClientBuilder configureSsl(HttpClientBuilder builder) {
+        if (!httpOptions.isEnableHttps()) {
+            return builder;
+        }
+        if (httpOptions.getHttpsKeyStorePath() == null
+                || httpOptions.getHttpsKeyStorePath().isEmpty()) {
+            return builder;
+        }
+        try {
+            KeyStore keyStore = KeyStore.getInstance(httpOptions.getHttpsKeyStoreType());
+            try (FileInputStream input = new FileInputStream(httpOptions.getHttpsKeyStorePath())) {
+                String password = httpOptions.getHttpsKeyStorePassword();
+                keyStore.load(input, password == null ? null : password.toCharArray());
+            }
+            SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
+            sslContextBuilder.loadTrustMaterial(keyStore, null);
+            return builder.setSSLSocketFactory(
+                    new SSLConnectionSocketFactory(sslContextBuilder.build()));
+        } catch (Exception e) {
+            throw new DorisRuntimeException("Failed to build Doris HTTPS client", e);
+        }
     }
 }

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/batch/DorisBatchStreamLoad.java
@@ -27,6 +27,7 @@ import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisBatchLoadException;
 import org.apache.doris.flink.exception.DorisRuntimeException;
+import org.apache.doris.flink.rest.DorisUrlBuilder;
 import org.apache.doris.flink.rest.RestService;
 import org.apache.doris.flink.rest.models.RespContent;
 import org.apache.doris.flink.sink.BackendUtil;
@@ -90,7 +91,7 @@ public class DorisBatchStreamLoad implements Serializable {
     private static final long STREAM_LOAD_MAX_ROWS = Integer.MAX_VALUE;
     private final LabelGenerator labelGenerator;
     private final byte[] lineDelimiter;
-    private static final String LOAD_URL_PATTERN = "http://%s/api/%s/%s/_stream_load";
+    private final DorisUrlBuilder urlBuilder;
     private String loadUrl;
     private String hostPort;
     private final String username;
@@ -123,10 +124,12 @@ public class DorisBatchStreamLoad implements Serializable {
             int subTaskId) {
         this.backendUtil =
                 StringUtils.isNotEmpty(dorisOptions.getBenodes())
-                        ? new BackendUtil(dorisOptions.getBenodes())
+                        ? new BackendUtil(dorisOptions.getBenodes(), dorisOptions.getHttpOptions())
                         : new BackendUtil(
-                                RestService.getBackendsV2(dorisOptions, dorisReadOptions, LOG));
+                                RestService.getBackendsV2(dorisOptions, dorisReadOptions, LOG),
+                                dorisOptions.getHttpOptions());
         this.hostPort = backendUtil.getAvailableBackend();
+        this.urlBuilder = new DorisUrlBuilder(dorisOptions.isEnableHttps());
         this.username = dorisOptions.getUsername();
         this.password = dorisOptions.getPassword();
         this.loadProps = executionOptions.getStreamLoadProp();
@@ -157,7 +160,7 @@ public class DorisBatchStreamLoad implements Serializable {
             Preconditions.checkState(
                     tableInfo.length == 2,
                     "tableIdentifier input error, the format is database.table");
-            this.loadUrl = String.format(LOAD_URL_PATTERN, hostPort, tableInfo[0], tableInfo[1]);
+            this.loadUrl = urlBuilder.streamLoad(hostPort, tableInfo[0], tableInfo[1]);
         }
         this.loadAsyncExecutor = new LoadAsyncExecutor(executionOptions.getFlushQueueSize());
         this.loadExecutorService =
@@ -173,7 +176,10 @@ public class DorisBatchStreamLoad implements Serializable {
         this.loadExecutorService.execute(loadAsyncExecutor);
         this.subTaskId = subTaskId;
         this.httpClientBuilder =
-                new HttpUtil(dorisReadOptions, executionOptions.isHttpUtf8Charset())
+                new HttpUtil(
+                                dorisReadOptions,
+                                executionOptions.isHttpUtf8Charset(),
+                                dorisOptions.getHttpOptions())
                         .getHttpClientBuilderForBatch();
     }
 
@@ -567,7 +573,7 @@ public class DorisBatchStreamLoad implements Serializable {
 
         private void refreshLoadUrl(String database, String table) {
             hostPort = backendUtil.getAvailableBackend(subTaskId);
-            loadUrl = String.format(LOAD_URL_PATTERN, hostPort, database, table);
+            loadUrl = urlBuilder.streamLoad(hostPort, database, table);
         }
     }
 

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/committer/DorisCommitter.java
@@ -27,6 +27,7 @@ import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisRuntimeException;
+import org.apache.doris.flink.rest.DorisUrlBuilder;
 import org.apache.doris.flink.rest.RestService;
 import org.apache.doris.flink.sink.BackendUtil;
 import org.apache.doris.flink.sink.DorisCommittable;
@@ -52,10 +53,10 @@ import static org.apache.doris.flink.sink.LoadStatus.SUCCESS;
 /** The committer to commit transaction. */
 public class DorisCommitter implements Committer<DorisCommittable>, Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(DorisCommitter.class);
-    private static final String commitPattern = "http://%s/api/%s/_stream_load_2pc";
     private final CloseableHttpClient httpClient;
     private final DorisOptions dorisOptions;
     private final DorisReadOptions dorisReadOptions;
+    private final DorisUrlBuilder urlBuilder;
     private final ObjectMapper jsonMapper = new ObjectMapper();
     private final BackendUtil backendUtil;
 
@@ -70,7 +71,10 @@ public class DorisCommitter implements Committer<DorisCommittable>, Closeable {
                 dorisOptions,
                 dorisReadOptions,
                 executionOptions,
-                new HttpUtil(dorisReadOptions, executionOptions.isHttpUtf8Charset())
+                new HttpUtil(
+                                dorisReadOptions,
+                                executionOptions.isHttpUtf8Charset(),
+                                dorisOptions.getHttpOptions())
                         .getHttpClient());
     }
 
@@ -81,15 +85,17 @@ public class DorisCommitter implements Committer<DorisCommittable>, Closeable {
             CloseableHttpClient client) {
         this.dorisOptions = dorisOptions;
         this.dorisReadOptions = dorisReadOptions;
+        this.urlBuilder = new DorisUrlBuilder(dorisOptions.isEnableHttps());
         Preconditions.checkArgument(maxRetry >= 0);
         this.maxRetry = executionOptions.getMaxRetries();
         this.ignoreCommitError = executionOptions.ignoreCommitError();
         this.httpClient = client;
         this.backendUtil =
                 StringUtils.isNotEmpty(dorisOptions.getBenodes())
-                        ? new BackendUtil(dorisOptions.getBenodes())
+                        ? new BackendUtil(dorisOptions.getBenodes(), dorisOptions.getHttpOptions())
                         : new BackendUtil(
-                                RestService.getBackendsV2(dorisOptions, dorisReadOptions, LOG));
+                                RestService.getBackendsV2(dorisOptions, dorisReadOptions, LOG),
+                                dorisOptions.getHttpOptions());
     }
 
     @Override
@@ -116,7 +122,7 @@ public class DorisCommitter implements Committer<DorisCommittable>, Closeable {
         int retry = 0;
         while (retry <= maxRetry) {
             // get latest-url
-            String url = String.format(commitPattern, hostPort, committable.getDb());
+            String url = urlBuilder.streamLoad2pc(hostPort, committable.getDb());
             HttpPut httpPut = builder.setUrl(url).setEmptyEntity().build();
 
             // http execute...

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/copy/BatchStageLoad.java
@@ -25,6 +25,7 @@ import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.CopyLoadException;
 import org.apache.doris.flink.exception.DorisBatchLoadException;
+import org.apache.doris.flink.rest.DorisUrlBuilder;
 import org.apache.doris.flink.sink.EscapeHandler;
 import org.apache.doris.flink.sink.HttpPutBuilder;
 import org.apache.doris.flink.sink.HttpUtil;
@@ -67,7 +68,6 @@ public class BatchStageLoad implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(BatchStageLoad.class);
     private final LabelGenerator labelGenerator;
     private final byte[] lineDelimiter;
-    private static final String UPLOAD_URL_PATTERN = "http://%s/copy/upload";
     private static final String LINE_DELIMITER_KEY_WITH_PRETIX = "file.line_delimiter";
     private String uploadUrl;
     private String hostPort;
@@ -85,7 +85,7 @@ public class BatchStageLoad implements Serializable {
     private final AtomicBoolean started;
     private volatile boolean loadThreadAlive = false;
     private AtomicReference<Throwable> exception = new AtomicReference<>(null);
-    private HttpClientBuilder httpClientBuilder = new HttpUtil().getHttpClientBuilderForCopyBatch();
+    private HttpClientBuilder httpClientBuilder;
 
     public BatchStageLoad(
             DorisOptions dorisOptions,
@@ -97,7 +97,9 @@ public class BatchStageLoad implements Serializable {
         this.loadProps = executionOptions.getStreamLoadProp();
         this.labelGenerator = labelGenerator;
         this.hostPort = dorisOptions.getFenodes();
-        this.uploadUrl = String.format(UPLOAD_URL_PATTERN, hostPort);
+        this.uploadUrl = new DorisUrlBuilder(dorisOptions.isEnableHttps()).copyUpload(hostPort);
+        this.httpClientBuilder =
+                new HttpUtil(dorisOptions.getHttpOptions()).getHttpClientBuilderForCopyBatch();
         this.fileNum = new AtomicInteger();
         this.lineDelimiter =
                 EscapeHandler.escapeString(

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommitter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/copy/DorisCopyCommitter.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.exception.CopyLoadException;
+import org.apache.doris.flink.rest.DorisUrlBuilder;
 import org.apache.doris.flink.sink.HttpUtil;
 import org.apache.doris.flink.sink.ResponseUtil;
 import org.apache.doris.flink.sink.copy.models.BaseResponse;
@@ -44,22 +45,26 @@ import java.util.Map;
 
 public class DorisCopyCommitter implements Committer<DorisCopyCommittable>, Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(DorisCopyCommitter.class);
-    private static final String commitPattern = "http://%s/copy/query";
     private static final int SUCCESS = 0;
     private static final String FAIL = "1";
     private ObjectMapper objectMapper = new ObjectMapper();
     private final DorisOptions dorisOptions;
-    private HttpClientBuilder httpClientBuilder = new HttpUtil().getHttpClientBuilderForCopyBatch();
+    private final DorisUrlBuilder urlBuilder;
+    private HttpClientBuilder httpClientBuilder;
     int maxRetry;
 
     public DorisCopyCommitter(DorisOptions dorisOptions, int maxRetry) {
         this.dorisOptions = dorisOptions;
+        this.urlBuilder = new DorisUrlBuilder(dorisOptions.isEnableHttps());
+        this.httpClientBuilder =
+                new HttpUtil(dorisOptions.getHttpOptions()).getHttpClientBuilderForCopyBatch();
         this.maxRetry = maxRetry;
     }
 
     public DorisCopyCommitter(
             DorisOptions dorisOptions, int maxRetry, HttpClientBuilder httpClientBuilder) {
         this.dorisOptions = dorisOptions;
+        this.urlBuilder = new DorisUrlBuilder(dorisOptions.isEnableHttps());
         this.maxRetry = maxRetry;
         this.httpClientBuilder = httpClientBuilder;
     }
@@ -88,7 +93,7 @@ public class DorisCopyCommitter implements Committer<DorisCopyCommittable>, Clos
             LOG.info("commit with copy sql: {}", copySQL);
             HttpPostBuilder postBuilder = new HttpPostBuilder();
             postBuilder
-                    .setUrl(String.format(commitPattern, hostPort))
+                    .setUrl(urlBuilder.copyQuery(hostPort))
                     .baseAuth(dorisOptions.getUsername(), dorisOptions.getPassword())
                     .setEntity(new StringEntity(objectMapper.writeValueAsString(params)));
             try (CloseableHttpClient httpClient = httpClientBuilder.build()) {

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeManager.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/schema/SchemaChangeManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.flink.sink.schema;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.StringUtils;
 
@@ -31,17 +32,19 @@ import org.apache.doris.flink.catalog.doris.TableSchema;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.exception.DorisSchemaChangeException;
 import org.apache.doris.flink.exception.IllegalArgumentException;
+import org.apache.doris.flink.rest.DorisUrlBuilder;
 import org.apache.doris.flink.rest.RestService;
 import org.apache.doris.flink.rest.models.Field;
 import org.apache.doris.flink.rest.models.Schema;
 import org.apache.doris.flink.sink.HttpGetWithEntity;
+import org.apache.doris.flink.sink.HttpUtil;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,20 +59,26 @@ import java.util.Optional;
 public class SchemaChangeManager implements Serializable {
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(SchemaChangeManager.class);
-    private static final String CHECK_SCHEMA_CHANGE_API =
-            "http://%s/api/enable_light_schema_change/%s/%s";
-    private static final String SCHEMA_CHANGE_API = "http://%s/api/query/default_cluster/%s";
+    private final DorisUrlBuilder urlBuilder;
     private ObjectMapper objectMapper = new ObjectMapper();
     private DorisOptions dorisOptions;
     private String charsetEncoding = "UTF-8";
+    private transient HttpClientBuilder httpClientBuilder;
 
     public SchemaChangeManager(DorisOptions dorisOptions) {
-        this.dorisOptions = dorisOptions;
+        this(dorisOptions, "UTF-8");
     }
 
     public SchemaChangeManager(DorisOptions dorisOptions, String charsetEncoding) {
         this.dorisOptions = dorisOptions;
+        this.urlBuilder = new DorisUrlBuilder(dorisOptions.isEnableHttps());
         this.charsetEncoding = charsetEncoding;
+        this.httpClientBuilder = HttpUtil.buildHttpClientBuilder(dorisOptions.getHttpOptions());
+    }
+
+    @VisibleForTesting
+    public void setHttpClientBuilder(HttpClientBuilder httpClientBuilder) {
+        this.httpClientBuilder = httpClientBuilder;
     }
 
     public boolean createTable(TableSchema table) throws IOException, IllegalArgumentException {
@@ -210,11 +219,8 @@ public class SchemaChangeManager implements Serializable {
             return false;
         }
         String requestUrl =
-                String.format(
-                        CHECK_SCHEMA_CHANGE_API,
-                        RestService.randomEndpoint(dorisOptions.getFenodes(), LOG),
-                        database,
-                        table);
+                urlBuilder.lightSchemaChange(
+                        RestService.randomEndpoint(dorisOptions, LOG), database, table);
         HttpGetWithEntity httpGet = new HttpGetWithEntity(requestUrl);
         httpGet.setHeader(HttpHeaders.AUTHORIZATION, authHeader());
         httpGet.setEntity(
@@ -278,10 +284,7 @@ public class SchemaChangeManager implements Serializable {
         Map<String, String> param = new HashMap<>();
         param.put("stmt", ddl);
         String requestUrl =
-                String.format(
-                        SCHEMA_CHANGE_API,
-                        RestService.randomEndpoint(dorisOptions.getFenodes(), LOG),
-                        database);
+                urlBuilder.schemaChange(RestService.randomEndpoint(dorisOptions, LOG), database);
         HttpPost httpPost = new HttpPost(requestUrl);
         httpPost.setHeader(HttpHeaders.AUTHORIZATION, authHeader());
         httpPost.setHeader(
@@ -293,7 +296,7 @@ public class SchemaChangeManager implements Serializable {
     }
 
     private String handleResponse(HttpUriRequest request) {
-        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+        try (CloseableHttpClient httpclient = httpClientBuilder.build()) {
             CloseableHttpResponse response = httpclient.execute(request);
             final int statusCode = response.getStatusLine().getStatusCode();
             final String reasonPhrase = response.getStatusLine().getReasonPhrase();
@@ -329,7 +332,7 @@ public class SchemaChangeManager implements Serializable {
     private boolean sendHttpPostRequest(String sql, String database)
             throws IOException, IllegalArgumentException {
         HttpPost httpPost = buildHttpPost(sql, database);
-        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+        try (CloseableHttpClient httpclient = httpClientBuilder.build()) {
             CloseableHttpResponse response = httpclient.execute(httpPost);
             final int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == 200 && response.getEntity() != null) {

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisStreamLoad.java
@@ -30,6 +30,7 @@ import org.apache.doris.flink.exception.DorisException;
 import org.apache.doris.flink.exception.DorisRuntimeException;
 import org.apache.doris.flink.exception.LabelAlreadyExistsException;
 import org.apache.doris.flink.exception.StreamLoadException;
+import org.apache.doris.flink.rest.DorisUrlBuilder;
 import org.apache.doris.flink.rest.models.RespContent;
 import org.apache.doris.flink.sink.EscapeHandler;
 import org.apache.doris.flink.sink.HttpPutBuilder;
@@ -77,13 +78,12 @@ public class DorisStreamLoad implements Serializable {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final LabelGenerator labelGenerator;
     private final byte[] lineDelimiter;
-    private static final String LOAD_URL_PATTERN = "http://%s/api/%s/%s/_stream_load";
-    private static final String ABORT_URL_PATTERN = "http://%s/api/%s/_stream_load_2pc";
     public static final String JOB_EXIST_FINISHED = "FINISHED";
 
     private String loadUrlStr;
     private String hostPort;
     private String abortUrlStr;
+    private final DorisUrlBuilder urlBuilder;
     private final String user;
     private final String passwd;
     private final String db;
@@ -114,8 +114,9 @@ public class DorisStreamLoad implements Serializable {
         this.user = dorisOptions.getUsername();
         this.passwd = dorisOptions.getPassword();
         this.labelGenerator = labelGenerator;
-        this.loadUrlStr = String.format(LOAD_URL_PATTERN, hostPort, db, table);
-        this.abortUrlStr = String.format(ABORT_URL_PATTERN, hostPort, db);
+        this.urlBuilder = new DorisUrlBuilder(dorisOptions.isEnableHttps());
+        this.loadUrlStr = urlBuilder.streamLoad(hostPort, db, table);
+        this.abortUrlStr = urlBuilder.streamLoad2pc(hostPort, db);
         this.enable2PC = executionOptions.enabled2PC();
         this.streamLoadProp = executionOptions.getStreamLoadProp();
         this.enableDelete = executionOptions.getDeletable();
@@ -169,14 +170,24 @@ public class DorisStreamLoad implements Serializable {
     }
 
     @VisibleForTesting
+    public String getLoadUrl() {
+        return loadUrlStr;
+    }
+
+    @VisibleForTesting
+    public String getAbortUrl() {
+        return abortUrlStr;
+    }
+
+    @VisibleForTesting
     public byte[] getLineDelimiter() {
         return lineDelimiter;
     }
 
     public void setHostPort(String hostPort) {
         this.hostPort = hostPort;
-        this.loadUrlStr = String.format(LOAD_URL_PATTERN, hostPort, this.db, this.table);
-        this.abortUrlStr = String.format(ABORT_URL_PATTERN, hostPort, db);
+        this.loadUrlStr = urlBuilder.streamLoad(hostPort, this.db, this.table);
+        this.abortUrlStr = urlBuilder.streamLoad2pc(hostPort, db);
     }
 
     public Future<RespContent> getPendingLoadFuture() {

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -307,7 +307,10 @@ public class DorisWriter<IN> {
                                 dorisOptions,
                                 executionOptions,
                                 labelGenerator,
-                                new HttpUtil(dorisReadOptions, executionOptions.isHttpUtf8Charset())
+                                new HttpUtil(
+                                                dorisReadOptions,
+                                                executionOptions.isHttpUtf8Charset(),
+                                                dorisOptions.getHttpOptions())
                                         .getHttpClient()));
     }
 

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/table/DorisConfigOptions.java
@@ -82,6 +82,27 @@ public class DorisConfigOptions {
                     .defaultValue(true)
                     .withDescription(
                             "Use automatic redirection of fe without explicitly obtaining the be list");
+    public static final ConfigOption<Boolean> DORIS_ENABLE_HTTPS =
+            ConfigOptions.key("doris.enable.https")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to enable HTTPS for Doris HTTP REST requests.");
+    public static final ConfigOption<String> DORIS_HTTPS_KEY_STORE_PATH =
+            ConfigOptions.key("doris.https.key-store-path")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Key store path used as trust material for Doris HTTPS requests.");
+    public static final ConfigOption<String> DORIS_HTTPS_KEY_STORE_TYPE =
+            ConfigOptions.key("doris.https.key-store-type")
+                    .stringType()
+                    .defaultValue("JKS")
+                    .withDescription("Key store type used for Doris HTTPS requests.");
+    public static final ConfigOption<String> DORIS_HTTPS_KEY_STORE_PASSWORD =
+            ConfigOptions.key("doris.https.key-store-password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Key store password used for Doris HTTPS requests.");
 
     // source config options
     // This is compatible with the previous writing method.

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/cfg/DorisOptionsTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/cfg/DorisOptionsTest.java
@@ -73,5 +73,26 @@ public class DorisOptionsTest {
         options1.setAutoRedirect(true);
         options1.setJdbcUrl("xxx1");
         Assert.assertNotEquals(exceptedOption, options1.build());
+
+        options1.setJdbcUrl("xxx");
+        options1.setHttpOptions(new DorisHttpOptions(true, "/tmp/ks.jks", "JKS", "secret"));
+        Assert.assertNotEquals(exceptedOption, options1.build());
+    }
+
+    @Test
+    public void testHttpOptions() {
+        DorisHttpOptions httpOptions =
+                new DorisHttpOptions(true, "/tmp/ks.p12", "PKCS12", "secret");
+        DorisOptions options =
+                DorisOptions.builder().setFenodes("fenodes").setHttpOptions(httpOptions).build();
+        Assert.assertTrue(options.isEnableHttps());
+        Assert.assertEquals(httpOptions, options.getHttpOptions());
+    }
+
+    @Test
+    public void testHttpOptionsDefaults() {
+        DorisHttpOptions options = new DorisHttpOptions(true, null, null, null);
+        Assert.assertTrue(options.isEnableHttps());
+        Assert.assertEquals("JKS", options.getHttpsKeyStoreType());
     }
 }

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/rest/DorisUrlBuilderTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/rest/DorisUrlBuilderTest.java
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.rest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DorisUrlBuilderTest {
+
+    @Test
+    public void testHttpUrls() {
+        DorisUrlBuilder builder = new DorisUrlBuilder(false);
+        Assert.assertEquals(
+                "http://host:8030/api/db/tbl/_stream_load",
+                builder.streamLoad("host:8030", "db", "tbl"));
+        Assert.assertEquals(
+                "http://host:8030/api/db/_stream_load_2pc",
+                builder.streamLoad2pc("host:8030", "db"));
+        Assert.assertEquals(
+                "http://host:8030/api/db/tbl/_schema",
+                builder.tableSchema("host:8030", "db", "tbl"));
+        Assert.assertEquals(
+                "http://host:8030/api/catalog/db/tbl/_schema",
+                builder.catalogTableSchema("host:8030", "catalog", "db", "tbl"));
+        Assert.assertEquals(
+                "http://host:8030/api/db/tbl/_query_plan",
+                builder.queryPlan("host:8030", "db", "tbl"));
+        Assert.assertEquals(
+                "http://host:8030/api/query/default_cluster/information_schema",
+                builder.informationSchemaQuery("host:8030"));
+        Assert.assertEquals(
+                "http://host:8030/api/backends?is_alive=true", builder.backends("host:8030"));
+        Assert.assertEquals("http://host:8030/copy/upload", builder.copyUpload("host:8030"));
+        Assert.assertEquals("http://host:8030/copy/query", builder.copyQuery("host:8030"));
+    }
+
+    @Test
+    public void testHttpsUrls() {
+        DorisUrlBuilder builder = new DorisUrlBuilder(true);
+        Assert.assertEquals(
+                "https://host:8030/api/db/tbl/_stream_load",
+                builder.streamLoad("host:8030", "db", "tbl"));
+        Assert.assertEquals(
+                "https://host:8030/api/db/_stream_load_2pc",
+                builder.streamLoad2pc("host:8030", "db"));
+        Assert.assertEquals(
+                "https://host:8030/api/db/tbl/_schema",
+                builder.tableSchema("host:8030", "db", "tbl"));
+        Assert.assertEquals(
+                "https://host:8030/api/catalog/db/tbl/_schema",
+                builder.catalogTableSchema("host:8030", "catalog", "db", "tbl"));
+        Assert.assertEquals(
+                "https://host:8030/api/db/tbl/_query_plan",
+                builder.queryPlan("host:8030", "db", "tbl"));
+        Assert.assertEquals(
+                "https://host:8030/api/query/default_cluster/information_schema",
+                builder.informationSchemaQuery("host:8030"));
+        Assert.assertEquals(
+                "https://host:8030/api/backends?is_alive=true", builder.backends("host:8030"));
+        Assert.assertEquals("https://host:8030/copy/upload", builder.copyUpload("host:8030"));
+        Assert.assertEquals("https://host:8030/copy/query", builder.copyQuery("host:8030"));
+    }
+}

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/rest/TestRestService.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/rest/TestRestService.java
@@ -20,6 +20,7 @@ package org.apache.doris.flink.rest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisException;
@@ -59,6 +60,7 @@ import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_TABLET_SIZE_
 import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_TABLET_SIZE_MIN;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -74,6 +76,12 @@ public class TestRestService {
     public void setUp() throws Exception {
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(true);
     }
 
     @After
@@ -183,6 +191,12 @@ public class TestRestService {
         String failFenodes = "127.0.0.1:1";
         BackendUtil.tryHttpConnection(any());
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(false);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(false);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(false);
         thrown.expect(DorisRuntimeException.class);
         thrown.expectMessage("No Doris FE is available");
         RestService.randomEndpoint(failFenodes, logger);
@@ -478,7 +492,7 @@ public class TestRestService {
                     "{\"msg\":\"success\",\"code\":0,\"data\":{\"keysType\":\"UNIQUE_KEYS\",\"properties\":[{\"name\":\"name\",\"aggregation_type\":\"\",\"comment\":\"\",\"type\":\"VARCHAR\"},{\"name\":\"age\",\"aggregation_type\":\"REPLACE\",\"comment\":\"\",\"type\":\"INT\"}],\"status\":200},\"count\":0}";
             JsonNode jsonNode = new ObjectMapper().readTree(res);
             restServiceMockedStatic
-                    .when(() -> RestService.handleResponse(any(), any()))
+                    .when(() -> RestService.handleResponse(any(), any(DorisOptions.class), any()))
                     .thenReturn(jsonNode);
             restServiceMockedStatic
                     .when(() -> RestService.getSchema(any(), any(), any(), any()))
@@ -499,7 +513,7 @@ public class TestRestService {
 
         try (MockedStatic<RestService> restServiceMockedStatic = mockStatic(RestService.class)) {
             restServiceMockedStatic
-                    .when(() -> RestService.handleResponse(any(), any()))
+                    .when(() -> RestService.handleResponse(any(), any(DorisOptions.class), any()))
                     .thenReturn(jsonNode);
             restServiceMockedStatic
                     .when(() -> RestService.getArrowFlightSqlPort(any()))

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/TestBackendUtil.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/TestBackendUtil.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.flink.sink;
 
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.exception.DorisRuntimeException;
 import org.apache.doris.flink.rest.models.BackendV2;
 import org.junit.After;
@@ -29,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mockStatic;
 
 public class TestBackendUtil {
@@ -43,6 +45,12 @@ public class TestBackendUtil {
     @Test
     public void testGetAvailableBackend() throws Exception {
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(true);
         List<BackendV2.BackendRowV2> backends =
                 Arrays.asList(
                         newBackend("127.0.0.2", 8040),
@@ -58,6 +66,12 @@ public class TestBackendUtil {
     @Test(expected = DorisRuntimeException.class)
     public void testNoAvailableBackend() throws Exception {
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(false);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(false);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(false);
         List<BackendV2.BackendRowV2> backends =
                 Arrays.asList(
                         newBackend("127.0.0.1", 12345),

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/TestHttpUtil.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/TestHttpUtil.java
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.protocol.HttpCoreContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestHttpUtil {
+
+    @Test
+    public void testRedirectStrategyKeepsPutRedirectable() throws ProtocolException {
+        HttpResponse response =
+                new BasicHttpResponse(HttpVersion.HTTP_1_1, 307, "Temporary Redirect");
+        response.setHeader("location", "http://127.0.0.1:8040/api/db/tbl/_stream_load");
+
+        Assert.assertTrue(
+                HttpUtil.getRedirectPutStrategy()
+                        .isRedirected(
+                                new HttpPut("https://127.0.0.1:8030/api/db/tbl/_stream_load"),
+                                response,
+                                new HttpCoreContext()));
+        Assert.assertTrue(
+                HttpUtil.getRedirectPutStrategy()
+                        .isRedirected(
+                                new HttpGet("https://127.0.0.1:8030/api/backends"),
+                                response,
+                                new HttpCoreContext()));
+    }
+}

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchStreamLoad.java
@@ -20,6 +20,7 @@ package org.apache.doris.flink.sink.batch;
 import org.apache.flink.api.common.time.Deadline;
 
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.BackendUtil;
@@ -52,6 +53,7 @@ import java.util.Properties;
 
 import static org.apache.doris.flink.sink.batch.TestBatchBufferStream.mergeByteArrays;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -70,6 +72,12 @@ public class TestDorisBatchStreamLoad {
     public void setUp() throws Exception {
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(true);
     }
 
     @Test

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchWriter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/batch/TestDorisBatchWriter.java
@@ -18,6 +18,7 @@
 package org.apache.doris.flink.sink.batch;
 
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.BackendUtil;
@@ -31,6 +32,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.MockedStatic;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mockStatic;
 
 public class TestDorisBatchWriter {
@@ -43,6 +45,12 @@ public class TestDorisBatchWriter {
     public void setUp() throws Exception {
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(true);
     }
 
     @Test

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/committer/TestDorisCommitter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/committer/TestDorisCommitter.java
@@ -18,6 +18,7 @@
 package org.apache.doris.flink.sink.committer;
 
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisRuntimeException;
@@ -42,6 +43,7 @@ import org.mockito.MockedStatic;
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -81,6 +83,12 @@ public class TestDorisCommitter {
                         Collections.singletonList(
                                 BackendV2.BackendRowV2.of("127.0.0.1", 8040, true)));
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(true);
 
         dorisCommitter =
                 new DorisCommitter(dorisOptions, readOptions, executionOptions, httpClient);

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/schema/SchemaManagerTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/schema/SchemaManagerTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.flink.sink.schema;
 
 import org.apache.doris.flink.catalog.doris.FieldSchema;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.exception.IllegalArgumentException;
 import org.apache.doris.flink.sink.BackendUtil;
@@ -27,7 +28,7 @@ import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.After;
 import org.junit.Assert;
@@ -38,6 +39,7 @@ import org.mockito.MockedStatic;
 import java.io.IOException;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -72,7 +74,6 @@ public class SchemaManagerTest {
 
     HttpEntityMock entityMock;
     SchemaChangeManager schemaChangeManager;
-    private MockedStatic<HttpClients> httpClientMockedStatic;
     private MockedStatic<BackendUtil> backendUtilMockedStatic;
 
     @Before
@@ -80,6 +81,7 @@ public class SchemaManagerTest {
         DorisOptions dorisOptions = OptionUtils.buildDorisOptions();
         schemaChangeManager = new SchemaChangeManager(dorisOptions);
         CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        HttpClientBuilder httpClientBuilder = mock(HttpClientBuilder.class);
         entityMock = new HttpEntityMock();
 
         CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
@@ -88,15 +90,17 @@ public class SchemaManagerTest {
         when(httpClient.execute(any())).thenReturn(httpResponse);
         when(httpResponse.getStatusLine()).thenReturn(normalLine);
         when(httpResponse.getEntity()).thenReturn(entityMock);
-        when(httpClient.execute(any())).thenReturn(httpResponse);
-        when(httpResponse.getStatusLine()).thenReturn(normalLine);
-        when(httpResponse.getEntity()).thenReturn(entityMock);
-
-        httpClientMockedStatic = mockStatic(HttpClients.class);
-        httpClientMockedStatic.when(() -> HttpClients.createDefault()).thenReturn(httpClient);
+        when(httpClientBuilder.build()).thenReturn(httpClient);
+        schemaChangeManager.setHttpClientBuilder(httpClientBuilder);
 
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(true);
     }
 
     @Test
@@ -156,9 +160,6 @@ public class SchemaManagerTest {
 
     @After
     public void after() {
-        if (httpClientMockedStatic != null) {
-            httpClientMockedStatic.close();
-        }
         if (backendUtilMockedStatic != null) {
             backendUtilMockedStatic.close();
         }

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/TestDorisStreamLoad.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/TestDorisStreamLoad.java
@@ -18,6 +18,7 @@
 package org.apache.doris.flink.sink.writer;
 
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisException;
@@ -300,6 +301,45 @@ public class TestDorisStreamLoad {
                         new LabelGenerator("test001", true),
                         httpClient);
         Assert.assertNull(dorisStreamLoad.getLineDelimiter());
+    }
+
+    @Test
+    public void testStreamLoadUrlUsesConfiguredScheme() {
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        DorisStreamLoad httpStreamLoad =
+                new DorisStreamLoad(
+                        "127.0.0.1:8040",
+                        dorisOptions,
+                        executionOptions,
+                        new LabelGenerator("test001", true),
+                        httpClient);
+        Assert.assertEquals(
+                "http://127.0.0.1:8040/api/db/table/_stream_load", httpStreamLoad.getLoadUrl());
+        Assert.assertEquals(
+                "http://127.0.0.1:8040/api/db/_stream_load_2pc", httpStreamLoad.getAbortUrl());
+
+        DorisOptions httpsOptions =
+                DorisOptions.builder()
+                        .setFenodes("127.0.0.1:8030")
+                        .setTableIdentifier("db.table")
+                        .setUsername("root")
+                        .setPassword("")
+                        .setHttpOptions(DorisHttpOptions.of(true))
+                        .build();
+        DorisStreamLoad httpsStreamLoad =
+                new DorisStreamLoad(
+                        "127.0.0.1:8040",
+                        httpsOptions,
+                        executionOptions,
+                        new LabelGenerator("test001", true),
+                        httpClient);
+        Assert.assertEquals(
+                "https://127.0.0.1:8040/api/db/table/_stream_load", httpsStreamLoad.getLoadUrl());
+        Assert.assertEquals(
+                "https://127.0.0.1:8040/api/db/_stream_load_2pc", httpsStreamLoad.getAbortUrl());
+        httpsStreamLoad.setHostPort("127.0.0.2:8040");
+        Assert.assertEquals(
+                "https://127.0.0.2:8040/api/db/table/_stream_load", httpsStreamLoad.getLoadUrl());
     }
 
     @Test

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriter.java
@@ -22,6 +22,7 @@ import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.BackendUtil;
@@ -46,6 +47,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -65,6 +67,12 @@ public class TestDorisWriter {
         executionOptions = OptionUtils.buildExecutionOptional();
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(true);
         // clear thread interrupted status before each test
         Thread.interrupted();
     }

--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableSchemaUtils;
 
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisLookupOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
@@ -43,8 +44,12 @@ import static org.apache.doris.flink.table.DorisConfigOptions.BENODES;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_BATCH_SIZE;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_ARROW_ASYNC;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_QUEUE_SIZE;
+import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_ENABLE_HTTPS;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_EXEC_MEM_LIMIT;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_FILTER_QUERY;
+import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_HTTPS_KEY_STORE_PASSWORD;
+import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_HTTPS_KEY_STORE_PATH;
+import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_HTTPS_KEY_STORE_TYPE;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_READ_FIELD;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_QUERY_TIMEOUT_S;
@@ -120,6 +125,10 @@ public final class DorisDynamicTableFactory
         options.add(PASSWORD);
         options.add(JDBC_URL);
         options.add(AUTO_REDIRECT);
+        options.add(DORIS_ENABLE_HTTPS);
+        options.add(DORIS_HTTPS_KEY_STORE_PATH);
+        options.add(DORIS_HTTPS_KEY_STORE_TYPE);
+        options.add(DORIS_HTTPS_KEY_STORE_PASSWORD);
 
         options.add(DORIS_READ_FIELD);
         options.add(DORIS_FILTER_QUERY);
@@ -202,12 +211,21 @@ public final class DorisDynamicTableFactory
                         .setFenodes(fenodes)
                         .setBenodes(benodes)
                         .setAutoRedirect(readableConfig.get(AUTO_REDIRECT))
+                        .setHttpOptions(getDorisHttpOptions(readableConfig))
                         .setJdbcUrl(readableConfig.get(JDBC_URL))
                         .setTableIdentifier(readableConfig.get(TABLE_IDENTIFIER));
 
         readableConfig.getOptional(USERNAME).ifPresent(builder::setUsername);
         readableConfig.getOptional(PASSWORD).ifPresent(builder::setPassword);
         return builder.build();
+    }
+
+    private DorisHttpOptions getDorisHttpOptions(ReadableConfig readableConfig) {
+        return new DorisHttpOptions(
+                readableConfig.get(DORIS_ENABLE_HTTPS),
+                readableConfig.getOptional(DORIS_HTTPS_KEY_STORE_PATH).orElse(null),
+                readableConfig.get(DORIS_HTTPS_KEY_STORE_TYPE),
+                readableConfig.getOptional(DORIS_HTTPS_KEY_STORE_PASSWORD).orElse(null));
     }
 
     private DorisReadOptions getDorisReadOptions(ReadableConfig readableConfig) {

--- a/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/main/java/org/apache/doris/flink/tools/cdc/DatabaseSync.java
@@ -32,6 +32,7 @@ import org.apache.doris.flink.catalog.doris.DorisSystem;
 import org.apache.doris.flink.catalog.doris.TableSchema;
 import org.apache.doris.flink.cfg.DorisConnectionOptions;
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.DorisSink;
@@ -224,7 +225,8 @@ public abstract class DatabaseSync {
                         .withBenodes(benodes)
                         .withUsername(user)
                         .withPassword(passwd)
-                        .withJdbcUrl(jdbcUrl);
+                        .withJdbcUrl(jdbcUrl)
+                        .withHttpOptions(getDorisHttpOptions());
         return builder.build();
     }
 
@@ -251,6 +253,7 @@ public abstract class DatabaseSync {
                 .setJdbcUrl(jdbcUrl)
                 .setFenodes(fenodes)
                 .setBenodes(benodes)
+                .setHttpOptions(getDorisHttpOptions())
                 .setUsername(user)
                 .setPassword(passwd);
         sinkConfig
@@ -336,6 +339,14 @@ public abstract class DatabaseSync {
                 .setSerializer(buildSchemaSerializer(dorisBuilder, executionOptions))
                 .setDorisOptions(dorisBuilder.build());
         return builder.build();
+    }
+
+    private DorisHttpOptions getDorisHttpOptions() {
+        return new DorisHttpOptions(
+                sinkConfig.getBoolean(DorisConfigOptions.DORIS_ENABLE_HTTPS),
+                sinkConfig.getString(DorisConfigOptions.DORIS_HTTPS_KEY_STORE_PATH),
+                sinkConfig.getString(DorisConfigOptions.DORIS_HTTPS_KEY_STORE_TYPE),
+                sinkConfig.getString(DorisConfigOptions.DORIS_HTTPS_KEY_STORE_PASSWORD));
     }
 
     public DorisRecordSerializer<String> buildSchemaSerializer(

--- a/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
+++ b/flink-doris-connector/flink-doris-connector-flink1/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.flink.sink;
 import org.apache.flink.api.connector.sink2.Sink;
 
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.batch.DorisBatchWriterAdapter;
@@ -38,6 +39,7 @@ import org.mockito.MockedStatic;
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
@@ -49,6 +51,12 @@ public class DorisSinkTest {
     public void setUp() throws Exception {
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(true);
     }
 
     @Test

--- a/flink-doris-connector/flink-doris-connector-flink2/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
+++ b/flink-doris-connector/flink-doris-connector-flink2/src/main/java/org/apache/doris/flink/table/DorisDynamicTableFactory.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableSchemaUtils;
 
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisLookupOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
@@ -43,8 +44,12 @@ import static org.apache.doris.flink.table.DorisConfigOptions.BENODES;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_BATCH_SIZE;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_ARROW_ASYNC;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_DESERIALIZE_QUEUE_SIZE;
+import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_ENABLE_HTTPS;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_EXEC_MEM_LIMIT;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_FILTER_QUERY;
+import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_HTTPS_KEY_STORE_PASSWORD;
+import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_HTTPS_KEY_STORE_PATH;
+import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_HTTPS_KEY_STORE_TYPE;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_READ_FIELD;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS;
 import static org.apache.doris.flink.table.DorisConfigOptions.DORIS_REQUEST_QUERY_TIMEOUT_S;
@@ -120,6 +125,10 @@ public final class DorisDynamicTableFactory
         options.add(PASSWORD);
         options.add(JDBC_URL);
         options.add(AUTO_REDIRECT);
+        options.add(DORIS_ENABLE_HTTPS);
+        options.add(DORIS_HTTPS_KEY_STORE_PATH);
+        options.add(DORIS_HTTPS_KEY_STORE_TYPE);
+        options.add(DORIS_HTTPS_KEY_STORE_PASSWORD);
 
         options.add(DORIS_READ_FIELD);
         options.add(DORIS_FILTER_QUERY);
@@ -202,12 +211,21 @@ public final class DorisDynamicTableFactory
                         .setFenodes(fenodes)
                         .setBenodes(benodes)
                         .setAutoRedirect(readableConfig.get(AUTO_REDIRECT))
+                        .setHttpOptions(getDorisHttpOptions(readableConfig))
                         .setJdbcUrl(readableConfig.get(JDBC_URL))
                         .setTableIdentifier(readableConfig.get(TABLE_IDENTIFIER));
 
         readableConfig.getOptional(USERNAME).ifPresent(builder::setUsername);
         readableConfig.getOptional(PASSWORD).ifPresent(builder::setPassword);
         return builder.build();
+    }
+
+    private DorisHttpOptions getDorisHttpOptions(ReadableConfig readableConfig) {
+        return new DorisHttpOptions(
+                readableConfig.get(DORIS_ENABLE_HTTPS),
+                readableConfig.getOptional(DORIS_HTTPS_KEY_STORE_PATH).orElse(null),
+                readableConfig.get(DORIS_HTTPS_KEY_STORE_TYPE),
+                readableConfig.getOptional(DORIS_HTTPS_KEY_STORE_PASSWORD).orElse(null));
     }
 
     private DorisReadOptions getDorisReadOptions(ReadableConfig readableConfig) {

--- a/flink-doris-connector/flink-doris-connector-flink2/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
+++ b/flink-doris-connector/flink-doris-connector-flink2/src/test/java/org/apache/doris/flink/sink/DorisSinkTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisHttpOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.sink.batch.DorisBatchWriterAdapter;
@@ -39,6 +40,7 @@ import org.mockito.MockedStatic;
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -51,6 +53,12 @@ public class DorisSinkTest {
     public void setUp() throws Exception {
         backendUtilMockedStatic = mockStatic(BackendUtil.class);
         backendUtilMockedStatic.when(() -> BackendUtil.tryHttpConnection(any())).thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), anyBoolean()))
+                .thenReturn(true);
+        backendUtilMockedStatic
+                .when(() -> BackendUtil.tryHttpConnection(any(), any(DorisHttpOptions.class)))
+                .thenReturn(true);
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Add optional HTTPS support for Doris HTTP REST requests in the Flink connector while keeping HTTP as the default behavior.

This change introduces HTTPS-related options aligned with the Spark connector:

- `doris.enable.https`
- `doris.https.key-store-path`
- `doris.https.key-store-type`
- `doris.https.key-store-password`

The HTTP protocol switch is applied to Stream Load, Batch Stream Load, Stream Load 2PC commit/abort, FE REST requests, backend discovery, schema change, and COPY-related HTTP requests.

For Stream Load redirection, the connector keeps the current Spark-compatible behavior: when `auto-redirect` is enabled, redirects are still handled by Apache HttpClient. If FE currently returns an HTTP `Location`, the request follows that redirect instead of failing fast, which preserves compatibility with existing Doris FE behavior. Once FE supports HTTPS redirect locations, the same implementation can support full HTTPS flow.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: Yes
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

The implementation keeps HTTP as the default protocol to avoid breaking existing deployments. HTTPS is enabled only through explicit configuration.

Verified with:

- `mvn -Pflink1 -pl flink-doris-connector-base -Dtest=DorisUrlBuilderTest,DorisOptionsTest,TestRestService,TestHttpUtil,TestBackendUtil,TestDorisStreamLoad,TestDorisCommitter,TestDorisBatchStreamLoad,SchemaManagerTest,TestDorisCopyCommitter test`
- `mvn -Pflink1 -pl flink-doris-connector-flink1 -am -DskipTests package`
- `mvn -Pflink2 -pl flink-doris-connector-flink2 -am -DskipTests package`
- `git diff --check`