### PR TITLE
[Fix] Make DorisSourceSplitReader.close() best-effort and idempotent

### DIFF
--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
@@ -80,12 +80,11 @@ public class DorisSourceSplitReader implements SplitReader<List, DorisSourceSpli
 
     /**
      * Creates the {@link ValueReader} for a split. Default behavior delegates to {@link
-     * ValueReader#createReader} (thrift or Arrow Flight SQL per read options). Protected to
-     * allow tests to substitute a fake reader without opening a real Doris BE connection.
+     * ValueReader#createReader} (thrift or Arrow Flight SQL per read options). Protected to allow
+     * tests to substitute a fake reader without opening a real Doris BE connection.
      */
     protected ValueReader createValueReader(DorisSourceSplit split) {
-        return ValueReader.createReader(
-                split.getPartitionDefinition(), options, readOptions, LOG);
+        return ValueReader.createReader(split.getPartitionDefinition(), options, readOptions, LOG);
     }
 
     private DorisSplitRecords finishSplit() {

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
@@ -75,9 +75,17 @@ public class DorisSourceSplitReader implements SplitReader<List, DorisSourceSpli
         }
         currentSplitId = nextSplit.splitId();
         LOG.info("Fetch a new split {}", nextSplit);
-        valueReader =
-                ValueReader.createReader(
-                        nextSplit.getPartitionDefinition(), options, readOptions, LOG);
+        valueReader = createValueReader(nextSplit);
+    }
+
+    /**
+     * Creates the {@link ValueReader} for a split. Default behavior delegates to {@link
+     * ValueReader#createReader} (thrift or Arrow Flight SQL per read options). Protected to
+     * allow tests to substitute a fake reader without opening a real Doris BE connection.
+     */
+    protected ValueReader createValueReader(DorisSourceSplit split) {
+        return ValueReader.createReader(
+                split.getPartitionDefinition(), options, readOptions, LOG);
     }
 
     private DorisSplitRecords finishSplit() {

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
@@ -115,7 +115,13 @@ public class DorisSourceSplitReader implements SplitReader<List, DorisSourceSpli
     @Override
     public void close() throws Exception {
         if (valueReader != null) {
-            valueReader.close();
+            try {
+                valueReader.close();
+            } catch (Exception e) {
+                LOG.warn("Error while closing value reader: {}", e.getMessage());
+            } finally {
+                valueReader = null;
+            }
         }
     }
 }

--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/source/reader/DorisSourceSplitReader.java
@@ -116,8 +116,13 @@ public class DorisSourceSplitReader implements SplitReader<List, DorisSourceSpli
         if (valueReader != null) {
             try {
                 valueReader.close();
+            } catch (InterruptedException e) {
+                // Preserve the interrupt status so Flink task cancellation semantics stay intact;
+                // close() is best-effort and must not abort reader shutdown.
+                Thread.currentThread().interrupt();
+                LOG.warn("Interrupted while closing value reader.", e);
             } catch (Exception e) {
-                LOG.warn("Error while closing value reader: {}", e.getMessage());
+                LOG.warn("Error while closing value reader.", e);
             } finally {
                 valueReader = null;
             }

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/source/reader/DorisSourceSplitReaderTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/source/reader/DorisSourceSplitReaderTest.java
@@ -47,7 +47,7 @@ public class DorisSourceSplitReaderTest {
         }
 
         @Override
-        public List next() {
+        public List<Object> next() {
             return Collections.emptyList();
         }
 
@@ -69,7 +69,7 @@ public class DorisSourceSplitReaderTest {
         }
 
         @Override
-        public List next() {
+        public List<Object> next() {
             return Collections.emptyList();
         }
 

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/source/reader/DorisSourceSplitReaderTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/source/reader/DorisSourceSplitReaderTest.java
@@ -1,0 +1,182 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.source.reader;
+
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.rest.PartitionDefinition;
+import org.apache.doris.flink.source.split.DorisSourceSplit;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+/** Unit tests for {@link DorisSourceSplitReader}, focusing on reader lifecycle. */
+public class DorisSourceSplitReaderTest {
+
+    /** A ValueReader that records how many times close() is invoked. hasNext() returns true so
+     * fetch() does not finish the split, leaving the reader open for close() to exercise. */
+    private static final class RecordingValueReader extends ValueReader {
+        final AtomicInteger closeCount = new AtomicInteger(0);
+
+        @Override
+        public boolean hasNext() {
+            return true;
+        }
+
+        @Override
+        public List next() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void close() throws Exception {
+            closeCount.incrementAndGet();
+        }
+    }
+
+    /** A ValueReader whose close() always throws, to verify best-effort swallowing + field nulling. */
+    private static final class ThrowingValueReader extends ValueReader {
+        final AtomicInteger closeCount = new AtomicInteger(0);
+
+        @Override
+        public boolean hasNext() {
+            return true;
+        }
+
+        @Override
+        public List next() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void close() throws Exception {
+            closeCount.incrementAndGet();
+            throw new RuntimeException("simulated thrift close failure");
+        }
+    }
+
+    /** A subclass that injects the recording reader instead of opening a real BE connection. */
+    private static final class TestSplitReader extends DorisSourceSplitReader {
+        final RecordingValueReader injectedReader = new RecordingValueReader();
+
+        TestSplitReader() {
+            super(
+                    new DorisOptions.Builder()
+                            .setFenodes("127.0.0.1:8030")
+                            .setTableIdentifier("db.table")
+                            .build(),
+                    DorisReadOptions.defaults());
+            handleSplitsChanges(
+                    new SplitsAddition<>(
+                            Collections.singletonList(
+                                    new DorisSourceSplit(
+                                            "test-split",
+                                            PartitionDefinition.emptyPartition("table")))));
+        }
+
+        @Override
+        protected ValueReader createValueReader(DorisSourceSplit split) {
+            return injectedReader;
+        }
+    }
+
+    /** A subclass that injects the throwing reader. */
+    private static final class ThrowingSplitReader extends DorisSourceSplitReader {
+        final ThrowingValueReader injectedReader = new ThrowingValueReader();
+
+        ThrowingSplitReader() {
+            super(
+                    new DorisOptions.Builder()
+                            .setFenodes("127.0.0.1:8030")
+                            .setTableIdentifier("db.table")
+                            .build(),
+                    DorisReadOptions.defaults());
+            handleSplitsChanges(
+                    new SplitsAddition<>(
+                            Collections.singletonList(
+                                    new DorisSourceSplit(
+                                            "test-split",
+                                            PartitionDefinition.emptyPartition("table")))));
+        }
+
+        @Override
+        protected ValueReader createValueReader(DorisSourceSplit split) {
+            return injectedReader;
+        }
+    }
+
+    @Test
+    public void closeWithoutReaderIsNoop() throws Exception {
+        // valueReader is null (no fetch yet). close() must not throw.
+        TestSplitReader reader = new TestSplitReader();
+        reader.close();
+
+        assertEquals(
+                "close() without a reader must not invoke any reader", 0,
+                reader.injectedReader.closeCount.get());
+    }
+
+    @Test
+    public void closeReleasesValueReader() throws Exception {
+        TestSplitReader reader = new TestSplitReader();
+        // fetch() injects the fake reader (hasNext==true so the split is not finished) leaving it open.
+        reader.fetch();
+
+        reader.close();
+
+        assertEquals(
+                "close() must release the value reader exactly once", 1,
+                reader.injectedReader.closeCount.get());
+    }
+
+    @Test
+    public void closeSwallowsExceptionAndNullsField() throws Exception {
+        ThrowingSplitReader reader = new ThrowingSplitReader();
+        reader.fetch();
+
+        // close() must NOT propagate the reader's exception (best-effort teardown).
+        reader.close();
+        assertEquals(
+                "close() must invoke the reader's close() once even when it throws", 1,
+                reader.injectedReader.closeCount.get());
+        // Field was nulled in finally: a second close() must be a no-op (no second invocation).
+        reader.close();
+        assertEquals(
+                "close() must null the reader in finally so a second close() is a no-op", 1,
+                reader.injectedReader.closeCount.get());
+    }
+
+    @Test
+    public void closeIsIdempotent() throws Exception {
+        TestSplitReader reader = new TestSplitReader();
+        reader.fetch();
+
+        reader.close();
+        reader.close();
+        reader.close();
+
+        assertEquals(
+                "repeated close() must invoke the reader's close() exactly once", 1,
+                reader.injectedReader.closeCount.get());
+    }
+}

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/source/reader/DorisSourceSplitReaderTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/source/reader/DorisSourceSplitReaderTest.java
@@ -17,11 +17,12 @@
 
 package org.apache.doris.flink.source.reader;
 
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.rest.PartitionDefinition;
 import org.apache.doris.flink.source.split.DorisSourceSplit;
-import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -30,11 +31,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 
-/** Unit tests for {@link DorisSourceSplitReader}, focusing on reader lifecycle. */
+/**
+ * Unit tests for {@link DorisSourceSplitReader}, focusing on reader lifecycle.
+ */
 public class DorisSourceSplitReaderTest {
 
-    /** A ValueReader that records how many times close() is invoked. hasNext() returns true so
-     * fetch() does not finish the split, leaving the reader open for close() to exercise. */
+    /**
+     * A ValueReader that records how many times close() is invoked. hasNext() returns true so
+     * fetch() does not finish the split, leaving the reader open for close() to exercise.
+     */
     private static final class RecordingValueReader extends ValueReader {
         final AtomicInteger closeCount = new AtomicInteger(0);
 
@@ -54,7 +59,9 @@ public class DorisSourceSplitReaderTest {
         }
     }
 
-    /** A ValueReader whose close() always throws, to verify best-effort swallowing + field nulling. */
+    /**
+     * A ValueReader whose close() always throws, to verify best-effort swallowing + field nulling.
+     */
     private static final class ThrowingValueReader extends ValueReader {
         final AtomicInteger closeCount = new AtomicInteger(0);
 
@@ -75,7 +82,9 @@ public class DorisSourceSplitReaderTest {
         }
     }
 
-    /** A subclass that injects the recording reader instead of opening a real BE connection. */
+    /**
+     * A subclass that injects the recording reader instead of opening a real BE connection.
+     */
     private static final class TestSplitReader extends DorisSourceSplitReader {
         final RecordingValueReader injectedReader = new RecordingValueReader();
 
@@ -100,7 +109,9 @@ public class DorisSourceSplitReaderTest {
         }
     }
 
-    /** A subclass that injects the throwing reader. */
+    /**
+     * A subclass that injects the throwing reader.
+     */
     private static final class ThrowingSplitReader extends DorisSourceSplitReader {
         final ThrowingValueReader injectedReader = new ThrowingValueReader();
 
@@ -132,7 +143,8 @@ public class DorisSourceSplitReaderTest {
         reader.close();
 
         assertEquals(
-                "close() without a reader must not invoke any reader", 0,
+                "close() without a reader must not invoke any reader",
+                0,
                 reader.injectedReader.closeCount.get());
     }
 

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/source/reader/DorisSourceSplitReaderTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/source/reader/DorisSourceSplitReaderTest.java
@@ -31,9 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * Unit tests for {@link DorisSourceSplitReader}, focusing on reader lifecycle.
- */
+/** Unit tests for {@link DorisSourceSplitReader}, focusing on reader lifecycle. */
 public class DorisSourceSplitReaderTest {
 
     /**
@@ -82,9 +80,7 @@ public class DorisSourceSplitReaderTest {
         }
     }
 
-    /**
-     * A subclass that injects the recording reader instead of opening a real BE connection.
-     */
+    /** A subclass that injects the recording reader instead of opening a real BE connection. */
     private static final class TestSplitReader extends DorisSourceSplitReader {
         final RecordingValueReader injectedReader = new RecordingValueReader();
 
@@ -109,9 +105,7 @@ public class DorisSourceSplitReaderTest {
         }
     }
 
-    /**
-     * A subclass that injects the throwing reader.
-     */
+    /** A subclass that injects the throwing reader. */
     private static final class ThrowingSplitReader extends DorisSourceSplitReader {
         final ThrowingValueReader injectedReader = new ThrowingValueReader();
 
@@ -151,13 +145,15 @@ public class DorisSourceSplitReaderTest {
     @Test
     public void closeReleasesValueReader() throws Exception {
         TestSplitReader reader = new TestSplitReader();
-        // fetch() injects the fake reader (hasNext==true so the split is not finished) leaving it open.
+        // fetch() injects the fake reader (hasNext==true so the split is not finished) leaving it
+        // open.
         reader.fetch();
 
         reader.close();
 
         assertEquals(
-                "close() must release the value reader exactly once", 1,
+                "close() must release the value reader exactly once",
+                1,
                 reader.injectedReader.closeCount.get());
     }
 
@@ -169,12 +165,14 @@ public class DorisSourceSplitReaderTest {
         // close() must NOT propagate the reader's exception (best-effort teardown).
         reader.close();
         assertEquals(
-                "close() must invoke the reader's close() once even when it throws", 1,
+                "close() must invoke the reader's close() once even when it throws",
+                1,
                 reader.injectedReader.closeCount.get());
         // Field was nulled in finally: a second close() must be a no-op (no second invocation).
         reader.close();
         assertEquals(
-                "close() must null the reader in finally so a second close() is a no-op", 1,
+                "close() must null the reader in finally so a second close() is a no-op",
+                1,
                 reader.injectedReader.closeCount.get());
     }
 
@@ -188,7 +186,8 @@ public class DorisSourceSplitReaderTest {
         reader.close();
 
         assertEquals(
-                "repeated close() must invoke the reader's close() exactly once", 1,
+                "repeated close() must invoke the reader's close() exactly once",
+                1,
                 reader.injectedReader.closeCount.get());
     }
 }


### PR DESCRIPTION
## What
DorisSourceSplitReader.close() (the FLIP-27 source split reader) did not swallow exceptions from valueReader.close() (thrift closeScanner) nor null the field afterward. On task teardown/cancellation, a throwing closeScanner propagated into the main flow and aborted cleanup; on repeated close() calls the reader was double-closed (not idempotent — DorisValueReader.close() re-locks and calls closeScanner again on a possibly-already-closed TSocket).

## Root cause
close() was `if (valueReader != null) { valueReader.close(); }` — no try/catch (exceptions propagate), no field-nulling (double-close re-invokes).

## Fix
Wrap valueReader.close() in try/catch+finally: swallow + LOG.warn (same message as the file's own finishSplit()), null the field in finally. Route checkSplitOrStartNext() through a protected createValueReader hook to make close() unit-testable without a real BE.

## Tests
New DorisSourceSplitReaderTest (4 cases): close releases the reader once; no-op when no reader; throwing close() swallowed + field nulled in finally; idempotency under repeated close().

## Non-goal (out of scope)
Extracting a shared closeValueReader() helper between finishSplit() and close() is a clean refactor but deferred — this PR stays a focused bug fix to close().

## Related
Complements #684 (same leak pattern in the legacy RichInputFormat path, DorisRowDataInputFormat). Different file, no conflict. Note: open PR #679 refactors this class's generics (List→DorisSourceRecord); if it merges first, a rebase of this branch will resolve the textual conflict in fetch()/checkSplitOrStartNext() — the close() fix itself is orthogonal.