### PR TITLE
[improve](cdc) skip delete events early when sink.enable-delete is false

### DIFF
--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumDataChange.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/JsonDebeziumDataChange.java
@@ -88,8 +88,14 @@ public class JsonDebeziumDataChange extends CdcDataChange {
             case OP_UPDATE:
                 return DorisRecord.of(dorisTableIdentifier, extractUpdate(recordRoot));
             case OP_DELETE:
+                if (!enableDelete) {
+                    // Drop delete events early to avoid useless serialization, network
+                    // transfer and stream load overhead on the Doris side.
+                    LOG.debug("skip delete record because delete is disabled: {}", record);
+                    return null;
+                }
                 valueMap = extractBeforeRow(recordRoot);
-                addDeleteSign(valueMap, enableDelete);
+                addDeleteSign(valueMap, true);
                 break;
             default:
                 LOG.error("parse record fail, unknown op {} in {}", op, record);

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumDataChange.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/serializer/jsondebezium/TestJsonDebeziumDataChange.java
@@ -101,6 +101,32 @@ public class TestJsonDebeziumDataChange extends TestJsonDebeziumChangeBase {
     }
 
     @Test
+    public void testSerializeDeleteSkippedWhenDeleteDisabled() throws IOException {
+        changeContext =
+                new JsonDebeziumChangeContext(
+                        dorisOptions,
+                        tableMapping,
+                        null,
+                        null,
+                        null,
+                        objectMapper,
+                        null,
+                        lineDelimiter,
+                        ignoreUpdateBefore,
+                        "",
+                        "",
+                        false);
+        dataChange = new JsonDebeziumDataChange(changeContext);
+
+        String record =
+                "{\"before\":{\"id\":1,\"name\":\"doris-update\",\"dt\":\"2022-01-01\",\"dtime\":\"2022-01-01 10:01:02\",\"ts\":\"2022-01-01 10:01:03\"},\"after\":null,\"source\":{\"version\":\"1.5.4.Final\",\"connector\":\"mysql\",\"name\":\"mysql_binlog_source\",\"ts_ms\":1663924328000,\"snapshot\":\"false\",\"db\":\"test\",\"sequence\":null,\"table\":\"t1\",\"server_id\":1,\"gtid\":null,\"file\":\"binlog.000006\",\"pos\":12500,\"row\":0,\"thread\":null,\"query\":null},\"op\":\"d\",\"ts_ms\":1663924328869,\"transaction\":null}";
+        JsonNode recordRoot = objectMapper.readValue(record, JsonNode.class);
+        String op = extractJsonNode(recordRoot, "op");
+        DorisRecord dorisRecord = dataChange.serialize(record, recordRoot, op);
+        Assert.assertNull(dorisRecord);
+    }
+
+    @Test
     public void testSerializeUpdateBefore() throws IOException {
         changeContext =
                 new JsonDebeziumChangeContext(


### PR DESCRIPTION
# Proposed changes

Issue Number: close #644

## Problem Summary:

When `sink.enable-delete=false`, CDC delete events are not filtered out. They are serialized with `__DORIS_DELETE_SIGN=0` (the before-image row) and sent to Doris, which effectively upserts the old row values. This causes useless serialization, network transfer and stream load processing on the Doris FE/BE side.

### What is changed

In `JsonDebeziumDataChange#serialize`, when the op is `d` and delete is disabled, return `null` before serialization so the event is dropped early. `DorisWriter#writeOneDorisRecord` and `DorisBatchWriter#writeOneDorisRecord` already treat a null `DorisRecord` as a no-op, so no other change is needed.

Add a unit test `testSerializeDeleteSkippedWhenDeleteDisabled` asserting that no `__DORIS_DELETE_SIGN=0` record is produced for delete events when delete is disabled.

### Why

- Reduce network traffic and Doris FE/BE load for CDC pipelines that intentionally ignore deletes.
- Avoid re-upserting the before-image of deleted rows, which is pointless work.

## Checklist(Required)

1. Does it affect the original behavior: Yes (only when `sink.enable-delete=false`: delete events are now dropped instead of being written back as `__DORIS_DELETE_SIGN=0` upserts of the before-image; the intent of disabling delete is preserved)
2. Has unit tests been added: Yes
3. Has document been added or modified: No
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

The change is scoped to the Debezium JSON CDC path (`JsonDebeziumDataChange`). The Table/SQL `RowDataSerializer` path is untouched.
