### PR TITLE
[Fix] Reduce initial snapshot checkpoint state

### DIFF
--- a/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/source/assigners/DorisSnapshotSplitAssigner.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/main/java/org/apache/doris/flink/source/assigners/DorisSnapshotSplitAssigner.java
@@ -24,6 +24,7 @@ import org.apache.doris.flink.cfg.DorisReadOptions;
 import org.apache.doris.flink.exception.DorisRuntimeException;
 import org.apache.doris.flink.rest.PartitionDefinition;
 import org.apache.doris.flink.rest.RestService;
+import org.apache.doris.flink.source.DorisSourceScanMode;
 import org.apache.doris.flink.source.split.DorisSnapshotSplit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,6 +89,16 @@ final class DorisSnapshotSplitAssigner implements DorisSplitAssigner<DorisSnapsh
                         RestService.findPartitions(options, readOptions, LOG);
                 for (int index = 0; index < partitions.size(); index++) {
                     PartitionDefinition partition = partitions.get(index);
+                    // Initial snapshots always use Flight SQL, which does not need the Thrift plan.
+                    if (readOptions.getScanMode() == DorisSourceScanMode.INITIAL) {
+                        partition =
+                                new PartitionDefinition(
+                                        partition.getDatabase(),
+                                        partition.getTable(),
+                                        partition.getBeAddress(),
+                                        partition.getTabletIds(),
+                                        "");
+                    }
                     String splitId = SNAPSHOT_SPLIT_PREFIX + partition.getBeAddress() + "-" + index;
                     splits.add(new DorisSnapshotSplit(splitId, partition));
                 }

--- a/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/source/assigners/DorisSnapshotSplitAssignerTest.java
+++ b/flink-doris-connector/flink-doris-connector-base/src/test/java/org/apache/doris/flink/source/assigners/DorisSnapshotSplitAssignerTest.java
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.flink.source.assigners;
+
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.rest.PartitionDefinition;
+import org.apache.doris.flink.rest.RestService;
+import org.apache.doris.flink.sink.OptionUtils;
+import org.apache.doris.flink.source.DorisSourceScanMode;
+import org.apache.doris.flink.source.split.DorisSnapshotSplit;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+class DorisSnapshotSplitAssignerTest {
+
+    @Test
+    void initialSplitsOmitThriftQueryPlan() throws Exception {
+        DorisSnapshotSplit split = planSingleSplit(DorisSourceScanMode.INITIAL);
+        PartitionDefinition partition = split.getPartitionDefinition();
+
+        assertThat(split.splitId()).isEqualTo("snapshot-127.0.0.1:9060-0");
+        assertThat(partition.getDatabase()).isEqualTo("db");
+        assertThat(partition.getTable()).isEqualTo("table");
+        assertThat(partition.getBeAddress()).isEqualTo("127.0.0.1:9060");
+        assertThat(partition.getTabletIds()).containsExactly(100L);
+        assertThat(partition.getQueryPlan()).isEmpty();
+    }
+
+    @Test
+    void snapshotSplitsKeepThriftQueryPlan() throws Exception {
+        DorisSnapshotSplit split = planSingleSplit(DorisSourceScanMode.SNAPSHOT);
+
+        assertThat(split.getPartitionDefinition().getQueryPlan()).isEqualTo("thrift-query-plan");
+    }
+
+    private static DorisSnapshotSplit planSingleSplit(DorisSourceScanMode scanMode)
+            throws Exception {
+        DorisOptions options = OptionUtils.buildDorisOptions();
+        DorisReadOptions readOptions = DorisReadOptions.builder().setScanMode(scanMode).build();
+        PartitionDefinition partition =
+                new PartitionDefinition(
+                        "db",
+                        "table",
+                        "127.0.0.1:9060",
+                        Collections.singleton(100L),
+                        "thrift-query-plan");
+        try (MockedStatic<RestService> restService = mockStatic(RestService.class)) {
+            restService
+                    .when(
+                            () ->
+                                    RestService.parseIdentifier(
+                                            eq(options.getTableIdentifier()), any()))
+                    .thenReturn(new String[] {"db", "table"});
+            restService
+                    .when(() -> RestService.findPartitions(eq(options), eq(readOptions), any()))
+                    .thenReturn(Collections.singletonList(partition));
+
+            DorisSnapshotSplitAssigner assigner =
+                    new DorisSnapshotSplitAssigner(options, readOptions);
+            return assigner.remainingSplits().get(0);
+        }
+    }
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: DORIS-28133

## Problem Summary:

Initial snapshot splits are always read through Flight SQL but currently retain the Thrift query plan. Large tables repeat this unused plan in every pending split, causing the source checkpoint payload to exceed Java's array limit.

Drop the unused plan only for INITIAL snapshot splits. SNAPSHOT mode keeps the plan for Thrift reads and fallback.

## Checklist(Required)

1. Does it affect the original behavior: Yes
2. Has unit tests been added: Yes
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

Validation: `mvn -Pflink1 -pl flink-doris-connector-base clean test` (386 tests, 0 failures).