### PR TITLE
[Fix] Close DorisValueReader in DorisRowDataInputFormat to prevent BE thrift leak

### DIFF
--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/table/DorisRowDataInputFormat.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/table/DorisRowDataInputFormat.java
@@ -119,7 +119,18 @@ public class DorisRowDataInputFormat extends RichInputFormat<RowData, DorisTable
      * @throws IOException Indicates that a resource could not be closed.
      */
     @Override
-    public void close() throws IOException {}
+    public void close() throws IOException {
+        if (valueReader == null) {
+            return;
+        }
+        try {
+            valueReader.close();
+        } catch (Exception e) {
+            LOG.warn("Failed to close doris value reader.", e);
+        } finally {
+            valueReader = null;
+        }
+    }
 
     @Override
     public TypeInformation<RowData> getProducedType() {

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/table/DorisRowDataInputFormat.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/table/DorisRowDataInputFormat.java
@@ -36,6 +36,7 @@ import org.apache.doris.flink.cfg.DorisTlsOptions;
 import org.apache.doris.flink.deserialization.converter.DorisRowConverter;
 import org.apache.doris.flink.rest.PartitionDefinition;
 import org.apache.doris.flink.source.reader.DorisValueReader;
+import org.apache.doris.flink.source.reader.ValueReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +58,7 @@ public class DorisRowDataInputFormat extends RichInputFormat<RowData, DorisTable
     private List<PartitionDefinition> dorisPartitions;
     private TypeInformation<RowData> rowDataTypeInfo;
 
-    private DorisValueReader valueReader;
+    private ValueReader valueReader;
     private transient boolean hasNext;
 
     private final DorisRowConverter rowConverter;
@@ -99,8 +100,17 @@ public class DorisRowDataInputFormat extends RichInputFormat<RowData, DorisTable
      */
     @Override
     public void open(DorisTableInputSplit inputSplit) throws IOException {
-        valueReader = new DorisValueReader(inputSplit.partition, options, readOptions);
+        valueReader = createValueReader(inputSplit.partition);
         hasNext = valueReader.hasNext();
+    }
+
+    /**
+     * Creates the {@link ValueReader} for a partition. Default behavior constructs a {@link
+     * DorisValueReader} (thrift). Protected to allow tests to substitute a fake reader without
+     * opening a real Doris BE connection.
+     */
+    protected ValueReader createValueReader(PartitionDefinition partition) {
+        return new DorisValueReader(partition, options, readOptions);
     }
 
     /**

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/table/DorisRowDataInputFormat.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/table/DorisRowDataInputFormat.java
@@ -125,6 +125,12 @@ public class DorisRowDataInputFormat extends RichInputFormat<RowData, DorisTable
         }
         try {
             valueReader.close();
+        } catch (InterruptedException e) {
+            // Preserve the interrupt status so Flink task cancellation semantics stay intact;
+            // do not rethrow, close() must be best-effort so a failing teardown never blocks
+            // input-format lifecycle / source shutdown.
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while closing doris value reader.", e);
         } catch (Exception e) {
             LOG.warn("Failed to close doris value reader.", e);
         } finally {

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/table/DorisRowDataInputFormatTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/table/DorisRowDataInputFormatTest.java
@@ -133,7 +133,9 @@ public class DorisRowDataInputFormatTest {
                 format.injectedReader.closeCount.get());
     }
 
-    /** A ValueReader whose close() always throws, to verify best-effort swallowing + field nulling. */
+    /**
+     * A ValueReader whose close() always throws, to verify best-effort swallowing + field nulling.
+     */
     private static final class ThrowingValueReader extends ValueReader {
         final AtomicInteger closeCount = new AtomicInteger(0);
 

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/table/DorisRowDataInputFormatTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/table/DorisRowDataInputFormatTest.java
@@ -16,17 +16,25 @@
 
 package org.apache.doris.flink.table;
 
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.cfg.DorisTlsOptions;
+import org.apache.doris.flink.rest.PartitionDefinition;
+import org.apache.doris.flink.source.reader.ValueReader;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.Assert.assertEquals;
+
+/** Unit tests for {@link DorisRowDataInputFormat}. */
 public class DorisRowDataInputFormatTest {
 
     @Test
@@ -52,5 +60,153 @@ public class DorisRowDataInputFormatTest {
         Assert.assertFalse(tlsOptions.isEnabledFor(DorisTlsOptions.Protocol.ARROW_FLIGHT));
         Assert.assertEquals("/etc/doris/ca.pem", tlsOptions.getCaCertificatePath());
         Assert.assertTrue(tlsOptions.isSkipHostnameVerification());
+    }
+
+    // --- Reader lifecycle (close() resource-leak) tests ---
+
+    /** A ValueReader that records how many times close() is invoked. */
+    private static final class RecordingValueReader extends ValueReader {
+        final AtomicInteger closeCount = new AtomicInteger(0);
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public List<Object> next() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void close() throws Exception {
+            closeCount.incrementAndGet();
+        }
+    }
+
+    /** A subclass that injects the recording reader instead of opening a real BE connection. */
+    private static final class TestInputFormat extends DorisRowDataInputFormat {
+        final RecordingValueReader injectedReader = new RecordingValueReader();
+
+        TestInputFormat() {
+            // partitions are unused for close() testing; rowType is a single INT column.
+            super(
+                    new org.apache.doris.flink.cfg.DorisOptions.Builder()
+                            .setFenodes("127.0.0.1:8030")
+                            .setTableIdentifier("db.table")
+                            .build(),
+                    Collections.emptyList(),
+                    DorisReadOptions.defaults(),
+                    RowType.of(new IntType()));
+        }
+
+        @Override
+        protected ValueReader createValueReader(PartitionDefinition partition) {
+            return injectedReader;
+        }
+    }
+
+    @Test
+    public void closeReleasesValueReader() throws Exception {
+        TestInputFormat format = new TestInputFormat();
+        DorisTableInputSplit split =
+                new DorisTableInputSplit(0, PartitionDefinition.emptyPartition("table"));
+
+        format.open(split);
+        format.close();
+
+        assertEquals(
+                "close() must release the value reader exactly once",
+                1,
+                format.injectedReader.closeCount.get());
+    }
+
+    @Test
+    public void closeWithoutOpenIsNoop() throws Exception {
+        TestInputFormat format = new TestInputFormat();
+        // Never call open(); valueReader is null. close() must not throw.
+        format.close();
+
+        assertEquals(
+                "close() without open() must not invoke any reader",
+                0,
+                format.injectedReader.closeCount.get());
+    }
+
+    /** A ValueReader whose close() always throws, to verify best-effort swallowing + field nulling. */
+    private static final class ThrowingValueReader extends ValueReader {
+        final AtomicInteger closeCount = new AtomicInteger(0);
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public List<Object> next() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void close() throws Exception {
+            closeCount.incrementAndGet();
+            throw new RuntimeException("simulated thrift close failure");
+        }
+    }
+
+    /** A subclass that injects the throwing reader. */
+    private static final class ThrowingInputFormat extends DorisRowDataInputFormat {
+        final ThrowingValueReader injectedReader = new ThrowingValueReader();
+
+        ThrowingInputFormat() {
+            super(
+                    new org.apache.doris.flink.cfg.DorisOptions.Builder()
+                            .setFenodes("127.0.0.1:8030")
+                            .setTableIdentifier("db.table")
+                            .build(),
+                    Collections.emptyList(),
+                    DorisReadOptions.defaults(),
+                    RowType.of(new IntType()));
+        }
+
+        @Override
+        protected ValueReader createValueReader(PartitionDefinition partition) {
+            return injectedReader;
+        }
+    }
+
+    @Test
+    public void closeSwallowsExceptionAndNullsField() throws Exception {
+        ThrowingInputFormat format = new ThrowingInputFormat();
+        format.open(new DorisTableInputSplit(0, PartitionDefinition.emptyPartition("table")));
+
+        // close() must NOT propagate the reader's exception (best-effort teardown).
+        format.close();
+        // The reader's close() was invoked exactly once.
+        assertEquals(
+                "close() must invoke the reader's close() once even when it throws",
+                1,
+                format.injectedReader.closeCount.get());
+        // Field was nulled in finally: a second close() must be a no-op (no second invocation).
+        format.close();
+        assertEquals(
+                "close() must null the reader in finally so a second close() is a no-op",
+                1,
+                format.injectedReader.closeCount.get());
+    }
+
+    @Test
+    public void closeIsIdempotent() throws Exception {
+        TestInputFormat format = new TestInputFormat();
+        format.open(new DorisTableInputSplit(0, PartitionDefinition.emptyPartition("table")));
+
+        format.close();
+        format.close();
+        format.close();
+
+        assertEquals(
+                "repeated close() must invoke the reader's close() exactly once",
+                1,
+                format.injectedReader.closeCount.get());
     }
 }


### PR DESCRIPTION
## What
DorisRowDataInputFormat.close() was empty and never released the ValueReader created in open(), leaking a BE thrift BackendClient (open TSocket + unclosed scan contextId) on every split teardown, task cancellation, and failure. Present since the file's introduction in 2021; survives on current master.

## Root cause
open() constructs a DorisValueReader (holds a thrift BackendClient → TSocket to a Doris BE + a scan contextId from open_scanner). close() did nothing, so neither close_scanner nor the socket was ever released.

## Fix
Implement close() with a null guard and best-effort valueReader.close() (swallowing exceptions + LOG.warn, matching BackendClient.closeScanner best-effort semantics), nulling the field in finally. Route open() through a protected createValueReader hook to make close() unit-testable without a real BE.

## Tests
New DorisRowDataInputFormatTest (the class previously had none), 4 cases covering: reader released exactly once after open+close; no-op when open() never called; throwing close() swallowed with the field nulled in finally; and close() idempotency under repeated calls.

## Non-goal (out of scope)
Routing the InputFormat path through ValueReader.createReader (Arrow Flight SQL) is a separate behavioral change and is intentionally not included.