### PR TITLE
[improve](sink) report standard FLIP-33 sink metrics numRecordsSend/numBytesSend

### DIFF
--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisWriteMetrics.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisWriteMetrics.java
@@ -108,6 +108,15 @@ public class DorisWriteMetrics implements Serializable {
         }
     }
 
+    /**
+     * Called for every record sent to Doris, regardless of the final load result, to keep the
+     * standard FLIP-33 sink metrics in line with the records the writer has sent.
+     */
+    public void recordSend(long bytes) {
+        numRecordsSend.inc();
+        numBytesSend.inc(bytes);
+    }
+
     @VisibleForTesting
     public void register(SinkWriterMetricGroup sinkMetricGroup) {
         numRecordsSend = sinkMetricGroup.getNumRecordsSendCounter();
@@ -192,10 +201,8 @@ public class DorisWriteMetrics implements Serializable {
 
     private void flushSuccessLoad(RespContent responseContent) {
         Optional.ofNullable(responseContent.getLoadBytes()).ifPresent(totalFlushLoadBytes::inc);
-        Optional.ofNullable(responseContent.getLoadBytes()).ifPresent(numBytesSend::inc);
         Optional.ofNullable(responseContent.getNumberLoadedRows())
                 .ifPresent(totalFlushLoadedRows::inc);
-        Optional.ofNullable(responseContent.getNumberLoadedRows()).ifPresent(numRecordsSend::inc);
         Optional.ofNullable(responseContent.getNumberTotalRows())
                 .ifPresent(totalFlushNumberTotalRows::inc);
         Optional.ofNullable(responseContent.getNumberFilteredRows())

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisWriteMetrics.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisWriteMetrics.java
@@ -58,6 +58,9 @@ public class DorisWriteMetrics implements Serializable {
 
     private transient Counter totalFlushFilteredRows;
     private transient Counter totalFlushUnselectedRows;
+    // Standard FLIP-33 sink metrics, shared by all tables of the writer
+    private transient Counter numRecordsSend;
+    private transient Counter numBytesSend;
     // Histogram
     private transient Histogram beginTxnTimeHistogramMs;
     private transient Histogram commitAndPublishTimeHistogramMs;
@@ -107,6 +110,8 @@ public class DorisWriteMetrics implements Serializable {
 
     @VisibleForTesting
     public void register(SinkWriterMetricGroup sinkMetricGroup) {
+        numRecordsSend = sinkMetricGroup.getNumRecordsSendCounter();
+        numBytesSend = sinkMetricGroup.getNumBytesSendCounter();
         totalFlushNumberTotalRows =
                 sinkMetricGroup.counter(
                         String.format(
@@ -187,8 +192,10 @@ public class DorisWriteMetrics implements Serializable {
 
     private void flushSuccessLoad(RespContent responseContent) {
         Optional.ofNullable(responseContent.getLoadBytes()).ifPresent(totalFlushLoadBytes::inc);
+        Optional.ofNullable(responseContent.getLoadBytes()).ifPresent(numBytesSend::inc);
         Optional.ofNullable(responseContent.getNumberLoadedRows())
                 .ifPresent(totalFlushLoadedRows::inc);
+        Optional.ofNullable(responseContent.getNumberLoadedRows()).ifPresent(numRecordsSend::inc);
         Optional.ofNullable(responseContent.getNumberTotalRows())
                 .ifPresent(totalFlushNumberTotalRows::inc);
         Optional.ofNullable(responseContent.getNumberFilteredRows())
@@ -222,6 +229,14 @@ public class DorisWriteMetrics implements Serializable {
 
     public Counter getTotalFlushLoadBytes() {
         return totalFlushLoadBytes;
+    }
+
+    public Counter getNumRecordsSend() {
+        return numRecordsSend;
+    }
+
+    public Counter getNumBytesSend() {
+        return numBytesSend;
     }
 
     public Counter getTotalFlushNumberTotalRows() {
@@ -279,6 +294,16 @@ public class DorisWriteMetrics implements Serializable {
     @VisibleForTesting
     public void setTotalFlushLoadBytes(Counter totalFlushLoadBytes) {
         this.totalFlushLoadBytes = totalFlushLoadBytes;
+    }
+
+    @VisibleForTesting
+    public void setNumRecordsSend(Counter numRecordsSend) {
+        this.numRecordsSend = numRecordsSend;
+    }
+
+    @VisibleForTesting
+    public void setNumBytesSend(Counter numBytesSend) {
+        this.numBytesSend = numBytesSend;
     }
 
     @VisibleForTesting

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/sink/writer/DorisWriter.java
@@ -200,6 +200,10 @@ public class DorisWriter<IN> {
             registerMetrics(tableKey);
         }
         streamLoader.writeRecord(record.getRow());
+        DorisWriteMetrics metrics = sinkMetricsMap.get(tableKey);
+        if (metrics != null) {
+            metrics.recordSend(record.getRow().length);
+        }
     }
 
     @VisibleForTesting

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriteMetrics.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriteMetrics.java
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.sink.writer;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.doris.flink.rest.models.RespContent;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Test for DorisWriteMetrics. */
+public class TestDorisWriteMetrics {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private SinkWriterMetricGroup metricGroup;
+    private Counter numRecordsSend;
+    private Counter numBytesSend;
+
+    @Before
+    public void setUp() {
+        metricGroup = mock(SinkWriterMetricGroup.class);
+        numRecordsSend = new SimpleCounter();
+        numBytesSend = new SimpleCounter();
+        when(metricGroup.getNumRecordsSendCounter()).thenReturn(numRecordsSend);
+        when(metricGroup.getNumBytesSendCounter()).thenReturn(numBytesSend);
+        when(metricGroup.counter(anyString())).thenAnswer(invocation -> new SimpleCounter());
+        when(metricGroup.histogram(anyString(), any()))
+                .thenAnswer(invocation -> new DescriptiveStatisticsHistogram(100));
+    }
+
+    @Test
+    public void testSuccessFlushUpdatesStandardSinkMetrics() throws IOException {
+        DorisWriteMetrics metrics = DorisWriteMetrics.of(metricGroup, "db_table");
+        metrics.flush(buildRespContent("Success", 5, 100));
+
+        Assert.assertEquals(5, numRecordsSend.getCount());
+        Assert.assertEquals(100, numBytesSend.getCount());
+        Assert.assertEquals(5, metrics.getTotalFlushLoadedRows().getCount());
+        Assert.assertEquals(100, metrics.getTotalFlushLoadBytes().getCount());
+        Assert.assertEquals(1, metrics.getTotalFlushSucceededTimes().getCount());
+    }
+
+    @Test
+    public void testStandardSinkMetricsSharedAcrossTables() throws IOException {
+        DorisWriteMetrics tableOneMetrics = DorisWriteMetrics.of(metricGroup, "db_table1");
+        DorisWriteMetrics tableTwoMetrics = DorisWriteMetrics.of(metricGroup, "db_table2");
+        tableOneMetrics.flush(buildRespContent("Success", 5, 100));
+        tableTwoMetrics.flush(buildRespContent("Success", 7, 200));
+
+        Assert.assertEquals(12, numRecordsSend.getCount());
+        Assert.assertEquals(300, numBytesSend.getCount());
+    }
+
+    @Test
+    public void testFailedFlushDoesNotUpdateStandardSinkMetrics() throws IOException {
+        DorisWriteMetrics metrics = DorisWriteMetrics.of(metricGroup, "db_table");
+        metrics.flush(buildRespContent("Fail", 0, 0));
+
+        Assert.assertEquals(0, numRecordsSend.getCount());
+        Assert.assertEquals(0, numBytesSend.getCount());
+        Assert.assertEquals(1, metrics.getTotalFlushFailedTimes().getCount());
+    }
+
+    private RespContent buildRespContent(String status, long loadedRows, long loadBytes)
+            throws IOException {
+        String json =
+                String.format(
+                        "{\"Status\": \"%s\", \"NumberLoadedRows\": %d, \"LoadBytes\": %d}",
+                        status, loadedRows, loadBytes);
+        return OBJECT_MAPPER.readValue(json, RespContent.class);
+    }
+}

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriteMetrics.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriteMetrics.java
@@ -56,35 +56,37 @@ public class TestDorisWriteMetrics {
     }
 
     @Test
-    public void testSuccessFlushUpdatesStandardSinkMetrics() throws IOException {
+    public void testRecordSendUpdatesStandardSinkMetrics() {
         DorisWriteMetrics metrics = DorisWriteMetrics.of(metricGroup, "db_table");
-        metrics.flush(buildRespContent("Success", 5, 100));
+        metrics.recordSend(100);
+        metrics.recordSend(50);
 
-        Assert.assertEquals(5, numRecordsSend.getCount());
-        Assert.assertEquals(100, numBytesSend.getCount());
-        Assert.assertEquals(5, metrics.getTotalFlushLoadedRows().getCount());
-        Assert.assertEquals(100, metrics.getTotalFlushLoadBytes().getCount());
-        Assert.assertEquals(1, metrics.getTotalFlushSucceededTimes().getCount());
+        Assert.assertEquals(2, numRecordsSend.getCount());
+        Assert.assertEquals(150, numBytesSend.getCount());
     }
 
     @Test
-    public void testStandardSinkMetricsSharedAcrossTables() throws IOException {
+    public void testStandardSinkMetricsSharedAcrossTables() {
         DorisWriteMetrics tableOneMetrics = DorisWriteMetrics.of(metricGroup, "db_table1");
         DorisWriteMetrics tableTwoMetrics = DorisWriteMetrics.of(metricGroup, "db_table2");
-        tableOneMetrics.flush(buildRespContent("Success", 5, 100));
-        tableTwoMetrics.flush(buildRespContent("Success", 7, 200));
+        tableOneMetrics.recordSend(100);
+        tableTwoMetrics.recordSend(200);
 
-        Assert.assertEquals(12, numRecordsSend.getCount());
+        Assert.assertEquals(2, numRecordsSend.getCount());
         Assert.assertEquals(300, numBytesSend.getCount());
     }
 
     @Test
-    public void testFailedFlushDoesNotUpdateStandardSinkMetrics() throws IOException {
+    public void testFlushDoesNotUpdateStandardSinkMetrics() throws IOException {
         DorisWriteMetrics metrics = DorisWriteMetrics.of(metricGroup, "db_table");
+        metrics.flush(buildRespContent("Success", 5, 100));
         metrics.flush(buildRespContent("Fail", 0, 0));
 
         Assert.assertEquals(0, numRecordsSend.getCount());
         Assert.assertEquals(0, numBytesSend.getCount());
+        Assert.assertEquals(5, metrics.getTotalFlushLoadedRows().getCount());
+        Assert.assertEquals(100, metrics.getTotalFlushLoadBytes().getCount());
+        Assert.assertEquals(1, metrics.getTotalFlushSucceededTimes().getCount());
         Assert.assertEquals(1, metrics.getTotalFlushFailedTimes().getCount());
     }
 

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriter.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/sink/writer/TestDorisWriter.java
@@ -235,6 +235,8 @@ public class TestDorisWriter {
         when(mockCounter.getCount()).thenReturn(0L);
         when(mockHistogram.getCount()).thenReturn(0L);
         dorisWriteMetrics.setTotalFlushLoadBytes(mockCounter);
+        dorisWriteMetrics.setNumRecordsSend(mockCounter);
+        dorisWriteMetrics.setNumBytesSend(mockCounter);
         dorisWriteMetrics.setTotalFlushNumberTotalRows(mockCounter);
         dorisWriteMetrics.setTotalFlushFilteredRows(mockCounter);
         dorisWriteMetrics.setTotalFlushLoadedRows(mockCounter);


### PR DESCRIPTION
# Proposed changes

Issue Number: related to #639

## Problem Summary:

The connector registers rich per-table counters (`totalFlushLoadBytes`, `totalFlushLoadedRows`, ...) on the `SinkWriterMetricGroup`, but never updates the standard FLIP-33 sink metrics `numRecordsSend` / `numBytesSend`. They stay at 0, so the Flink Web UI metrics tab and any dashboard/alerting built on the standard connector metrics cannot observe Doris sink throughput.

(Note: the "Bytes/Records Received/Sent" boxes on the job overview page counting 0 for a fully chained CdcTools job is expected Flink behavior — those only count data exchanged between tasks. This PR makes the standard sink metrics usable instead.)

### What is changed

In `DorisWriteMetrics`:

- fetch `numRecordsSend` / `numBytesSend` from the `SinkWriterMetricGroup` during `register`
- increment them with `NumberLoadedRows` / `LoadBytes` of every successful stream load response, alongside the existing connector-specific counters

The two counters are writer-scoped (the metric group returns the same counter instance), so multi-table sinks aggregate across tables correctly.

Add `TestDorisWriteMetrics` covering: successful flush updates both standard counters, aggregation across two tables, and failed flush leaving them untouched.

### Why

`numRecordsSend` / `numBytesSend` are the standardized connector metrics (FLIP-33) that users and monitoring systems expect from every sink. `SinkWriterMetricGroup#getNumRecordsSendCounter` / `getNumBytesSendCounter` are available in all supported Flink versions (1.15+ and 2.x).

## Checklist(Required)

1. Does it affect the original behavior: No (only adds metric reporting)
2. Has unit tests been added: Yes
3. Has document been added or modified: No
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No
